### PR TITLE
fixed `yarn dev` not being cross platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_ENV=development next dev",
+    "dev": "set NODE_ENV=development && next dev",
     "build": "prisma generate && next build",
-    "start": "NODE_ENV=production next start",
+    "start": "set NODE_ENV=production && next start",
     "lint": "next lint",
     "format": "next lint --fix && prettier '**/*.{json,yaml}' --write --ignore-path .gitignore",
     "check-types": "tsc --noEmit --pretty",


### PR DESCRIPTION
## What does this PR do?
This PR makes the `yarn dev` command cross platform by tweaking the `dev` and `start` scripts in the package.json, by using `set NODE_ENV=development && next dev` instead of `NODE_ENV=development next dev`, so that it can be compatible on windows as well other than linux and macOS.

## How should this be manually tested?
Run the `yarn dev` command on windows

## What are the relevant issues?
Fixes #309 