### PR TITLE
Fix issue where twitter/x usernames with _ would result in null

### DIFF
--- a/src/features/talent/utils/extractUsername.ts
+++ b/src/features/talent/utils/extractUsername.ts
@@ -11,7 +11,7 @@ export function extractTwitterUsername(input: string): string | null {
   if (match && match[2]) {
     return match[2].startsWith('@') ? match[2].slice(1) : match[2];
   }
-  const usernameRegex = /^@?[a-zA-Z0-9]{1,90}$/;
+  const usernameRegex = /^@?[a-zA-Z0-9_]{1,90}$/;
   const usernameMatch = input.match(usernameRegex);
   if (usernameMatch && usernameMatch[0]) {
     return usernameMatch[0].startsWith('@')


### PR DESCRIPTION
## What does this PR do?
update the regex for extractTwitterUsername to include '_'
## Where should the reviewer start?
start in src/features/talent/utils/extractUsername.ts
## How should this be manually tested?
as described in the linked issue #742 
## Any background context you want to provide?
twitter/x usernames do allow '_' 
My own username of `harsimran_d` was resulting in null although its perfectly valid
## What are the relevant issues?
Closes #742 
## Screenshots (if appropriate)