### PR TITLE
Homepage image optimizations (largest request down 3.7kb)

### DIFF
--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -21,15 +21,15 @@ interface BannerProps {
 const avatars = [
   {
     name: 'Anoushk',
-    src: 'https://res.cloudinary.com/dgvnuwspr/image/upload/v1683132586/People%20DPs/recA3Sa7t1loYvDHo.jpg',
+    src: 'https://res.cloudinary.com/dgvnuwspr/image/upload/c_scale,w_30,h_30,f_auto/v1683132586/People%20DPs/recA3Sa7t1loYvDHo.jpg',
   },
   {
     name: 'Ujjwal',
-    src: 'https://res.cloudinary.com/dgvnuwspr/image/upload/v1683135404/People%20DPs/rec4XUFtbh6upVYpA.jpg',
+    src: 'https://res.cloudinary.com/dgvnuwspr/image/upload/c_scale,w_30,h_30,f_auto/v1683135404/People%20DPs/rec4XUFtbh6upVYpA.jpg',
   },
   {
     name: 'Yash',
-    src: 'https://res.cloudinary.com/dgvnuwspr/image/upload/v1683135395/People%20DPs/recb4gDjdKoFDAyo7.png',
+    src: 'https://res.cloudinary.com/dgvnuwspr/image/upload/c_scale,w_30,h_30,f_auto/v1683135395/People%20DPs/recb4gDjdKoFDAyo7.png',
   },
 ];
 

--- a/src/components/home/SideBar.tsx
+++ b/src/components/home/SideBar.tsx
@@ -269,7 +269,10 @@ const Earner = ({
             mr={'1.0625rem'}
             alt=""
             rounded={'full'}
-            src={avatar}
+            src={avatar.replace(
+              '/upload/',
+              '/upload/c_scale,w_32,h_32,f_auto/'
+            )}
           />
         ) : (
           <Center mr={'1.0625rem'}>

--- a/src/components/misc/listingsCard.tsx
+++ b/src/components/misc/listingsCard.tsx
@@ -217,7 +217,14 @@ export const BountiesCard = ({
               mr={isMobile ? 3 : 5}
               alt={sponsorName}
               rounded={5}
-              src={logo || `${router.basePath}/assets/images/sponsor-logo.png`}
+              src={
+                logo
+                  ? logo.replace(
+                      '/upload/',
+                      '/upload/c_scale,w_64,h_64,f_auto/'
+                    )
+                  : `${router.basePath}/assets/images/sponsor-logo.png`
+              }
             />
             <Flex justify={'space-between'} direction={'column'} w={'full'}>
               <Text
@@ -373,7 +380,14 @@ export const GrantsCard = ({
               mr={isMobile ? 3 : 5}
               alt={'company logo'}
               rounded={5}
-              src={logo || '/assets/home/placeholder/ph3.png'}
+              src={
+                logo
+                  ? logo.replace(
+                      '/upload/',
+                      '/upload/c_scale,w_64,h_64,f_auto/'
+                    )
+                  : `assets/home/placeholder/ph3.png`
+              }
             />
             <Flex justify={'space-between'} direction={'column'} w={'full'}>
               <Text


### PR DESCRIPTION
## What does this PR do?

- Requests the proper sizes of images being rendered. 

## Where should the reviewer start?

- Network tab

## Components to manually test

- The [right sidebar](https://github.com/SuperteamDAO/earn/assets/20273871/d46001c2-2e1b-4f11-99c2-9782ef3951ef) and its images — this component isn't rendering in the Dev Mode, with data fetch returning:

```json
{
    "error": {
        "clientVersion": "4.13.0"
    },
    "message": "Error occurred while fetching totals"
}
```

## Any background context you want to provide?

- https://cloudinary.com/documentation/image_transformations

## Screenshots (if appropriate)

![CleanShot 2023-12-10 at 22 16 47@2x](https://github.com/SuperteamDAO/earn/assets/20273871/d198e9e5-48f1-4873-b70e-d52f280b4165)
![CleanShot 2023-12-10 at 22 01 11@2x](https://github.com/SuperteamDAO/earn/assets/20273871/bd2e300d-2eab-4888-b28c-111ede2e7fd7)


Once I have access to staging preview URL, would love to see what this image size has been reduced to (largest image resource request on the page currently):

![CleanShot 2023-12-10 at 22 01 33@2x](https://github.com/SuperteamDAO/earn/assets/20273871/869c9a71-b14e-40db-b54e-738c179ac109)
