### PR TITLE
styles: fix onboarding success page design

### DIFF
--- a/src/components/TalentBio/index.tsx
+++ b/src/components/TalentBio/index.tsx
@@ -95,15 +95,17 @@ export function TalentBio({
   };
 
   return (
-    <Box
+    <Flex
+      justify={'space-between'}
+      direction={'column'}
       w={w ?? '80%'}
-      px={'1.5625rem'}
-      py={'1.125rem'}
+      h="full"
+      p={'1.5625rem'}
       bg={'white'}
       borderRadius={10}
     >
       <Flex align={'center'} justify="space-between">
-        <Flex align={'center'}>
+        <Flex align={'center'} h={'fit-content'}>
           <Avatar
             name={`${user?.firstName}${user?.lastName}`}
             size="lg"
@@ -111,7 +113,8 @@ export function TalentBio({
           />
           <Box ml={'12px'}>
             <Text
-              fontSize={'md'}
+              color={'rgb(71,86,104)'}
+              fontSize={'xl'}
               fontWeight={'600'}
               cursor={'pointer'}
               onClick={() => {
@@ -149,39 +152,7 @@ export function TalentBio({
           </Button>
         )}
       </Flex>
-      <Text mt={4} color={'gray.400'} fontSize={'sm'} fontWeight={'400'}>
-        {user?.bio}
-      </Text>
-      <Flex justify={'space-between'} mt={4}>
-        {!user?.private && (
-          <Chip
-            icon={'/assets/talent/eyes.png'}
-            label={'Interested In'}
-            value={user?.workPrefernce as string}
-          />
-        )}
-        <Chip
-          icon={'/assets/talent/cap.png'}
-          label={'Works At'}
-          value={user?.currentEmployer as string}
-        />
-      </Flex>
-
-      {successPage ? (
-        <a style={{ textDecoration: 'none' }} href={`/t/${user?.username}`}>
-          <Button w={'full'} mt={'1.575rem'} color={'white'} bg={'#6562FF'}>
-            View Your Profile
-          </Button>
-        </a>
-      ) : (
-        <a style={{ textDecoration: 'none' }} href={createMailtoLink()}>
-          <Button w={'full'} mt={'1.575rem'} color={'white'} bg={'#6562FF'}>
-            Get in Touch
-          </Button>
-        </a>
-      )}
-
-      <Flex justify={'space-between'} mt={'32px'}>
+      <Flex justify={'space-between'} mx={'10px'} mt={'20px'}>
         {socialLinks.map((ele, eleIndex) => {
           return (
             <Box
@@ -206,6 +177,43 @@ export function TalentBio({
           );
         })}
       </Flex>
-    </Box>
+      <Text mt={4} color={'gray.400'} fontSize={'sm'} fontWeight={'400'}>
+        {user?.bio}
+      </Text>
+      <Flex justify={'space-between'} mt={4}>
+        {!user?.private && (
+          <Chip
+            icon={'/assets/talent/eyes.png'}
+            label={'Interested In'}
+            value={user?.workPrefernce as string}
+          />
+        )}
+        <Chip
+          icon={'/assets/talent/cap.png'}
+          label={'Works At'}
+          value={user?.currentEmployer as string}
+        />
+      </Flex>
+
+      {successPage ? (
+        <a style={{ textDecoration: 'none' }} href={`/t/${user?.username}`}>
+          <Button
+            w={'full'}
+            mt={'1.575rem'}
+            py={'1.5rem'}
+            color={'white'}
+            bg={'#6562FF'}
+          >
+            View Your Profile
+          </Button>
+        </a>
+      ) : (
+        <a style={{ textDecoration: 'none' }} href={createMailtoLink()}>
+          <Button w={'full'} mt={'1.575rem'} color={'white'} bg={'#6562FF'}>
+            Get in Touch
+          </Button>
+        </a>
+      )}
+    </Flex>
   );
 }

--- a/src/pages/new/talent.tsx
+++ b/src/pages/new/talent.tsx
@@ -13,7 +13,6 @@ import {
 import type { User } from '@prisma/client';
 import axios from 'axios';
 import { type GetServerSideProps } from 'next';
-import { getURL } from 'next/dist/shared/lib/utils';
 import router from 'next/router';
 import React, { Fragment, useEffect, useState } from 'react';
 import { create } from 'zustand';
@@ -27,6 +26,7 @@ import { TalentBio } from '@/components/TalentBio';
 import { Default } from '@/layouts/Default';
 import { Meta } from '@/layouts/Meta';
 import { userStore } from '@/store/user';
+import { getURL } from '@/utils/validUrl';
 
 const useFormStore = create<UserStoreType>()((set) => ({
   form: {

--- a/src/pages/new/talent.tsx
+++ b/src/pages/new/talent.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   Center,
+  Flex,
   Heading,
   HStack,
   Image,
@@ -12,6 +13,7 @@ import {
 import type { User } from '@prisma/client';
 import axios from 'axios';
 import { type GetServerSideProps } from 'next';
+import { getURL } from 'next/dist/shared/lib/utils';
 import router from 'next/router';
 import React, { Fragment, useEffect, useState } from 'react';
 import { create } from 'zustand';
@@ -25,7 +27,6 @@ import { TalentBio } from '@/components/TalentBio';
 import { Default } from '@/layouts/Default';
 import { Meta } from '@/layouts/Meta';
 import { userStore } from '@/store/user';
-import { getURL } from '@/utils/validUrl';
 
 const useFormStore = create<UserStoreType>()((set) => ({
   form: {
@@ -220,30 +221,45 @@ const SuccessScreen = () => {
         align={'start'}
         justifyContent={'center'}
         flexDir={{ base: 'column', md: 'row' }}
-        gap={10}
-        w={'fit-content'}
-        mx={'auto'}
-        mt={10}
+        gap={8}
+        h={{ md: '25rem' }}
+        minH={{ md: '25rem' }}
+        mx={3}
+        my={8}
       >
-        <Box w={'full'} p={{ base: 4, md: 0 }}>
+        <Box w={{ sm: 'full', lg: '25rem' }} h={'full'}>
           <TalentBio
             user={form as unknown as User}
             successPage={true}
-            w={{ md: '90%' }}
+            w={{ sm: '100%' }}
           />
         </Box>
-        <VStack
-          maxW={'35rem'}
-          h={'full'}
-          mx={{ base: 4, md: 0 }}
-          mb={12}
-          p={5}
+
+        <Flex
+          justify={'space-between'}
+          direction={'column'}
+          gap={'12px'}
+          maxW={{ lg: '35rem' }}
+          h={'100%'}
+          p={'1.5625rem'}
           bg="white"
           rounded={'lg'}
         >
-          <Image alt="final" src="/assets/talent/fake-tasks.png" />
+          <Flex
+            h={'full'}
+            bg={'rgb(224,242,255)'}
+            borderRadius={'8px'}
+            objectFit={'contain'}
+          >
+            <Image
+              objectFit={'contain'}
+              alt="final"
+              src="/assets/talent/fake-tasks.png"
+            />
+          </Flex>
           <Button
             w="full"
+            py={'1.5rem'}
             color={'white'}
             bg={'rgb(101, 98, 255)'}
             onClick={() => {
@@ -252,7 +268,7 @@ const SuccessScreen = () => {
           >
             Start Earning
           </Button>
-        </VStack>
+        </Flex>
       </HStack>
     </Box>
   );


### PR DESCRIPTION
## What does this PR do?
fixes the profile creation success page ui so that it matches the figma mockup
## Where should the reviewer start?
create a new profile or can view previously submitted bounty page to see the talentBio component 


## Screenshots (if appropriate)
before:
![image](https://github.com/SuperteamDAO/earn/assets/61344052/ea41d270-e90b-4a7e-9750-ec44944d9881)

after:
![image](https://github.com/SuperteamDAO/earn/assets/61344052/96d4888d-4c45-45c9-ae70-2ec6878a3f05)


