### PR TITLE
styles: detailed submission page fixes

### DIFF
--- a/src/features/listings/components/SubmissionsPage/SubmissionPage.tsx
+++ b/src/features/listings/components/SubmissionsPage/SubmissionPage.tsx
@@ -112,8 +112,8 @@ export const SubmissionPage = ({ bounty, submission, user, link }: Props) => {
             </Button>
           </HStack>
           {isMobile && (
-            <VStack w={'30rem'} mt={12}>
-              <TalentBio successPage={false} user={user} />
+            <VStack mt={12}>
+              <TalentBio w={'100%'} successPage={false} user={user} />
             </VStack>
           )}
         </VStack>
@@ -130,7 +130,7 @@ export const SubmissionPage = ({ bounty, submission, user, link }: Props) => {
       </VStack>
       {!isMobile && (
         <VStack w={['100%', '100%', '36rem', '36rem']}>
-          <TalentBio successPage={false} user={user} />
+          <TalentBio w={'100%'} successPage={false} user={user} />
         </VStack>
       )}
     </VStack>

--- a/src/pages/grants/[id].tsx
+++ b/src/pages/grants/[id].tsx
@@ -130,7 +130,7 @@ const Grants = ({ slug }: GrantsDetailsProps) => {
                   <Flex
                     pos={{ base: 'fixed', md: 'static' }}
                     zIndex={999}
-                    bottom={0}
+                    bottom={12}
                     left="50%"
                     w="full"
                     px={{ base: 3, md: 0 }}


### PR DESCRIPTION
## What does this PR do?
I edited the Listing Submission page to fix the current Ui bug of Overflowing components, and The submission button in Grants page 

## Where should the reviewer start?
src/features/listings/components/SubmissionsPage/SubmissionPage.tsx
src/pages/grants/[id].tsx

## How should this be manually tested?
Look at the current listing in which someone have already won the bounty/project and then the vercel deployment of this PR

## Any background context you want to provide?
Ui bugs in submission page and grant page
## What are the relevant issues?
fixes #622 
## Screenshots (if appropriate)
## After this PR : 

<div style="display: flex; flex-wrap: nowrap;">
    <img src="https://github.com/SuperteamDAO/earn/assets/111289008/6928c6e6-df74-41e0-9fd6-b84b03bcb49e" alt="earnbug2" width="22%" style="margin-right: 10px;">
    <img src="https://github.com/SuperteamDAO/earn/assets/111289008/8b81e9fc-e8f7-4718-8c76-312799c61465" alt="earnbug2" width="22%" style="margin-right: 10px;">
    <img src="https://github.com/SuperteamDAO/earn/assets/111289008/6b36f588-452e-4d34-998e-673494e0455f" alt="earn" width="22%" style="margin-right: 10px;">
</div>
 <img src="https://github.com/SuperteamDAO/earn/assets/111289008/efad7a29-c1dd-40e8-903d-46848b85646b" alt="earnbug" width="100%" style="margin-right: 10px;">

### Before this PR:

<div style="display: flex; flex-wrap: nowrap;">
    <img src="https://github.com/SuperteamDAO/earn/assets/111289008/9faa5f03-62ef-465d-a3d1-f8444d0ef1d0" alt="earnbug2" width="33%" style="margin-right: 10px;">
    <img src="https://github.com/SuperteamDAO/earn/assets/111289008/e19e4c20-e474-47fa-ba53-66458ab50a45" alt="earnbug" width="33%" style="margin-right: 10px;">
    <img src="https://github.com/SuperteamDAO/earn/assets/111289008/9b34ca9f-c4bd-4589-a132-bb7f32cec680" alt="earn" width="33%" style="margin-right: 10px;">
</div>


