### PR TITLE
Add Telegram notifications bot link to user menu

### DIFF
--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -56,6 +56,11 @@ export function UserMenu() {
     onClose();
   };
 
+  // Generate Telegram bot link with user context
+  const telegramBotLink = user?.id 
+    ? `https://t.me/super_fun_earn_bot?start=earn_userid_${user.id}`
+    : 'https://t.me/super_fun_earn_bot?start=earn';
+
   return (
     <>
       <EmailSettingsModal isOpen={isOpen} onClose={handleClose} />
@@ -169,6 +174,22 @@ export function UserMenu() {
               Email Preferences
             </DropdownMenuItem>
           )}
+
+          {/* NEW: Telegram Bot Integration */}
+          <DropdownMenuItem asChild>
+            <Link
+              href={telegramBotLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => {
+                posthog.capture('telegram notifications_user menu');
+              }}
+              className="text-sm tracking-tight text-slate-500"
+            >
+              🔔 Telegram Notifications
+            </Link>
+          </DropdownMenuItem>
+          {/* END NEW */}
 
           <SupportFormDialog>
             <DropdownMenuItem

--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -57,8 +57,10 @@ export function UserMenu() {
   };
 
   // Generate Telegram bot link with user context
-  const telegramBotLink = user?.id 
-    ? `https://t.me/super_fun_earn_bot?start=earn_userid_${user.id}`
+  const telegramBotLink = user?.id
+    ? `https://t.me/super_fun_earn_bot?start=earn_userid_${encodeURIComponent(
+        user.id,
+      )}`
     : 'https://t.me/super_fun_earn_bot?start=earn';
 
   return (
@@ -181,6 +183,7 @@ export function UserMenu() {
               href={telegramBotLink}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="Connect Telegram notifications bot"
               onClick={() => {
                 posthog.capture('telegram notifications_user menu');
               }}


### PR DESCRIPTION
# Add Telegram Notifications Bot Integration

## Summary
Integrates Telegram notification bot (@super_fun_earn_bot) into the user menu as required for personalized bounty notifications.

## Changes
- Added "🔔 Telegram Notifications" link to UserMenu dropdown
- Passes user ID context via deep link parameter (`earn_userid_${user.id}`)
- Added PostHog analytics tracking (`telegram notifications_user menu`)
- Opens in new tab for seamless user experience

## Integration Details
- **Bot Username:** @super_fun_earn_bot
- **Link Position:** Between "Email Preferences" and "Get Help"
- **User Context:** Passes user ID for personalized bot experience
- **Analytics:** Tracks clicks via PostHog for usage metrics

## Testing
- [x] Menu item appears for all logged-in users
- [x] Link opens Telegram with correct bot
- [x] User ID is passed correctly in deep link
- [x] PostHog event fires on click

**Closes bounty requirement:** "The bot must be accessible via a direct link from the user menu (present on the top right on desktop, and top left on mobile) on Superteam Earn."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "🔔 Telegram Notifications" link to the user menu, allowing users to quickly access the Telegram bot for notifications.
- **Analytics**
  - Clicking the Telegram Notifications link now triggers an analytics event for improved tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->