### PR TITLE
SEO: Robots disallow list | titles, meta-description and canonical

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -6,7 +6,7 @@ module.exports = {
     policies: [
       {
         userAgent: '*',
-        disallow: ['/signup', '/dashboard', '/new/sponsor'],
+        disallow: ['/signup', '/dashboard', '/new/sponsor', '/t/*/edit'],
       },
     ],
   },

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -2,4 +2,12 @@
 module.exports = {
   siteUrl: 'https://earn.superteam.fun/',
   generateRobotsTxt: true,
+  robotsTxtOptions: {
+    policies: [
+      {
+        userAgent: '*',
+        disallow: ['/signup', '/dashboard', '/new/sponsor'],
+      },
+    ],
+  },
 };

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,9 +1,0 @@
-# *
-User-agent: *
-Allow: /
-
-# Host
-Host: https://earn-frontend-v2.vercel.app/
-
-# Sitemaps
-Sitemap: https://earn-frontend-v2.vercel.app/sitemap.xml

--- a/src/layouts/Home.tsx
+++ b/src/layouts/Home.tsx
@@ -73,8 +73,8 @@ function Home({ children, type }: HomeProps) {
       className="bg-white"
       meta={
         <Meta
-          title="Superteam Earn"
-          description="Every Solana opportunity in one place!"
+          title="Superteam Earn |  Bounties, Grants, and Jobs in Crypto"
+          description="Explore the latest bounties on Superteam Earn, offering opportunities in the crypto space across Design, Development, and Content."
           canonical="https://earn.superteam.fun"
         />
       }

--- a/src/layouts/Sidebar.tsx
+++ b/src/layouts/Sidebar.tsx
@@ -166,8 +166,9 @@ export default function SimpleSidebar({ children }: { children: ReactNode }) {
       className="bg-white"
       meta={
         <Meta
-          title="Dashboard | Superteam Earn"
-          description="Every Solana opportunity in one place!"
+          title="Superteam Earn |  Bounties, Grants, and Jobs in Crypto"
+          description="Explore the latest bounties on Superteam Earn, offering opportunities in the crypto space across Design, Development, and Content."
+          canonical="https://earn.superteam.fun"
         />
       }
     >

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -8,7 +8,10 @@ export default function Custom404() {
     <>
       <Default
         meta={
-          <Meta title="Superteam Earn" description="404 - Page Not Found" />
+          <Meta
+            title="Superteam Earn | Page Not Found"
+            description="404 - Page Not Found"
+          />
         }
       >
         <VStack

--- a/src/pages/all/[slug].tsx
+++ b/src/pages/all/[slug].tsx
@@ -13,11 +13,14 @@ import Loading from '@/components/shared/Loading';
 import type { Bounty } from '@/interface/bounty';
 import type { Grant } from '@/interface/grant';
 import Home from '@/layouts/Home';
+import { Meta } from '@/layouts/Meta';
 
 interface Listings {
   bounties?: Bounty[];
   grants?: Grant[];
 }
+
+type SlugKeys = 'Design' | 'Content' | 'Development' | 'Hyperdrive';
 
 function ListingCategoryPage({ slug }: { slug: string }) {
   const [isListingsLoading, setIsListingsLoading] = useState(true);
@@ -46,8 +49,27 @@ function ListingCategoryPage({ slug }: { slug: string }) {
     getListings();
   }, []);
 
+  const titlesForSlugs: { [key in SlugKeys]: string } = {
+    Design: 'Superteam Earn | Design Bounties and Grants',
+    Content: 'Superteam Earn | Content Bounties and Grants',
+    Development: 'Superteam Earn | Development Bounties and Grants',
+    Hyperdrive: 'Superteam Earn | Apply to Hyperdrive global Solana Hackathon',
+  };
+
+  const titleKey = slug as SlugKeys;
+  const title = titlesForSlugs[titleKey] || 'Superteam Earn'; // Default title if slug not found
+  const formattedSlug =
+    slug === 'Hyperdrive' ? slug.toUpperCase() : slug.toLowerCase();
+  const metaDescription = `Find the latest ${formattedSlug} bounties and grants for freelancers and builders in the crypto space on Superteam Earn.`;
+  const canonicalURL = `https://earn.superteam.fun/all/${slug}/`;
+
   return (
     <Home type="category">
+      <Meta
+        title={title}
+        description={metaDescription}
+        canonical={canonicalURL}
+      />
       <Box w={'100%'}>
         <ListingSection
           type="bounties"

--- a/src/pages/bounties/index.tsx
+++ b/src/pages/bounties/index.tsx
@@ -8,6 +8,7 @@ import EmptySection from '@/components/shared/EmptySection';
 import Loading from '@/components/shared/Loading';
 import type { Bounty } from '@/interface/bounty';
 import Home from '@/layouts/Home';
+import { Meta } from '@/layouts/Meta';
 
 interface Listings {
   bounties?: Bounty[];
@@ -45,6 +46,12 @@ function AllBountiesPage() {
 
   return (
     <Home type="home">
+      <Meta
+        title="Superteam Earn | Discover Bounties and Grants in Crypto for Design, Development, and Content"
+        description="Explore the latest bounties on Superteam Earn, offering opportunities in the crypto space across Design, Development, and Content."
+        canonical="https://earn.superteam.fun/bounties/"
+      />
+
       <Box w={'100%'}>
         <ListingSection
           type="bounties"

--- a/src/pages/grants/index.tsx
+++ b/src/pages/grants/index.tsx
@@ -112,8 +112,8 @@ function Grants() {
       <Default
         meta={
           <Meta
-            title="Superteam Earn"
-            description="Every Solana opportunity in one place!"
+            title="Superteam Earn | Grants"
+            description="Discover Solana Grants for Development, Art, Content, and more to fund your ideas"
             canonical="https://earn.superteam.fun/grants/"
           />
         }

--- a/src/pages/listings/bounties/[slug]/index.tsx
+++ b/src/pages/listings/bounties/[slug]/index.tsx
@@ -57,9 +57,23 @@ function BountyDetails({ bounty: initialBounty }: BountyDetailsProps) {
     <Default
       meta={
         <Head>
-          <title>{`${
-            initialBounty?.title || 'Bounty'
-          } | Superteam Earn`}</title>
+          <title>{`Superteam Earn Bounty | ${
+            initialBounty?.title || 'Apply'
+          } by ${initialBounty?.sponsor?.name}`}</title>
+          <meta
+            name="description"
+            content={`Bounty on Superteam Earn | ${
+              initialBounty?.sponsor?.name
+            } is seeking freelancers and builders ${
+              initialBounty?.title
+                ? `to work on ${initialBounty.title}`
+                : '| Apply Here'
+            }`}
+          />
+          <link
+            rel="canonical"
+            href={`http://earn.superteam.fun/listings/bounties/${bounty?.slug}/`}
+          />
           <meta
             property="og:title"
             content={`${initialBounty?.title || 'Bounty'} | Superteam Earn`}

--- a/src/pages/new/index.tsx
+++ b/src/pages/new/index.tsx
@@ -11,8 +11,8 @@ const Index = () => {
     <Default
       meta={
         <Meta
-          title="Superteam Earn"
-          description="Every Solana opportunity in one place!"
+          title="Make Your Profile | Earn on Superteam | Connect with Crypto Talent"
+          description="Join Superteam to engage with top talent and discover bounties and grants for your crypto projects."
           canonical="https://earn.superteam.fun/new/"
         />
       }

--- a/src/pages/new/talent.tsx
+++ b/src/pages/new/talent.tsx
@@ -265,8 +265,8 @@ function Talent() {
     <Default
       meta={
         <Meta
-          title="New Talent | Superteam Earn"
-          description="Every Solana opportunity in one place!"
+          title="Create Your Profile to Access Bounties & Grants | Superteam Earn"
+          description="Become part of Superteam's talent network, where you can present your skills and collaborate on various crypto bounties, grants, and projects."
           canonical="https://earn.superteam.fun/new/talent/"
         />
       }

--- a/src/pages/projects/index.tsx
+++ b/src/pages/projects/index.tsx
@@ -8,6 +8,7 @@ import EmptySection from '@/components/shared/EmptySection';
 import Loading from '@/components/shared/Loading';
 import type { Bounty } from '@/interface/bounty';
 import Home from '@/layouts/Home';
+import { Meta } from '@/layouts/Meta';
 
 interface Listings {
   bounties?: Bounty[];
@@ -46,6 +47,11 @@ function AllBountiesPage() {
 
   return (
     <Home type="home">
+      <Meta
+        title="Superteam Earn | Apply to Projects in the Crypto Space"
+        description="Discover unique crypto projects seeking talent. Apply on Superteam Earn and take your chance to work and earn in the crypto space."
+        canonical="https://earn.superteam.fun/projects/"
+      ></Meta>
       <Box w={'100%'}>
         <ListingSection
           type="bounties"

--- a/src/pages/regions/[slug]/index.tsx
+++ b/src/pages/regions/[slug]/index.tsx
@@ -14,6 +14,7 @@ import { Superteams } from '@/constants/Superteam';
 import type { Bounty } from '@/interface/bounty';
 import type { Grant } from '@/interface/grant';
 import Home from '@/layouts/Home';
+import { Meta } from '@/layouts/Meta';
 
 interface Listings {
   bounties?: Bounty[];
@@ -46,9 +47,19 @@ const RegionsPage = ({ slug }: { slug: string }) => {
     getListings();
   }, []);
 
+  const formattedSlug =
+    slug === 'uk' || slug === 'uae'
+      ? slug.toUpperCase()
+      : slug.charAt(0).toUpperCase() + slug.slice(1);
+
   return (
     <>
       <Home type="region">
+        <Meta
+          title={`Welcome to Superteam Earn ${formattedSlug} | Discover Bounties and Grants`}
+          description={`Welcome to Superteam ${formattedSlug}'s page — Discover bounties and grants and become a part of the global crypto community`}
+          canonical={`https://earn.superteam.fun/regions/${slug}/`}
+        ></Meta>
         <Box w={'100%'}>
           <ListingSection
             type="bounties"

--- a/src/pages/sponsor.tsx
+++ b/src/pages/sponsor.tsx
@@ -10,6 +10,7 @@ import {
   useMediaQuery,
 } from '@chakra-ui/react';
 import axios from 'axios';
+import Head from 'next/head';
 import type { ImageProps } from 'next/image';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -654,118 +655,134 @@ const Sponsor = () => {
 
   function Hero() {
     return (
-      <Flex
-        align="center"
-        justify="start"
-        overflow="hidden"
-        w="80%"
-        mt="9.375rem"
-        mb={isLargerThan12800px ? '12.5rem' : '5rem'}
-      >
+      <>
+        <Head>
+          <title>
+            Find Top Talent for Your Crypto Projects on Superteam Earn
+          </title>
+          <meta
+            name="description"
+            content="Seeking top talent for your crypto project? Superteam Earn connects you with experts for Bounties, Projects, and Grants in the crypto space."
+          />
+        </Head>
         <Flex
           align="center"
-          justify={isLargerThan12800px ? 'start' : 'center'}
-          gap="1.875rem"
-          w={isLargerThan12800px ? '45%' : '100%'}
-          flexFlow="column"
+          justify="start"
+          overflow="hidden"
+          w="80%"
+          mt="9.375rem"
+          mb={isLargerThan12800px ? '12.5rem' : '5rem'}
         >
-          <Text
-            color="gray.700"
-            fontFamily="var(--font-sans)"
-            fontSize="3.9rem"
-            fontWeight={'light'}
-            lineHeight="1.15em"
-            letterSpacing={'-0.04em'}
-            textAlign="start"
+          <Flex
+            align="center"
+            justify={isLargerThan12800px ? 'start' : 'center'}
+            gap="1.875rem"
+            w={isLargerThan12800px ? '45%' : '100%'}
+            flexFlow="column"
           >
-            Where Top Crypto Founders Meet Top Global Talent
-          </Text>
-          <Text
-            w="100%"
-            color="gray.500"
-            fontSize="1.3rem"
-            fontWeight={400}
-            textAlign="start"
-            css={{
-              textWrap: 'pretty',
-            }}
-          >
-            Whether you have a bounty, a project, or a grant that you need
-            filled, we&apos;re here to help (for free!)
-          </Text>
-
-          <Flex justify="start" gap="2rem" w="100%">
-            <Button
-              w="12.5rem"
-              h="3.125rem"
-              color={'white'}
-              fontSize="1.125rem"
-              bg={'#6562FF'}
-              borderRadius="0.625rem"
-              onClick={() => {
-                window.location.href = '/new/sponsor';
-              }}
-              variant={'solid'}
+            <Text
+              color="gray.700"
+              fontFamily="var(--font-sans)"
+              fontSize="3.9rem"
+              fontWeight={'light'}
+              lineHeight="1.15em"
+              letterSpacing={'-0.04em'}
+              textAlign="start"
             >
-              Get Started
-            </Button>
-            <Flex align="center" gap="0.5rem" fontSize="1rem" fontWeight={700}>
-              <Box minW="2.3125rem" h="2.3125rem" borderRadius="50%">
-                <HighQualityImage
-                  src={Kash}
-                  style={{ width: '100%', height: '100%' }}
-                  alt="Kash"
-                  placeholder="blur"
-                />
-              </Box>
+              Where Top Crypto Founders Meet Top Global Talent
+            </Text>
+            <Text
+              w="100%"
+              color="gray.500"
+              fontSize="1.3rem"
+              fontWeight={400}
+              textAlign="start"
+              css={{
+                textWrap: 'pretty',
+              }}
+            >
+              Whether you have a bounty, a project, or a grant that you need
+              filled, we&apos;re here to help (for free!)
+            </Text>
 
-              <Link
-                _hover={{ textDecoration: 'none' }}
-                href="https://airtable.com/shrmOAXpF2vhONYqe"
-                isExternal
+            <Flex justify="start" gap="2rem" w="100%">
+              <Button
+                w="12.5rem"
+                h="3.125rem"
+                color={'white'}
+                fontSize="1.125rem"
+                bg={'#6562FF'}
+                borderRadius="0.625rem"
+                onClick={() => {
+                  window.location.href = '/new/sponsor';
+                }}
+                variant={'solid'}
               >
-                <Text
-                  p="0.125rem"
-                  color="gray.500"
-                  fontSize="0.9rem"
-                  fontWeight={700}
-                  lineHeight="1.25rem"
-                  borderColor="gray.400"
-                  borderBottom="0.0625rem dashed"
-                  cursor="pointer"
+                Get Started
+              </Button>
+              <Flex
+                align="center"
+                gap="0.5rem"
+                fontSize="1rem"
+                fontWeight={700}
+              >
+                <Box minW="2.3125rem" h="2.3125rem" borderRadius="50%">
+                  <HighQualityImage
+                    src={Kash}
+                    style={{ width: '100%', height: '100%' }}
+                    alt="Kash"
+                    placeholder="blur"
+                  />
+                </Box>
+
+                <Link
+                  _hover={{ textDecoration: 'none' }}
+                  href="https://airtable.com/shrmOAXpF2vhONYqe"
+                  isExternal
                 >
-                  Get a Bounty Strategy Session
-                </Text>
-              </Link>
+                  <Text
+                    p="0.125rem"
+                    color="gray.500"
+                    fontSize="0.9rem"
+                    fontWeight={700}
+                    lineHeight="1.25rem"
+                    borderColor="gray.400"
+                    borderBottom="0.0625rem dashed"
+                    cursor="pointer"
+                  >
+                    Get a Bounty Strategy Session
+                  </Text>
+                </Link>
+              </Flex>
             </Flex>
           </Flex>
-        </Flex>
 
-        {isLargerThan12800px ? (
-          <Box
-            pos="absolute"
-            top={{
-              base: '-400px',
-              lg: '-500px',
-              xl: '-180px',
-              '2xl': '-500px',
-            }}
-            right="-10%"
-            w="60%"
-            maxW="90rem"
-          >
-            <HighQualityImage
-              style={{ objectFit: 'contain' }}
-              alt="Illustration of bounties being posted and applications being submitted"
-              id={'sponsor-hero'}
-              src={SponsorHeroDisplay}
-              sizes="50vw"
-              priority={true}
-              loading="eager"
-            />
-          </Box>
-        ) : null}
-      </Flex>
+          {isLargerThan12800px ? (
+            <Box
+              pos="absolute"
+              top={{
+                base: '-400px',
+                lg: '-500px',
+                xl: '-180px',
+                '2xl': '-500px',
+              }}
+              right="-10%"
+              w="60%"
+              maxW="90rem"
+            >
+              <HighQualityImage
+                style={{ objectFit: 'contain' }}
+                alt="Illustration of bounties being posted and applications being submitted"
+                id={'sponsor-hero'}
+                src={SponsorHeroDisplay}
+                sizes="50vw"
+                priority={true}
+                loading="eager"
+              />
+            </Box>
+          ) : null}
+        </Flex>
+      </>
     );
   }
 

--- a/src/pages/t/[slug]/index.tsx
+++ b/src/pages/t/[slug]/index.tsx
@@ -250,10 +250,14 @@ function TalentProfile({ slug }: TalentProps) {
           <Meta
             title={
               talent?.firstName && talent?.lastName
-                ? `${talent?.firstName} ${talent?.lastName}`
+                ? `Superteam Earn Talent: ${talent?.firstName} ${talent?.lastName}`
                 : 'Superteam Earn'
             }
-            description="Every Solana opportunity in one place!"
+            description={
+              talent?.firstName && talent?.lastName
+                ? `${talent.firstName} ${talent.lastName} is on Superteam Earn. Become a part of our talent community to explore opportunities in the crypto space and work on bounties, grants, and projects.`
+                : 'Superteam Earn is a platform for developers, designers, and content marketers to work on real-world crypto projects. Explore opportunities by becoming part of our community.'
+            }
           />
         }
       >


### PR DESCRIPTION
What does this PR do:

- Adds title and meta-description to all paths (except the ones disallowed in the robots.txt)
- Adds paths behind a login page to a disallow list in robots.txt
- Fixes all canonical URL paths (which were all pointing to https://earn.superteam.fun)
- All the title tags and descriptions try and use keywords used in the top linking text & top searched queries without spamming them(keyword stuffing).
  - Title / Meta-Description / Canonical URLs are generated for [slugs] — like each profile page, each bounty page, region page, content/development/hyperdrive/design routes etc.
- All canonical URLs have a trailing slash (to avoid 308 internal redirects) as is the default with nextjs
  
--- 

What should be manually tested:

- t/[slug] — these pages are not accessible in dev env. hence not able to verify if they work correctly or not. People profiles. An example profile that can be tested is: [earn.superteam.fun/t/arieljfbrand](https://earn.superteam.fun/t/arieljfbrand/)`
