### PR TITLE
revert: I and 0

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -42,8 +42,7 @@ const fontSans = localFont({
   declarations: [
     {
       prop: 'font-feature-settings',
-      value:
-        '"dlig", "liga", "calt", "tnum", "zero", "ss08", "cv10", "cv06", "cv08"',
+      value: "'tnum'",
     },
     {
       prop: 'unicode-range',

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -10,8 +10,7 @@ export const styles = {
     body: {
       bg: 'brand.grey.50',
       fontFamily: 'var(--font-sans)',
-      fontFeatureSettings:
-        '"dlig", "liga", "calt", "tnum", "zero", "ss08", "cv10", "cv06", "cv08"',
+      fontFeatureSettings: '"tnum"',
     },
     width: {
       HomeCard: '4100rem',


### PR DESCRIPTION
## What does this PR do?

- Doesn't use the distinct I and 0 for the typeface Inter.

## Screenshots (if appropriate)

![CleanShot 2023-12-20 at 18 13 29@2x](https://github.com/SuperteamDAO/earn/assets/20273871/4a2245b0-e952-47c4-be67-49ce61f97257)
![CleanShot 2023-12-20 at 18 13 52@2x](https://github.com/SuperteamDAO/earn/assets/20273871/8220cbf2-7d1e-451a-a917-0307d12e4c5a)
