### PR TITLE
fix: remove trailing slash for tweet embed link 

### DIFF
--- a/src/utils/tweetTemplate.ts
+++ b/src/utils/tweetTemplate.ts
@@ -9,5 +9,5 @@ ${url}
 export function tweetEmbedLink(content: string) {
   const tweetUrl = new URL(`https://twitter.com/intent/tweet`);
   tweetUrl.searchParams.set('text', content);
-  return tweetUrl.toString();
+  return tweetUrl.toString().slice(0, -1);
 }

--- a/src/utils/tweetTemplate.ts
+++ b/src/utils/tweetTemplate.ts
@@ -9,5 +9,9 @@ ${url}
 export function tweetEmbedLink(content: string) {
   const tweetUrl = new URL(`https://twitter.com/intent/tweet`);
   tweetUrl.searchParams.set('text', content);
-  return tweetUrl.toString().slice(0, -1);
+  let stringUrl = tweetUrl.toString();
+  if (stringUrl[stringUrl.length - 1] === '/') {
+    stringUrl = stringUrl.slice(0, stringUrl.length - 1);
+  }
+  return stringUrl;
 }


### PR DESCRIPTION
## What does this PR do?
removes trailing slash for tweet embed link 
because the trailing slash stops from the OG Image to be displayed in the tweet

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)