### PR TITLE
[feat] added apt error message when discord field is not filled

### DIFF
--- a/src/components/Talent/YourLinks.tsx
+++ b/src/components/Talent/YourLinks.tsx
@@ -296,7 +296,7 @@ export function YourLinks({ success, useFormStore }: Props) {
             )}
             {socialsError === 2 && (
               <Text align="center" mb={'0.5rem'} color={'red'}>
-                Please fill at least one social to continue!
+                Please fill the discord field!
               </Text>
             )}
             <Button

--- a/src/components/Talent/YourLinks.tsx
+++ b/src/components/Talent/YourLinks.tsx
@@ -146,7 +146,7 @@ export function YourLinks({ success, useFormStore }: Props) {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { form } = useFormStore();
   const [pow, setPow] = useState<PoW[]>([]);
-  const [socialsError, setsocialsError] = useState<boolean>(false);
+  const [socialsError, setsocialsError] = useState<number | boolean>(false);
   const [isLoading, setisLoading] = useState<boolean>(false);
   const [selectedProject, setSelectedProject] = useState<number | null>(null);
 
@@ -166,7 +166,7 @@ export function YourLinks({ success, useFormStore }: Props) {
     pow: PoW[],
   ) => {
     if (socials.discord.length === 0) {
-      setsocialsError(true);
+      setsocialsError(2);
       return;
     }
     // atleast one URL
@@ -177,7 +177,7 @@ export function YourLinks({ success, useFormStore }: Props) {
       socials.telegram.length === 0 &&
       socials.website.length === 0
     ) {
-      setsocialsError(true);
+      setsocialsError(1);
       return;
     }
     setsocialsError(false);
@@ -288,10 +288,15 @@ export function YourLinks({ success, useFormStore }: Props) {
             >
               Add Project
             </Button>
-            {socialsError && (
+            {socialsError === 1 && (
               <Text align="center" mb={'0.5rem'} color={'red'}>
                 Please fill at least one social (apart from Discord) to
                 continue!
+              </Text>
+            )}
+            {socialsError === 2 && (
+              <Text align="center" mb={'0.5rem'} color={'red'}>
+                Please fill at least one social to continue!
               </Text>
             )}
             <Button

--- a/src/components/Talent/YourLinks.tsx
+++ b/src/components/Talent/YourLinks.tsx
@@ -146,7 +146,7 @@ export function YourLinks({ success, useFormStore }: Props) {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { form } = useFormStore();
   const [pow, setPow] = useState<PoW[]>([]);
-  const [socialsError, setsocialsError] = useState<number | boolean>(false);
+  const [socialsError, setsocialsError] = useState<number>(0);
   const [isLoading, setisLoading] = useState<boolean>(false);
   const [selectedProject, setSelectedProject] = useState<number | null>(null);
 
@@ -180,7 +180,7 @@ export function YourLinks({ success, useFormStore }: Props) {
       setsocialsError(1);
       return;
     }
-    setsocialsError(false);
+    setsocialsError(0);
 
     updateState({ ...socials });
     setisLoading(true);


### PR DESCRIPTION
## What does this PR do?
Currently, we have the message `Please fill at least one social (apart from Discord) to continue!` when atleast one of the fields isn't filled. However, even if discord ISN'T filled, the same message shows up.

This PR makes sure:
When Discord Filled -> Message : `Please fill at least one social (apart from Discord) to continue!`
When Discord is NOT Filled -> Message : `Please fill the discord field!`

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?
ref #417

## Screenshots (if appropriate)

When discord ISN'T filled(but ATLEAST ONE OTHER social is)
<img width="655" alt="Screenshot 2024-02-24 at 11 35 45 AM" src="https://github.com/SuperteamDAO/earn/assets/120790871/c05c7ced-53a3-464d-9bfd-d798ae2ca7d0">

When discord IS filled(but NOT EVEN ONE of the other socials are)
<img width="634" alt="Screenshot 2024-02-24 at 11 36 19 AM" src="https://github.com/SuperteamDAO/earn/assets/120790871/9f1ff35b-9cf0-4095-96c7-62a23a330fe8">

When discord ISN'T filled(but all the other socials are)
<img width="604" alt="Screenshot 2024-02-24 at 11 40 26 AM" src="https://github.com/SuperteamDAO/earn/assets/120790871/5a67406b-d46f-4bfb-8e08-4d6f1d099163">


It works fine when discord + atleast one other social is filled.