### PR TITLE
feat: add Telegram bot link for Superteam Earn notifications

### DIFF
--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -56,6 +56,9 @@ export function UserMenu() {
     onClose();
   };
 
+  const telegramBotLink =
+    'https://t.me/SuperteamEarnNotificationsBot?start=earn';
+
   return (
     <>
       <EmailSettingsModal isOpen={isOpen} onClose={handleClose} />
@@ -169,6 +172,21 @@ export function UserMenu() {
               Email Preferences
             </DropdownMenuItem>
           )}
+
+          <DropdownMenuItem asChild>
+            <Link
+              href={telegramBotLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Connect Telegram notifications bot"
+              onClick={() => {
+                posthog.capture('telegram notifications menu');
+              }}
+              className="text-sm tracking-tight text-slate-500"
+            >
+              Earn Alerts
+            </Link>
+          </DropdownMenuItem>
 
           <SupportFormDialog>
             <DropdownMenuItem


### PR DESCRIPTION
## What does this PR do?
Adds an "Earn Alerts" item to the user menu that links to the Telegram bot and tracks a PostHog event.

## Where should the reviewer start?
Check the `UserMenu` component, especially the new `DropdownMenuItem` with `telegramBotLink`.

## How should this be manually tested?
- Open the user menu.
- Click "Earn Alerts".
- It should open the Telegram bot in a new tab and fire a PostHog event.

## Any background context you want to provide?
Helps users subscribe to job alerts via Telegram.

## What are the relevant issues?
N/A

## Screenshots (if appropriate)
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an "Earn Alerts" option in the user menu, allowing users to access Earn notifications via a Telegram bot. The link opens in a new tab and tracks user interaction for analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->