### PR TITLE
Exclude preview env on custom domains from being indexed

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,25 +1,25 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
-    dirs: ["."],
+    dirs: ['.'],
   },
   poweredByHeader: false,
   trailingSlash: true,
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ["res.cloudinary.com"],
+    domains: ['res.cloudinary.com'],
   },
   async headers() {
     const headers = [];
 
-    if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
+    if (process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview') {
       headers.push({
-        source: "/:path*",
+        source: '/:path*',
         headers: [
           {
-            key: "X-Robots-Tag",
-            value: "noindex",
+            key: 'X-Robots-Tag',
+            value: 'noindex',
           },
         ],
       });
@@ -28,5 +28,4 @@ const nextConfig = {
     return headers;
   },
 };
-
 module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -1,14 +1,31 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
-    dirs: ['.'],
+    dirs: ["."],
   },
   poweredByHeader: false,
   trailingSlash: true,
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ['res.cloudinary.com'],
+    domains: ["res.cloudinary.com"],
+  },
+  async headers() {
+    const headers = [];
+
+    if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
+      headers.push({
+        source: "/:path*",
+        headers: [
+          {
+            key: "X-Robots-Tag",
+            value: "noindex",
+          },
+        ],
+      });
+    }
+
+    return headers;
   },
 };
 


### PR DESCRIPTION
## What does this PR do?

- Excludes preview env. deploys (beta.superteam.fun, etc) from being indexed.

## Where should the reviewer start?

- next.config.js

## How should this be manually tested?

## Any background context you want to provide?

- https://vercel.com/guides/are-vercel-preview-deployment-indexed-by-search-engines#:~:text=module.exports,%7D%3B
- https://vercel.com/docs/deployments/preview-deployments#:~:text=When%20a%20custom%20domain%20is%20assigned%20to%20a%20Git%20branch%2C%20this%20behavior%20is%20prevented.%20In%20that%20case%2C%20the%20X%2DRobots%2DTag%20header%20is%20not%20set

## What are the relevant issues?

## Screenshots (if appropriate)