### PR TITLE
[FIX] - Fixed home page, bounties page and projects page for listings based on user location

### DIFF
--- a/src/features/listing-builder/store/index.ts
+++ b/src/features/listing-builder/store/index.ts
@@ -76,6 +76,7 @@ const mergeListingWithInitialFormState = (
   token: listing.token || 'USDC',
   minRewardAsk: listing.minRewardAsk,
   maxRewardAsk: listing.maxRewardAsk,
+  region: listing.region as Regions | undefined,
 });
 
 export const useListingFormStore = create<ListingStoreType>()((set) => ({

--- a/src/features/listings/types/index.ts
+++ b/src/features/listings/types/index.ts
@@ -34,7 +34,7 @@ export interface Listing {
   type?: BountyType | string;
   applicationType?: 'fixed' | 'rolling';
   totalWinnersSelected?: number;
-  region?: Regions;
+  region?: Regions | string;
   totalPaymentsMade?: number;
   isWinnersAnnounced?: boolean;
   templateId?: string;

--- a/src/pages/api/listings/homepage.ts
+++ b/src/pages/api/listings/homepage.ts
@@ -116,14 +116,16 @@ interface BountyProps {
   statusFilter?: Status;
   type?: BountyType;
   take?: number;
+  userLocation?: string;
 }
 
 export async function getListings({
   order = 'desc',
   skillFilter,
   statusFilter,
-  type,
+
   take = 20,
+  userLocation,
 }: BountyProps) {
   const skillFilterQuery = getSkillFilterQuery(skillFilter);
 
@@ -160,11 +162,16 @@ export async function getListings({
       isPrivate: false,
       hackathonprize: false,
       isArchived: false,
-      type,
-      OR: [
-        { compensationType: 'fixed', usdValue: { gt: 100 } },
-        { compensationType: 'range', maxRewardAsk: { gt: 100 } },
-        { compensationType: 'variable' },
+      OR: [{ region: userLocation }, { region: 'GLOBAL' }],
+
+      AND: [
+        {
+          OR: [
+            { compensationType: 'fixed', usdValue: { gt: 100 } },
+            { compensationType: 'range', maxRewardAsk: { gt: 100 } },
+            { compensationType: 'variable' },
+          ],
+        },
       ],
       language: { in: ['eng', 'sco'] }, //cuz both eng and sco refer to listings in english
       ...skillFilterQuery,

--- a/src/pages/bounties/index.tsx
+++ b/src/pages/bounties/index.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { type Listing, ListingTabs } from '@/features/listings';
 import { Home } from '@/layouts/Home';
 import { Meta } from '@/layouts/Meta';
+import { userStore } from '@/store/user';
 import { dayjs } from '@/utils/dayjs';
 
 interface Listings {
@@ -16,30 +17,38 @@ export default function BountiesPage() {
   const [listings, setListings] = useState<Listings>({
     bounties: [],
   });
-  const date = dayjs().subtract(2, 'months').toISOString();
-
-  const getListings = async () => {
-    setIsListingsLoading(true);
-    try {
-      const listingsData = await axios.get('/api/listings/', {
-        params: {
-          category: 'bounties',
-          type: 'bounty',
-          deadline: date,
-          take: 100,
-        },
-      });
-      setListings(listingsData.data);
-      setIsListingsLoading(false);
-    } catch (e) {
-      setIsListingsLoading(false);
-    }
-  };
+  const [userLocation, setUserLocation] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!isListingsLoading) return;
-    getListings();
+    const { userInfo } = userStore.getState();
+    const location = userInfo?.location;
+    setUserLocation(location?.toLocaleUpperCase() || null);
   }, []);
+
+  useEffect(() => {
+    const getListings = async () => {
+      setIsListingsLoading(true);
+      try {
+        const date = dayjs().subtract(2, 'months').toISOString();
+        const listingsData = await axios.get('/api/listings/', {
+          params: {
+            category: 'bounties',
+            take: 100,
+            type: 'bounty',
+            deadline: date,
+            location: userLocation,
+          },
+        });
+        setListings(listingsData.data);
+      } catch (e) {
+        console.error('Error fetching listings', e);
+      } finally {
+        setIsListingsLoading(false);
+      }
+    };
+
+    getListings();
+  }, [userLocation]);
 
   return (
     <Home type="home">


### PR DESCRIPTION
## What does this PR do?
This PR updates the code to filter bounties and projects so that only those which belong to the user's location or are marked as global are shown to the user. This ensures that users see relevant bounties based on their location on home page, bounties page and Projects page.

## Where should the reviewer start?
The reviewer should start by looking at the changes made in the /api/listings/index.tsx, particularly the OR clause is used. Ensure that the filtering logic using OR with region: 'GLOBAL' and region: location is correctly implemented.

## How should this be manually tested?
Set up your local environment to run the Next.js application.
Ensure you have the Prisma client configured and connected to the database.
Run the application and navigate to the page where bounties are listed.
Test the filtering by checking if bounties shown belong to either 'GLOBAL' or the specific user location.
You can change the user location to different values and verify if the filtering works as expected.

## Any background context you want to provide?
Nope 

## What are the relevant issues?
There may have been previous issues or feature requests related to filtering bounties based on user location. If any specific issue numbers or tickets are related to this change, they should be referenced here (e.g. #630  )

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/1274af2a-8f81-4d3a-be36-d88e476641ba)
![image](https://github.com/user-attachments/assets/cb3680b6-181d-4d52-bb63-6dd10e0cc746)
![image](https://github.com/user-attachments/assets/c1a86a7c-9f66-4d0b-978f-fd7a5c54be08)
