### PR TITLE
fix: linkedin min length

### DIFF
--- a/src/features/talent/utils/extractUsername.ts
+++ b/src/features/talent/utils/extractUsername.ts
@@ -43,7 +43,7 @@ export function extractLinkedInUsername(input: string): string | null {
   if (urlMatch && urlMatch[1]) {
     return urlMatch[1];
   }
-  const usernameRegex = /^[a-zA-Z0-9\-]{5,90}$/;
+  const usernameRegex = /^[a-zA-Z0-9\-]{3,90}$/;
   const usernameMatch = input.match(usernameRegex);
   if (usernameMatch && usernameMatch[0]) {
     return usernameMatch[0];


### PR DESCRIPTION
fixes: #854

## What does this PR do?

This PR fixes the issue of a null value occurring when someone tries to add a LinkedIn profile with fewer than 5 characters. 

According to LinkedIn's documentation, the minimum allowed character length is 3.

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/d4f0cb4a-3d52-4968-af70-8ed0cf78ab78)
![image](https://github.com/user-attachments/assets/b9e64358-f41b-4922-984e-4fa35813b31c)
