### PR TITLE
[TalentProfile][Fix] After uploading PoW, now we update the talentFeed

### DIFF
--- a/src/pages/t/[slug]/index.tsx
+++ b/src/pages/t/[slug]/index.tsx
@@ -54,9 +54,6 @@ function TalentProfile({ talent, stats }: TalentProps) {
   const [showSubskills, setShowSubskills] = useState<Record<number, boolean>>(
     {},
   );
-  const [talentFeed, setTalentFeed] = useState<FeedDataProps[]>(
-    talent?.feed || [],
-  );
 
   const handleToggleSubskills = (index: number) => {
     setShowSubskills({
@@ -116,14 +113,14 @@ function TalentProfile({ talent, stats }: TalentProps) {
 
   const filteredFeed = useMemo(() => {
     if (activeTab === 'activity') {
-      return talentFeed;
+      return talent?.feed;
     }
 
-    return talentFeed.filter((item) => item.type === 'PoW');
-  }, [activeTab, talentFeed]);
+    return talent?.feed?.filter((item) => item.type === 'PoW');
+  }, [activeTab, talent?.feed]);
 
-  const addNewPow = (newPow: any) => {
-    setTalentFeed([newPow, ...talentFeed]);
+  const addNewPow = () => {
+    router.replace(router.asPath);
   };
 
   const isMD = useBreakpointValue({ base: false, md: true });
@@ -633,12 +630,10 @@ function TalentProfile({ talent, stats }: TalentProps) {
           </Box>
         )}
         <AddProject
-          {...{
-            isOpen: isOpenPow,
-            onClose: onClosePow,
-            upload: true,
-            onNewPow: addNewPow,
-          }}
+          isOpen={isOpenPow}
+          onClose={onClosePow}
+          upload
+          onNewPow={addNewPow}
         />
       </Default>
     </>

--- a/src/pages/t/[slug]/index.tsx
+++ b/src/pages/t/[slug]/index.tsx
@@ -54,6 +54,9 @@ function TalentProfile({ talent, stats }: TalentProps) {
   const [showSubskills, setShowSubskills] = useState<Record<number, boolean>>(
     {},
   );
+  const [talentFeed, setTalentFeed] = useState<FeedDataProps[]>(
+    talent?.feed || [],
+  );
 
   const handleToggleSubskills = (index: number) => {
     setShowSubskills({
@@ -113,16 +116,14 @@ function TalentProfile({ talent, stats }: TalentProps) {
 
   const filteredFeed = useMemo(() => {
     if (activeTab === 'activity') {
-      return talent?.feed;
+      return talentFeed;
     }
 
-    return talent?.feed?.filter((item) => item.type === 'PoW');
-  }, [activeTab, talent?.feed]);
+    return talentFeed.filter((item) => item.type === 'PoW');
+  }, [activeTab, talentFeed]);
 
   const addNewPow = (newPow: any) => {
-    if (talent) {
-      talent.feed = [newPow, ...talent.feed];
-    }
+    setTalentFeed([newPow, ...talentFeed]);
   };
 
   const isMD = useBreakpointValue({ base: false, md: true });


### PR DESCRIPTION
## What does this PR do?

Before, when user uploaded a new PoW through the Add Project in their profile page, we didn't show the newly created PoW.
After, now we do. There was a bug on how we updated the talent variable in that React component and also the shape of the object created is not the same one as the one we get from the backend. Missing lots of fields.

#### Solution:
- Completely refresh the page to avoid managing unnecessary partial states.

## Where should the reviewer start?

The flow starts like this:
```
AddProject.tsx -> onSubmit() -> t/[slug]/index.tsx addNewPow()
```

## How should this be manually tested?
Go to your profile, click on +ADD (next to Proof of Work), complete the form, click on AddProject.
Expected result: no reload should be needed. The PoW should be added to the profile automatically.

![image](https://github.com/user-attachments/assets/6f890559-6848-4a1e-a1e4-35f8e67e5588)
![image](https://github.com/user-attachments/assets/279a6abb-4469-4fea-9996-cf005b2913ac)

## Any background context you want to provide?

No. First contribution to this repo and to Superteam

## What are the relevant issues?

No issue submitted for this so far.

## Screenshots (if appropriate)

Uploaded above