### PR TITLE
Add Telegram bot link to user menu

### DIFF
--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -56,6 +56,11 @@ export function UserMenu() {
     onClose();
   };
 
+  // Generate Telegram bot link with user context
+  const telegramBotLink = user?.id 
+    ? `https://t.me/super_fun_earn_bot?start=earn_userid_${user.id}`
+    : 'https://t.me/super_fun_earn_bot?start=earn';
+
   return (
     <>
       <EmailSettingsModal isOpen={isOpen} onClose={handleClose} />
@@ -169,6 +174,22 @@ export function UserMenu() {
               Email Preferences
             </DropdownMenuItem>
           )}
+
+          {/* NEW: Telegram Bot Integration */}
+          <DropdownMenuItem asChild>
+            <Link
+              href={telegramBotLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => {
+                posthog.capture('telegram notifications_user menu');
+              }}
+              className="text-sm tracking-tight text-slate-500"
+            >
+              🔔 Telegram Notifications
+            </Link>
+          </DropdownMenuItem>
+          {/* END NEW */}
 
           <SupportFormDialog>
             <DropdownMenuItem

--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -111,7 +111,7 @@ export function UserMenu() {
           {user?.isTalentFilled && (
             <>
               <DropdownMenuItem asChild>
-                <Link
+                <a
                   href={`/t/${user?.username}`}
                   onClick={() => {
                     posthog.capture('profile_user menu');
@@ -122,7 +122,7 @@ export function UserMenu() {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <Link
+                <a
                   href={`/t/${user?.username}/edit`}
                   onClick={() => {
                     posthog.capture('edit profile_user menu');
@@ -162,7 +162,7 @@ export function UserMenu() {
                   className="text-sm tracking-tight text-slate-500"
                 >
                   Create New Sponsor
-                </a>
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
             </div>
@@ -182,7 +182,7 @@ export function UserMenu() {
 
           {/* NEW: Telegram Bot Integration */}
           <DropdownMenuItem asChild>
-            <Link
+            <a
               href={telegramBotLink}
               target="_blank"
               rel="noopener noreferrer"

--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -2,7 +2,7 @@ import { ChevronDown } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { usePostHog } from 'posthog-js/react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { SupportFormDialog } from '@/components/shared/SupportFormDialog';
 import { Button } from '@/components/ui/button';
@@ -57,11 +57,14 @@ export function UserMenu() {
   };
 
   // Generate Telegram bot link with user context
-  const telegramBotLink = user?.id
-    ? `https://t.me/super_fun_earn_bot?start=earn_userid_${encodeURIComponent(
-        user.id,
-      )}`
-    : 'https://t.me/super_fun_earn_bot?start=earn';
+  const telegramBotLink = useMemo(() => {
+    if (!user?.id) {
+      return 'https://t.me/super_fun_earn_bot?start=earn';
+    }
+    return `https://t.me/super_fun_earn_bot?start=earn_userid_${encodeURIComponent(
+      user.id,
+    )}`;
+  }, [user?.id]);
 
   return (
     <>
@@ -108,7 +111,7 @@ export function UserMenu() {
           {user?.isTalentFilled && (
             <>
               <DropdownMenuItem asChild>
-                <Link
+                <a
                   href={`/t/${user?.username}`}
                   onClick={() => {
                     posthog.capture('profile_user menu');
@@ -116,10 +119,10 @@ export function UserMenu() {
                   className="text-sm tracking-tight text-slate-500"
                 >
                   Profile
-                </Link>
+                </a>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <Link
+                <a
                   href={`/t/${user?.username}/edit`}
                   onClick={() => {
                     posthog.capture('edit profile_user menu');
@@ -127,14 +130,14 @@ export function UserMenu() {
                   className="text-sm tracking-tight text-slate-500"
                 >
                   Edit Profile
-                </Link>
+                </a>
               </DropdownMenuItem>
             </>
           )}
 
           {!!user?.currentSponsorId && (
             <DropdownMenuItem asChild>
-              <Link
+              <a
                 href="/dashboard/listings"
                 onClick={() => {
                   posthog.capture('sponsor dashboard_user menu');
@@ -142,7 +145,7 @@ export function UserMenu() {
                 className="text-sm tracking-tight text-slate-500"
               >
                 Dashboard
-              </Link>
+              </a>
             </DropdownMenuItem>
           )}
 
@@ -154,12 +157,12 @@ export function UserMenu() {
                 God Mode
               </DropdownMenuLabel>
               <DropdownMenuItem asChild>
-                <Link
+                <a
                   href="/new/sponsor"
                   className="text-sm tracking-tight text-slate-500"
                 >
                   Create New Sponsor
-                </Link>
+                </a>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
             </div>
@@ -179,7 +182,7 @@ export function UserMenu() {
 
           {/* NEW: Telegram Bot Integration */}
           <DropdownMenuItem asChild>
-            <Link
+            <a
               href={telegramBotLink}
               target="_blank"
               rel="noopener noreferrer"
@@ -190,7 +193,7 @@ export function UserMenu() {
               className="text-sm tracking-tight text-slate-500"
             >
               🔔 Telegram Notifications
-            </Link>
+            </a>
           </DropdownMenuItem>
           {/* END NEW */}
 

--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -111,7 +111,7 @@ export function UserMenu() {
           {user?.isTalentFilled && (
             <>
               <DropdownMenuItem asChild>
-                <a
+                <Link
                   href={`/t/${user?.username}`}
                   onClick={() => {
                     posthog.capture('profile_user menu');
@@ -119,10 +119,10 @@ export function UserMenu() {
                   className="text-sm tracking-tight text-slate-500"
                 >
                   Profile
-                </a>
+                </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <a
+                <Link
                   href={`/t/${user?.username}/edit`}
                   onClick={() => {
                     posthog.capture('edit profile_user menu');
@@ -130,14 +130,14 @@ export function UserMenu() {
                   className="text-sm tracking-tight text-slate-500"
                 >
                   Edit Profile
-                </a>
+                </Link>
               </DropdownMenuItem>
             </>
           )}
 
           {!!user?.currentSponsorId && (
             <DropdownMenuItem asChild>
-              <a
+              <Link
                 href="/dashboard/listings"
                 onClick={() => {
                   posthog.capture('sponsor dashboard_user menu');
@@ -145,7 +145,7 @@ export function UserMenu() {
                 className="text-sm tracking-tight text-slate-500"
               >
                 Dashboard
-              </a>
+              </Link>
             </DropdownMenuItem>
           )}
 
@@ -157,7 +157,7 @@ export function UserMenu() {
                 God Mode
               </DropdownMenuLabel>
               <DropdownMenuItem asChild>
-                <a
+                <Link
                   href="/new/sponsor"
                   className="text-sm tracking-tight text-slate-500"
                 >
@@ -182,7 +182,7 @@ export function UserMenu() {
 
           {/* NEW: Telegram Bot Integration */}
           <DropdownMenuItem asChild>
-            <a
+            <Link
               href={telegramBotLink}
               target="_blank"
               rel="noopener noreferrer"

--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -111,7 +111,7 @@ export function UserMenu() {
           {user?.isTalentFilled && (
             <>
               <DropdownMenuItem asChild>
-                <a
+                <Link
                   href={`/t/${user?.username}`}
                   onClick={() => {
                     posthog.capture('profile_user menu');
@@ -122,7 +122,7 @@ export function UserMenu() {
                 </Link>
               </DropdownMenuItem>
               <DropdownMenuItem asChild>
-                <a
+                <Link
                   href={`/t/${user?.username}/edit`}
                   onClick={() => {
                     posthog.capture('edit profile_user menu');

--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -57,8 +57,10 @@ export function UserMenu() {
   };
 
   // Generate Telegram bot link with user context
-  const telegramBotLink = user?.id 
-    ? `https://t.me/super_fun_earn_bot?start=earn_userid_${user.id}`
+  const telegramBotLink = user?.id
+    ? `https://t.me/super_fun_earn_bot?start=earn_userid_${encodeURIComponent(
+        user.id,
+      )}`
     : 'https://t.me/super_fun_earn_bot?start=earn';
 
   return (
@@ -181,6 +183,7 @@ export function UserMenu() {
               href={telegramBotLink}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="Connect Telegram notifications bot"
               onClick={() => {
                 posthog.capture('telegram notifications_user menu');
               }}


### PR DESCRIPTION
What does this PR do?
Adds a Telegram bot link to the user menu dropdown on Superteam Earn, enabling users to access personalized bounty notifications directly from the platform. This integration allows seamless connection to the notification bot that sends alerts based on user preferences.
Where should the reviewer start?
Primary changes: src/features/navbar/components/UserMenu.tsx (lines 58-82)

Added Telegram bot link generation with user context
Integrated the link into the dropdown menu with proper styling
Added PostHog analytics tracking for user interactions

How should this be manually tested?

Desktop Testing:

Log into Superteam Earn
Click on user menu (top right corner)
Verify "🔔 Telegram Notifications" option appears in dropdown
Click the link - should open Telegram bot with user-specific start parameter


Mobile Testing:

Access site on mobile device
Navigate to user menu (top left on mobile)
Confirm the Telegram bot option is visible and functional


User Context Testing:

Test with logged-in user (should include user ID in bot URL)
Test fallback for users without ID (generic start parameter)


Analytics Verification:

Click tracking should fire PostHog event: telegram notifications_user menu



Any background context you want to provide?
This is part of the Superteam Earn Telegram Bot bounty implementation. The bot provides:

Personalized notifications for new bounties and projects
Filtering by USD value, listing type (bounties/projects), and skills
Geography-based eligibility notifications
12-hour delay notification system

The menu link provides the required seamless access from the Earn platform as specified in the bounty requirements.
What are the relevant issues?
Superteam Earn Telegram Bot Bounty - This PR fulfills the requirement for "accessible via a direct link from the user menu (present on the top right on desktop, and top left on mobile)."
Technical Implementation Details

Dynamic URL Generation: Bot link includes user ID for personalized onboarding
Graceful Fallback: Generic bot link for edge cases
Accessibility: Proper ARIA labels and semantic HTML
Analytics Integration: PostHog event tracking for user interactions
Security: Proper URL encoding and external link attributes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "🔔 Telegram Notifications" link to the user menu, allowing users to connect to a Telegram bot for notifications.
- **Enhancements**
  - The Telegram link dynamically includes the user's ID when logged in for a personalized experience.
- **Analytics**
  - Clicking the Telegram Notifications link is now tracked for usage insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->