### PR TITLE
perf: preconnect to third party URLs.

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -35,7 +35,6 @@ export default function Document() {
           href="https://res.cloudinary.com"
           crossOrigin="anonymous"
         />
-        {/* Add other head tags here */}
       </Head>
       <body>
         <Main />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -4,7 +4,39 @@ import Script from 'next/script';
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.googleapis.com"
+          crossOrigin="anonymous"
+        />
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link rel="preconnect" href="https://app.posthog.com" />
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
+        <link rel="preconnect" href="https://res.cloudinary.com" />
+        <link
+          rel="preconnect"
+          href="https://app.posthog.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preconnect"
+          href="https://www.googletagmanager.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          rel="preconnect"
+          href="https://res.cloudinary.com"
+          crossOrigin="anonymous"
+        />
+        {/* Add other head tags here */}
+      </Head>
       <body>
         <Main />
         <NextScript />
@@ -17,13 +49,13 @@ export default function Document() {
           strategy="afterInteractive"
           dangerouslySetInnerHTML={{
             __html: `
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${process.env.NEXT_PUBLIC_GA_TRACKING_ID}', {
-              page_path: window.location.pathname,
-            });
-          `,
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${process.env.NEXT_PUBLIC_GA_TRACKING_ID}', {
+                page_path: window.location.pathname,
+              });
+            `,
           }}
         />
       </body>


### PR DESCRIPTION
## What does this PR do?

- Preconnects to third party origins: https://fonts.googleapis.com, 
https://fonts.gstatic.com (requested by Solana Wallet React UI), https://app.posthog.com, https://www.googletagmanager.com and res.cloudinary.com

## How should this be manually tested?

- Running a webpagetest for network waterfall improvements.

## Any background context you want to provide?

- https://www.webpagetest.org/result/231229_BiDcR7_CHN/2/details/#waterfall_view_step1

![CleanShot 2023-12-30 at 03 10 00@2x](https://github.com/SuperteamDAO/earn/assets/20273871/ac5b9e1d-4996-4935-914c-8f0c162c2ab0)
![CleanShot 2023-12-30 at 03 15 13@2x](https://github.com/SuperteamDAO/earn/assets/20273871/d64042cd-f2a3-4c99-bb27-15a9c3fc1d58)

## Resources

- https://crenshaw.dev/preconnect-resource-hint-crossorigin-attribute/
- https://web.dev/learn/performance/resource-hints#:~:text=A%20common%20use%20case%20for,that%20serves%20the%20font%20files.