### PR TITLE
fix: type of bounty and projects added when creating draft and checking listings in dashboard

### DIFF
--- a/src/components/listings/bounty/Bounty.tsx
+++ b/src/components/listings/bounty/Bounty.tsx
@@ -159,6 +159,7 @@ function CreateListing({ bounty, isEditMode = false, type }: Props) {
     };
     draft = {
       ...draft,
+      type,
       skills: mergeSkills({ skills: mainSkills, subskills: subSkill }),
       ...bountybasic,
       deadline: bountybasic?.deadline

--- a/src/pages/dashboard/bounties/index.tsx
+++ b/src/pages/dashboard/bounties/index.tsx
@@ -224,7 +224,7 @@ function Bounties() {
             }}
             focusBorderColor="brand.purple"
             onChange={(e) => debouncedSetSearchText(e.target.value)}
-            placeholder="Search bounties..."
+            placeholder="Search listing..."
             type="text"
           />
           <InputRightElement pointerEvents="none">
@@ -255,7 +255,16 @@ function Bounties() {
                   fontWeight={500}
                   textTransform={'capitalize'}
                 >
-                  Bounty Name
+                  Listing Name
+                </Th>
+                <Th
+                  maxW={96}
+                  color="brand.slate.400"
+                  fontSize="sm"
+                  fontWeight={500}
+                  textTransform={'capitalize'}
+                >
+                  Type
                 </Th>
                 <Th
                   align="right"
@@ -335,6 +344,14 @@ function Bounties() {
                           {currentBounty.title}
                         </Text>
                       </NextLink>
+                    </Td>
+                    <Td align="right">
+                      <Text textAlign={'right'}>
+                        {
+                          // eslint-disable-next-line no-underscore-dangle
+                          currentBounty?.type !== 'permissioned' ? 'Bounty' : 'Project'
+                        }
+                      </Text>
                     </Td>
                     <Td align="right">
                       <Text textAlign={'right'}>
@@ -508,7 +525,7 @@ function Bounties() {
           <Text as="span" fontWeight={700}>
             {totalBounties}
           </Text>{' '}
-          Bounties
+          Listings
         </Text>
         <Button
           mr={4}


### PR DESCRIPTION
BUG -
When creating a draft, projects were also being saved as bounties, 
when sponsor comes back and edits drafts and publishes, it gets published as a bounty even though created from new project listing page

## What does this PR do?
Adds the missing row `type` in createDraft function
added column label in listing table for differentiation, changed all labels from  bounties -> listings for consistency

## Where should the reviewer start?
/src/components/listings/bounty/Bounty.tsx  - line 162

## How should this be manually tested?
1. Create a sponsor account
1. Start new *project* listing
1. Save as draft
1. publish it
1. check if published in bounties or projects (success if published in projects)

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)