### PR TITLE
feat:  Telegram Notification bot link to earn page from UserMenu

### DIFF
--- a/src/features/navbar/components/MobileDrawer.tsx
+++ b/src/features/navbar/components/MobileDrawer.tsx
@@ -17,6 +17,7 @@ import { Sheet, SheetContent } from '@/components/ui/sheet';
 import { useDisclosure } from '@/hooks/use-disclosure';
 import { useLogout, useUser } from '@/store/user';
 import { cn } from '@/utils/cn';
+import { getTelegramBotURL } from '@/utils/getTelegramBotURL';
 
 import { HACKATHONS } from '@/features/hackathon/constants/hackathons';
 import { EarnAvatar } from '@/features/talent/components/EarnAvatar';
@@ -259,6 +260,10 @@ export const MobileDrawer = ({
             <NavItem
               label="Leaderboard"
               onClick={() => router.push(`/leaderboard`)}
+            />
+            <NavItem
+              label="Telegram Notifications"
+              onClick={() => router.push(getTelegramBotURL(user))}
             />
             <SupportFormDialog>
               <NavItem

--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useDisclosure } from '@/hooks/use-disclosure';
 import { useLogout, useUser } from '@/store/user';
+import { getTelegramBotURL } from '@/utils/getTelegramBotURL';
 
 import { EarnAvatar } from '@/features/talent/components/EarnAvatar';
 import { EmailSettingsModal } from '@/features/talent/components/EmailSettingsModal';
@@ -169,6 +170,21 @@ export function UserMenu() {
               Email Preferences
             </DropdownMenuItem>
           )}
+
+          <SupportFormDialog>
+            <DropdownMenuItem
+              className="text-sm tracking-tight text-slate-500"
+              onSelect={() => {
+                const win = window.open(getTelegramBotURL(user), '_blank');
+                if (win != null) {
+                  win.focus();
+                }
+                posthog.capture('telegram notification_user menu');
+              }}
+            >
+              Telegram Notifications
+            </DropdownMenuItem>
+          </SupportFormDialog>
 
           <SupportFormDialog>
             <DropdownMenuItem

--- a/src/utils/getTelegramBotURL.ts
+++ b/src/utils/getTelegramBotURL.ts
@@ -1,0 +1,9 @@
+import { type User } from '@/interface/user';
+
+export const getTelegramBotURL = (user: User | null) => {
+  if (!user || !user.location) {
+    return `https://t.me/superteam_earn_notifications_bot?start=${btoa('location=global')}`;
+  }
+  const data = btoa(`location=${user.location}`);
+  return `https://t.me/superteam_earn_notifications_bot?start=${data}`;
+};


### PR DESCRIPTION
## What does this PR do?
Add link to Telegram Bot in Desktop & Mobile user menus.
Send location of user to bot payload

## Where should the reviewer start?
/src/features/navbar/components/UserMenu.tsx
/src/features/navbar/components/MobileDrawer.tsx
/src/utils/getTelegramBotURL.ts

## How should this be manually tested?
Open the user menu (Top Right on Desktop or Top Left on Mobile.
Click "Telegram Notifications".
It should open the the deeplink to web to open Telegram apps.
## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)