### PR TITLE
Feature | Prefilled Description for "From Scratch" listings

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 import type { SkillMap } from '@/interface/skills';
+import { type IScratchEditorData } from '@/utils/createDefaultEditorData';
 
 import { Superteams } from './Superteam';
 
@@ -855,4 +856,27 @@ export const workType = [
   'Freelance',
   'Fulltime',
   'Internship',
+];
+
+export const scratchEditorData: IScratchEditorData = [
+  {
+    text: 'About the Bounty & Scope',
+    element: 'h1',
+  },
+  {
+    text: 'Rewards',
+    element: 'h1',
+  },
+  {
+    text: 'Judging Criteria',
+    element: 'h1',
+  },
+  {
+    text: 'Submission Requirements',
+    element: 'h1',
+  },
+  {
+    text: 'Resources',
+    element: 'h1',
+  },
 ];

--- a/src/features/listing-builder/components/CreateListing.tsx
+++ b/src/features/listing-builder/components/CreateListing.tsx
@@ -3,17 +3,22 @@ import { Regions } from '@prisma/client';
 import axios from 'axios';
 import { useAtom } from 'jotai';
 import { useRouter } from 'next/router';
-import { useEffect, useReducer, useState } from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
 
 import { ErrorSection } from '@/components/shared/ErrorSection';
 import { SurveyModal } from '@/components/Survey';
-import { type MultiSelectOptions, tokenList } from '@/constants';
+import {
+  type MultiSelectOptions,
+  scratchEditorData,
+  tokenList,
+} from '@/constants';
 import {
   type Bounty,
   getBountyDraftStatus,
   type References,
 } from '@/features/listings';
 import { userStore } from '@/store/user';
+import { createDefaultEditorData } from '@/utils/createDefaultEditorData';
 import { dayjs } from '@/utils/dayjs';
 
 import type { SuperteamName } from '../types';
@@ -305,6 +310,11 @@ export function CreateListing({
 
   const isNewOrDraft = bountyDraftStatus === 'DRAFT' || newBounty === true;
 
+  const defaultEditorData = useMemo(
+    () => createDefaultEditorData(scratchEditorData),
+    [],
+  );
+
   return (
     <>
       {!userInfo?.id || !userInfo?.currentSponsorId ? (
@@ -373,6 +383,7 @@ export function CreateListing({
               setMainSkills={setMainSkills}
               setBountyBasic={setBountyBasic}
               type={type}
+              defaultEditorData={defaultEditorData}
             />
           )}
           {steps > 1 && (

--- a/src/features/listing-builder/components/ListingBuilder/Template.tsx
+++ b/src/features/listing-builder/components/ListingBuilder/Template.tsx
@@ -102,7 +102,7 @@ export const Template = ({
               cursor={'pointer'}
               onClick={() => {
                 setEditorData(defaultEditorData);
-                setSteps(3);
+                setSteps(2);
               }}
             >
               <AddIcon color="gray.500" mb="1rem" />

--- a/src/features/listing-builder/components/ListingBuilder/Template.tsx
+++ b/src/features/listing-builder/components/ListingBuilder/Template.tsx
@@ -22,6 +22,7 @@ interface Props {
   setSubSkills: Dispatch<SetStateAction<MultiSelectOptions[]>>;
   setBountyBasic: Dispatch<SetStateAction<BountyBasicType | undefined>>;
   type: 'bounty' | 'project' | 'hackathon';
+  defaultEditorData?: string;
 }
 export const Template = ({
   setSteps,
@@ -30,6 +31,7 @@ export const Template = ({
   setSubSkills,
   setBountyBasic,
   type,
+  defaultEditorData,
 }: Props) => {
   const [bountiesTemplates, setBountiesTemplates] = useState([]);
   const [isBountiesTemplatesLoading, setIsBountiesTemplatesLoading] =
@@ -99,7 +101,8 @@ export const Template = ({
               borderRadius={5}
               cursor={'pointer'}
               onClick={() => {
-                setSteps(2);
+                setEditorData(defaultEditorData);
+                setSteps(3);
               }}
             >
               <AddIcon color="gray.500" mb="1rem" />

--- a/src/utils/createDefaultEditorData.ts
+++ b/src/utils/createDefaultEditorData.ts
@@ -1,0 +1,16 @@
+export type IScratchEditorData = Array<{
+  text: string;
+  element?: keyof HTMLElementTagNameMap;
+}>;
+
+export const createDefaultEditorData = (data: IScratchEditorData) => {
+  return data
+    .map(
+      (item) =>
+        `<${item.element ?? 'p'}>
+    ${item.text}
+    </${item.element ?? 'p'}>
+    `,
+    )
+    .join('\n');
+};


### PR DESCRIPTION
## What does this PR do?
Addresses #274, the description for From Scratch listings will get prefilled with the mentioned headings

## Where should the reviewer start?
1. The utility function `createDefaultEditorData ` creates the html string which has to be inserted (`createDefaultEditorData.tsx`)
2. The actual data (`scratchEditorData`) is present in the constants file (`constants/index.ts`)
3. The result of `createDefaultEditorData` is memoized and passed as a new prop to the Template component (`CreateListing.tsx`)
4. Within the component, the onClick event is hooked into, to set the editor data if the "From Scratch" button is clicked

## How should this be manually tested?
1. Create a listing as normal
2. Select "from Scratch" in the template section
3. Fill the next section and continue
4. Verify that the description section contains the needed headings mentioned in the issue
5. Verify that the pre filled text can be deleted and new text can be entered

## Any background context you want to provide?
None

## What are the relevant issues?
https://github.com/SuperteamDAO/earn/issues/274
## Screenshots (if appropriate)
![image](https://github.com/SuperteamDAO/earn/assets/31418899/ca046c65-da9d-4ebb-b0e6-f8836d1e4c89)
