### PR TITLE
fixed global option 

### DIFF
--- a/src/constants/Superteam.ts
+++ b/src/constants/Superteam.ts
@@ -2,6 +2,16 @@ import { Regions } from '@prisma/client';
 
 export const Superteams = [
   {
+    name: 'Global',
+    icons: '',
+    banner: '',
+    region: Regions.GLOBAL,
+    displayValue: 'Global',
+    country: ['Global'],
+    code: 'GLOBAL',
+    hello: 'Hello',
+  },
+  {
     name: 'Superteam India',
     icons: '/assets/superteams/india.jpg',
     banner: '/assets/superteam-banners/India.png',


### PR DESCRIPTION
## What does this PR do?
fixes #682   ,  fixed the previous issue

## Where should the reviewer start?
Can start from constants/Superteam.ts

## How should this be manually tested?
By going to contstans/Superteam.ts, also added a comment there.

## Any background context you want to provide?
I added an object inside  the array to render a option of Global, to navigate to home page with ease

## What are the relevant issues?
Once user selects a region, the global option dissapears. this means user has to either remove the extra path on the address bar or reload the bounties/projects page to see the globally available bounties/projects again.

## Screenshots (if appropriate)
Before 
![test](https://github.com/user-attachments/assets/1d996888-3843-489c-9c70-bc66eef5c99b)

After
![Screenshot 2024-09-14 182211](https://github.com/user-attachments/assets/6d2db7f7-0b01-4ef5-8e21-5622597369e0)
