### PR TITLE
refactor: move posthog to instrumentation client

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,13 @@
+import posthog from 'posthog-js';
+
+import { getURL } from './src/utils/validUrl';
+
+posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
+  api_host: `${getURL()}docs-keep`,
+  ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
+  autocapture: false,
+  loaded: (posthog) => {
+    if (process.env.NODE_ENV === 'development') posthog.debug();
+  },
+  defaults: '2025-05-24',
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -77,7 +77,6 @@ const nextConfig: NextConfig = {
       'next-seo',
       'nprogress',
       'posthog-js',
-      'posthog-js/react',
       'react-day-picker',
       'react-hook-form',
       'react-select',

--- a/src/components/shared/SupportFormDialog.tsx
+++ b/src/components/shared/SupportFormDialog.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import IsoDomPurify from 'isomorphic-dompurify';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -59,7 +59,6 @@ export function SupportFormDialog({ children, onSubmit }: ModalFormProps) {
   const { user } = useUser();
   const [open, setOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const posthog = usePostHog();
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),

--- a/src/components/shared/Survey.tsx
+++ b/src/components/shared/Survey.tsx
@@ -1,5 +1,4 @@
-import { type Survey, type SurveyQuestion } from 'posthog-js';
-import { usePostHog } from 'posthog-js/react';
+import posthog, { type Survey, type SurveyQuestion } from 'posthog-js';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -25,7 +24,6 @@ export const SurveyModal = ({
   surveyId: string;
 }) => {
   const { refetchUser } = useUser();
-  const posthog = usePostHog();
 
   const [question, setQuestion] = useState<SurveyQuestion | undefined | null>(
     null,

--- a/src/features/auth/components/CompleteProfileModal.tsx
+++ b/src/features/auth/components/CompleteProfileModal.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -24,7 +24,6 @@ export function CompleteProfileModal({
   bodyText,
   isSponsor,
 }: Props) {
-  const posthog = usePostHog();
   const router = useRouter();
 
   const header = isSponsor

--- a/src/features/auth/components/EmailSignIn.tsx
+++ b/src/features/auth/components/EmailSignIn.tsx
@@ -1,6 +1,6 @@
 import { useLoginWithEmail } from '@privy-io/react-auth';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -27,7 +27,6 @@ export const EmailSignIn = ({ redirectTo }: LoginProps) => {
   const [emailError, setEmailError] = useState('');
 
   const router = useRouter();
-  const posthog = usePostHog();
 
   const { state, sendCode, loginWithCode } = useLoginWithEmail({
     onComplete: async ({ user, wasAlreadyAuthenticated }) => {

--- a/src/features/auth/components/SignIn.tsx
+++ b/src/features/auth/components/SignIn.tsx
@@ -1,7 +1,7 @@
 import { useLoginWithOAuth } from '@privy-io/react-auth';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { type Dispatch, type SetStateAction, useState } from 'react';
 import { MdOutlineEmail } from 'react-icons/md';
 
@@ -26,7 +26,6 @@ export const SignIn = ({
   redirectTo,
 }: SigninProps) => {
   const router = useRouter();
-  const posthog = usePostHog();
   const [isLoading, setIsLoading] = useState(false);
   const isMD = useBreakpoint('md');
 

--- a/src/features/comments/components/Comment.tsx
+++ b/src/features/comments/components/Comment.tsx
@@ -1,7 +1,7 @@
 import { type CommentRefType } from '@prisma/client';
 import { AlertCircle, ChevronDown, Loader2, Pin, Trash2 } from 'lucide-react';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { VerifiedBadge } from '@/components/shared/VerifiedBadge';
@@ -77,7 +77,6 @@ export const Comment = ({
   isDisabled = false,
 }: Props) => {
   const { user } = useUser();
-  const posthog = usePostHog();
 
   const {
     isOpen: deleteIsOpen,

--- a/src/features/comments/components/CommentForm.tsx
+++ b/src/features/comments/components/CommentForm.tsx
@@ -1,5 +1,5 @@
 import type { CommentRefType } from '@prisma/client';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -35,7 +35,6 @@ export const CommentForm = ({
   onSuccess,
 }: Props) => {
   const { user } = useUser();
-  const posthog = usePostHog();
 
   const [newComment, setNewComment] = useState('');
   const [newCommentLoading, setNewCommentLoading] = useState(false);

--- a/src/features/comments/components/Comments.tsx
+++ b/src/features/comments/components/Comments.tsx
@@ -1,7 +1,7 @@
 import { type CommentRefType } from '@prisma/client';
 import { useSetAtom } from 'jotai';
 import { ArrowRight, Loader2 } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
 
 import { ErrorInfo } from '@/components/shared/ErrorInfo';
@@ -50,8 +50,6 @@ export const Comments = ({
   setCount,
   onSuccess,
 }: Props) => {
-  const posthog = usePostHog();
-
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(false);
   const [comments, setComments] = useState<Comment[]>([]);

--- a/src/features/conversion-popups/components/CategoryPop.tsx
+++ b/src/features/conversion-popups/components/CategoryPop.tsx
@@ -2,7 +2,7 @@ import { usePrivy } from '@privy-io/react-auth';
 import { useQuery } from '@tanstack/react-query';
 import { useAtom, useSetAtom } from 'jotai';
 import Image from 'next/image';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
@@ -148,8 +148,6 @@ export const CategoryPop = ({ category }: { category: CategoryKeys }) => {
   });
 
   const isMD = useBreakpoint('md');
-
-  const posthog = usePostHog();
 
   const initated = useRef(false); // only run use effect once
   useEffect(() => {

--- a/src/features/conversion-popups/components/GrantsPop.tsx
+++ b/src/features/conversion-popups/components/GrantsPop.tsx
@@ -1,6 +1,6 @@
 import { usePrivy } from '@privy-io/react-auth';
 import { useAtom, useSetAtom } from 'jotai';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useRef, useState } from 'react';
 
 import {
@@ -55,7 +55,6 @@ export const GrantsPop = () => {
   const { authenticated, ready } = usePrivy();
 
   const isMD = useBreakpoint('md');
-  const posthog = usePostHog();
 
   const initated = useRef(false); // only run use effect once
   useEffect(() => {

--- a/src/features/conversion-popups/components/HomepagePop.tsx
+++ b/src/features/conversion-popups/components/HomepagePop.tsx
@@ -2,7 +2,7 @@ import { usePrivy } from '@privy-io/react-auth';
 import { DialogTitle } from '@radix-ui/react-dialog';
 import { useQuery } from '@tanstack/react-query';
 import { useAtom, useSetAtom } from 'jotai';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
@@ -92,7 +92,6 @@ export const HomepagePop = () => {
   });
 
   const isMD = useBreakpoint('md');
-  const posthog = usePostHog();
 
   const initated = useRef(false); // only run use effect once
   useEffect(() => {

--- a/src/features/conversion-popups/components/ListingPop.tsx
+++ b/src/features/conversion-popups/components/ListingPop.tsx
@@ -1,7 +1,7 @@
 import { usePrivy } from '@privy-io/react-auth';
 import { useAtom, useSetAtom } from 'jotai';
 import Image from 'next/image';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
@@ -81,7 +81,7 @@ export const ListingPop = ({ listing }: { listing: Listing | null }) => {
   const { authenticated, ready } = usePrivy();
 
   const isMD = useBreakpoint('md');
-  const posthog = usePostHog();
+
   const [bountySnackbar] = useAtom(bountySnackbarAtom);
 
   const initated = useRef(false); // only run use effect once

--- a/src/features/conversion-popups/components/RegionPop.tsx
+++ b/src/features/conversion-popups/components/RegionPop.tsx
@@ -1,7 +1,7 @@
 import { usePrivy } from '@privy-io/react-auth';
 import { useQuery } from '@tanstack/react-query';
 import { useAtom, useSetAtom } from 'jotai';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { UserFlag } from '@/components/shared/UserFlag';
@@ -65,7 +65,6 @@ export const RegionPop = ({ st }: { st: Superteam }) => {
   });
 
   const isMD = useBreakpoint('md');
-  const posthog = usePostHog();
 
   const initated = useRef(false); // only run use effect once
   useEffect(() => {

--- a/src/features/credits/components/CreditLog.tsx
+++ b/src/features/credits/components/CreditLog.tsx
@@ -1,7 +1,7 @@
 import { format } from 'date-fns';
 import { Check, Minus, Plus, Undo } from 'lucide-react';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { type ReactNode } from 'react';
 
 import { Separator } from '@/components/ui/separator';
@@ -41,8 +41,6 @@ interface CreditHistoryCardProps {
 }
 
 export function CreditHistoryCard({ title, entries }: CreditHistoryCardProps) {
-  const posthog = usePostHog();
-
   const isUpcoming = entries.some((entry) => {
     if (!entry.effectiveMonth) return false;
 

--- a/src/features/feed/components/FeedCardContainer.tsx
+++ b/src/features/feed/components/FeedCardContainer.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { type ReactNode, useEffect, useState } from 'react';
 import { GoComment } from 'react-icons/go';
 import { IoMdHeart, IoMdHeartEmpty } from 'react-icons/io';
@@ -113,7 +113,6 @@ export const FeedCardContainer = ({
   };
 
   const router = useRouter();
-  const posthog = usePostHog();
 
   return (
     <div

--- a/src/features/grants/components/ApplicationActionButton.tsx
+++ b/src/features/grants/components/ApplicationActionButton.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { AlertTriangle, Loader2, Pencil } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -28,7 +28,7 @@ export const ApplicationActionButton = ({
   grant,
 }: GrantApplicationButtonProps) => {
   const { user } = useUser();
-  const posthog = usePostHog();
+
   const { region, id, link, isNative, isPublished } = grant;
 
   const { data: application, isLoading: isUserApplicationLoading } = useQuery({

--- a/src/features/grants/hooks/useGrantState.ts
+++ b/src/features/grants/hooks/useGrantState.ts
@@ -1,5 +1,5 @@
 import { useRouter, useSearchParams } from 'next/navigation';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useCallback, useMemo } from 'react';
 
 import { GrantCategorySchema } from '../constants/schema';
@@ -9,7 +9,6 @@ const defaultCategory = GrantCategorySchema._def.defaultValue();
 type QueryParamUpdates = Partial<Record<'grantCategory', string | null>>;
 
 export const useGrantState = () => {
-  const posthog = usePostHog();
   const router = useRouter();
   const searchParamsFromHook = useSearchParams();
 

--- a/src/features/hackathon/hooks/useHackathonState.ts
+++ b/src/features/hackathon/hooks/useHackathonState.ts
@@ -1,5 +1,5 @@
 import { useRouter, useSearchParams } from 'next/navigation';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useCallback, useMemo } from 'react';
 
 import {
@@ -30,7 +30,6 @@ type QueryParamUpdates = Partial<
 >;
 
 export const useHackathonState = () => {
-  const posthog = usePostHog();
   const router = useRouter();
   const searchParamsFromHook = useSearchParams();
 

--- a/src/features/home/components/Banner/SponsorBanner.tsx
+++ b/src/features/home/components/Banner/SponsorBanner.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { getImageProps } from 'next/image';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React from 'react';
 
 import { cn } from '@/utils/cn';
@@ -11,7 +11,6 @@ import { sponsorCountQuery } from '../../queries/sponsor-count';
 import { userCountQuery } from '../../queries/user-count';
 
 export function HomeSponsorBanner() {
-  const posthog = usePostHog();
   const common = {
     alt: 'Illustration — Gradient Light blue with Logos of Solana first Companies',
     quality: 85,

--- a/src/features/home/components/Banner/TalentBanner.tsx
+++ b/src/features/home/components/Banner/TalentBanner.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { getImageProps } from 'next/image';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React from 'react';
 
 import { ASSET_URL } from '@/constants/ASSET_URL';
@@ -16,7 +16,6 @@ const avatars = [
 ];
 
 export function HomeTalentBanner() {
-  const posthog = usePostHog();
   const common = {
     alt: 'Illustration — Two people working on laptops outdoors at night, surrounded by a mystical mountainous landscape illuminated by the moonlight',
     quality: 85,

--- a/src/features/home/components/CategoryBanner.tsx
+++ b/src/features/home/components/CategoryBanner.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -58,7 +58,7 @@ const banners: CategoryBanner[] = [
 
 export function CategoryBanner({ category }: { category: CategoryTypes }) {
   const [banner, setBanner] = useState<CategoryBanner | null>(null);
-  const posthog = usePostHog();
+
   const { user } = useUser();
 
   useEffect(() => {

--- a/src/features/home/components/HowItWorks.tsx
+++ b/src/features/home/components/HowItWorks.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Check } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { useUser } from '@/store/user';
 import { cn } from '@/utils/cn';
@@ -128,7 +128,6 @@ export const HowItWorks = () => {
 
   const hasSubmissions = (stats?.participations ?? 0) > 0;
   const hasWins = (stats?.wins ?? 0) > 0;
-  const posthog = usePostHog();
 
   if (hasWins) return null;
 

--- a/src/features/home/components/RecentActivity.tsx
+++ b/src/features/home/components/RecentActivity.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { MdArrowForward } from 'react-icons/md';
 
 import { LocalImage } from '@/components/ui/local-image';
@@ -95,7 +95,6 @@ const ActivityCard = ({
 };
 
 export const RecentActivity = () => {
-  const posthog = usePostHog();
   const { data, isLoading } = useQuery(homeFeedQuery);
 
   if (isLoading) return null;

--- a/src/features/home/components/RecentEarners.tsx
+++ b/src/features/home/components/RecentEarners.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useEffect, useRef, useState } from 'react';
 import { MdArrowForward } from 'react-icons/md';
 
@@ -69,7 +69,6 @@ export const RecentEarners = ({ earners }: { earners?: User[] }) => {
   const marqueeRef = useRef<HTMLDivElement>(null);
   const animationFrameRef = useRef<number | null>(null);
   const [isPaused, setIsPaused] = useState(false);
-  const posthog = usePostHog();
 
   const multipliedEarners = earners ? [...earners, ...earners, ...earners] : [];
 

--- a/src/features/home/components/SponsorBanner.tsx
+++ b/src/features/home/components/SponsorBanner.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { MdArrowForward } from 'react-icons/md';
 
 import { ExternalImage } from '@/components/ui/cloudinary-image';
@@ -8,7 +8,6 @@ import { ExternalImage } from '@/components/ui/cloudinary-image';
 import { userCountQuery } from '../queries/user-count';
 
 export const SponsorBanner = () => {
-  const posthog = usePostHog();
   const { data } = useQuery(userCountQuery);
 
   return (

--- a/src/features/leaderboard/components/RanksTable.tsx
+++ b/src/features/leaderboard/components/RanksTable.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { UserFlag } from '@/components/shared/UserFlag';
 import {
@@ -42,7 +42,6 @@ export function RanksTable({
   search,
 }: Props) {
   const { user } = useUser();
-  const posthog = usePostHog();
 
   const userSkills = getSubskills(user?.skills as any, skillCategories[skill]);
 

--- a/src/features/listing-builder/components/AiGenerate/Dialog.tsx
+++ b/src/features/listing-builder/components/AiGenerate/Dialog.tsx
@@ -5,7 +5,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useAtom, useSetAtom } from 'jotai';
 import { marked } from 'marked';
 import { AnimatePresence, motion } from 'motion/react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { type ReactNode, useCallback, useEffect, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -53,7 +53,7 @@ interface AIDescriptionDialogProps {
 
 export function AiGenerateDialog({ children }: AIDescriptionDialogProps) {
   const listingForm = useListingForm();
-  const posthog = usePostHog();
+
   const type = useWatch({
     control: listingForm.control,
     name: 'type',

--- a/src/features/listing-builder/components/Form/DescriptionAndTemplate/Templates.tsx
+++ b/src/features/listing-builder/components/Form/DescriptionAndTemplate/Templates.tsx
@@ -3,7 +3,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { ChevronRight, Eye, LayoutGrid, Plus } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 
@@ -48,7 +48,6 @@ import { isAutoGenerateOpenAtom, isEditingAtom } from '../../../atoms';
 import { useListingForm } from '../../../hooks';
 
 export function Templates() {
-  const posthog = usePostHog();
   const { user } = useUser();
   const router = useRouter();
 

--- a/src/features/listing-builder/components/Form/PrePublish/Modal.tsx
+++ b/src/features/listing-builder/components/Form/PrePublish/Modal.tsx
@@ -2,7 +2,7 @@ import { useIsFetching, useQuery } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { ExternalLink, Loader2 } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -59,7 +59,7 @@ export function PrePublish() {
   const submitListingMutation = useAtomValue(submitListingMutationAtom);
 
   const router = useRouter();
-  const posthog = usePostHog();
+
   const { user } = useUser();
 
   const {

--- a/src/features/listing-builder/components/Form/TitleAndType.tsx
+++ b/src/features/listing-builder/components/Form/TitleAndType.tsx
@@ -2,7 +2,7 @@ import type { CompensationType } from '@prisma/client';
 import { useQuery } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
 import { Link } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 import slugify from 'slugify';
@@ -49,7 +49,7 @@ const typeOptions = [
 
 export function TitleAndType() {
   const form = useListingForm();
-  const posthog = usePostHog();
+
   const type = useWatch({ name: 'type', control: form.control });
   const title = useWatch({ control: form.control, name: 'title' });
   const listingId = useWatch({ control: form.control, name: 'id' });

--- a/src/features/listing-builder/components/Modals/PreviewListingModal.tsx
+++ b/src/features/listing-builder/components/Modals/PreviewListingModal.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from 'jotai';
 import { ExternalLink, Info, Loader2 } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useMemo, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 
@@ -21,7 +21,6 @@ export const PreviewListingModal = () => {
   const [showPreview, setShowPreview] = useAtom(previewAtom);
   const [activeView, setActiveView] = useState('desktop');
   const [isLoading, setIsLoading] = useState(true);
-  const posthog = usePostHog();
 
   const form = useListingForm();
   const type = useWatch({

--- a/src/features/listing-builder/components/layout/Header.tsx
+++ b/src/features/listing-builder/components/layout/Header.tsx
@@ -3,7 +3,7 @@ import { useIsFetching } from '@tanstack/react-query';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { ChevronLeft, Eye, Loader2 } from 'lucide-react';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useWatch } from 'react-hook-form';
 
 import { Button } from '@/components/ui/button';
@@ -25,7 +25,7 @@ import { StatusBadge } from './StatusBadge';
 
 export function Header() {
   const { authenticated, ready } = usePrivy();
-  const posthog = usePostHog();
+
   const isDraftSaving = useAtomValue(isDraftSavingAtom);
   const setShowPreview = useSetAtom(previewAtom);
   const form = useListingForm();

--- a/src/features/listings/components/CategoryPill.tsx
+++ b/src/features/listings/components/CategoryPill.tsx
@@ -1,4 +1,4 @@
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { cn } from '@/utils/cn';
 
@@ -15,8 +15,6 @@ export function CategoryPill({
   isActive,
   onClick,
 }: CategoryPillProps) {
-  const posthog = usePostHog();
-
   return (
     <div
       className={cn(

--- a/src/features/listings/components/ListingFilters.tsx
+++ b/src/features/listings/components/ListingFilters.tsx
@@ -1,5 +1,5 @@
 import { LucideListFilter } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import {
   DropdownMenu,
@@ -34,7 +34,6 @@ export const ListingFilters = ({
   onStatusChange,
   onSortChange,
 }: ListingFiltersProps) => {
-  const posthog = usePostHog();
   const sortOptions = getListingSortOptions(activeStatus);
 
   const isDefaultFilterApplied =

--- a/src/features/listings/components/ListingPage/ExtraInfoSection.tsx
+++ b/src/features/listings/components/ListingPage/ExtraInfoSection.tsx
@@ -1,5 +1,5 @@
 import { ExternalLink } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { type ParentSkills } from '@/interface/skills';
 import { dayjs } from '@/utils/dayjs';
@@ -26,7 +26,6 @@ export function ExtraInfoSection({
   commitmentDate,
   isGrant = false,
 }: ExtraInfoSectionProps) {
-  const posthog = usePostHog();
   return (
     <div className="flex w-full flex-col gap-8 pt-2 md:w-[23rem]">
       {region && region !== 'Global' && (

--- a/src/features/listings/components/ListingPage/ListingHeader.tsx
+++ b/src/features/listings/components/ListingPage/ListingHeader.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Check, Clock, File, MessageSquare, Pause } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React from 'react';
 
 import { VerifiedBadge } from '@/components/shared/VerifiedBadge';
@@ -47,7 +47,7 @@ export function ListingHeader({
     isPrivate,
   } = listing;
   const router = useRouter();
-  const posthog = usePostHog();
+
   const isMD = useMediaQuery('(min-width: 768px)');
   const hasDeadlineEnded = dayjs().isAfter(deadline);
   const hasHackathonStarted = dayjs().isAfter(Hackathon?.startDate);

--- a/src/features/listings/components/ListingPage/ListingWinners.tsx
+++ b/src/features/listings/components/ListingPage/ListingWinners.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useMemo } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -40,7 +40,6 @@ const getOrRemoveBonuses = (
 export function ListingWinners({ bounty }: Props) {
   const isProject = bounty?.type === 'project';
 
-  const posthog = usePostHog();
   const isMD = useBreakpoint('md');
   const isSM = useBreakpoint('sm');
   const isLG = useBreakpoint('lg');

--- a/src/features/listings/components/ListingPage/ShareListing.tsx
+++ b/src/features/listings/components/ListingPage/ShareListing.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import * as React from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -53,7 +53,6 @@ export function ShareListing({
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 } & SourceType) {
-  const posthog = usePostHog();
   function setShareOpen(o: boolean) {
     if (o) posthog.capture('open_share listing');
     else posthog.capture('close_share listing');
@@ -136,7 +135,6 @@ function MainContent({ listing, grant, source }: SourceType) {
     return encodeURIComponent(`${copy}! Check it out: \n${listingLink()}`);
   };
 
-  const posthog = usePostHog();
   const { hasCopied, onCopy } = useClipboard(listingLink());
   function onListingLinkCopy() {
     posthog.capture('copy_share listing');

--- a/src/features/listings/components/ListingPage/SubscribeListing.tsx
+++ b/src/features/listings/components/ListingPage/SubscribeListing.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { TbBell, TbBellRinging } from 'react-icons/tb';
 import { toast } from 'sonner';
 
@@ -26,7 +26,7 @@ const toggleSubscription = async (id: string) => {
 
 export const SubscribeListing = ({ id, isTemplate = false }: Props) => {
   const { user } = useUser();
-  const posthog = usePostHog();
+
   const queryClient = useQueryClient();
 
   const { data: sub = [] } = useQuery(listingSubscriptionsQuery(id));

--- a/src/features/listings/components/Submission/SubmissionActionButton.tsx
+++ b/src/features/listings/components/Submission/SubmissionActionButton.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { Loader2, Pencil } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useState } from 'react';
 
 import { SurveyModal } from '@/components/shared/Survey';
@@ -122,7 +122,7 @@ export const SubmissionActionButton = ({
 
   const isSubmitted = submission?.isSubmitted ?? false;
   const submissionStatus = submission?.status;
-  const posthog = usePostHog();
+
   const router = useRouter();
   const { query } = router;
 

--- a/src/features/listings/components/Submission/SubmissionDrawer.tsx
+++ b/src/features/listings/components/Submission/SubmissionDrawer.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { X } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { type JSX, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -96,7 +96,7 @@ export const SubmissionDrawer = ({
           : [],
     },
   });
-  const posthog = usePostHog();
+
   const router = useRouter();
   const { query } = router;
 

--- a/src/features/listings/components/ViewAllButton.tsx
+++ b/src/features/listings/components/ViewAllButton.tsx
@@ -1,6 +1,6 @@
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { Button } from '@/components/ui/button';
 
@@ -11,7 +11,6 @@ export const ViewAllButton = ({
   posthogEvent: string;
   href: string;
 }) => {
-  const posthog = usePostHog();
   return (
     <Button
       className="my-4 w-full border-slate-300 py-3 text-sm font-medium text-slate-400 sm:py-4.5 sm:text-sm"

--- a/src/features/listings/hooks/useListingState.ts
+++ b/src/features/listings/hooks/useListingState.ts
@@ -1,5 +1,5 @@
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
@@ -39,7 +39,6 @@ type QueryParamUpdates = Partial<
 export const useListingState = ({
   defaultCategory = DEFAULT_HOOK_INITIAL_CATEGORY_VALUE,
 }: UseListingStateProps) => {
-  const posthog = usePostHog();
   const router = useRouter();
   const pathname = usePathname();
   const searchParamsFromHook = useSearchParams();

--- a/src/features/navbar/components/DesktopNavbar.tsx
+++ b/src/features/navbar/components/DesktopNavbar.tsx
@@ -2,7 +2,7 @@ import { usePrivy } from '@privy-io/react-auth';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useMemo } from 'react';
 import { IoSearchOutline, IoWalletOutline } from 'react-icons/io5';
 
@@ -41,7 +41,7 @@ export const DesktopNavbar = ({
 }: Props) => {
   const { authenticated, ready } = usePrivy();
   const router = useRouter();
-  const posthog = usePostHog();
+
   const { user } = useUser();
   const { creditBalance } = useCreditBalance();
 

--- a/src/features/navbar/components/Header.tsx
+++ b/src/features/navbar/components/Header.tsx
@@ -1,7 +1,7 @@
 import { usePrivy } from '@privy-io/react-auth';
 import { useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect } from 'react';
 
 import { useDisclosure } from '@/hooks/use-disclosure';
@@ -58,7 +58,6 @@ export const Header = () => {
     onClose: onCreditClose,
   } = useDisclosure();
 
-  const posthog = usePostHog();
   function searchOpenWithEvent() {
     posthog.capture('initiate_search');
     onSearchOpen();

--- a/src/features/navbar/components/MobileDrawer.tsx
+++ b/src/features/navbar/components/MobileDrawer.tsx
@@ -1,7 +1,7 @@
 import { usePrivy } from '@privy-io/react-auth';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useState } from 'react';
 
 import { SupportFormDialog } from '@/components/shared/SupportFormDialog';
@@ -68,8 +68,6 @@ export const MobileDrawer = ({
   const { isOpen, onClose, onOpen } = useDisclosure();
 
   const { user } = useUser();
-
-  const posthog = usePostHog();
 
   const isLoggedIn = !!user && authenticated && ready;
 

--- a/src/features/navbar/components/MobileNavbar.tsx
+++ b/src/features/navbar/components/MobileNavbar.tsx
@@ -1,7 +1,7 @@
 import { usePrivy } from '@privy-io/react-auth';
 import { Menu } from 'lucide-react';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React from 'react';
 import { IoWalletOutline } from 'react-icons/io5';
 
@@ -40,7 +40,6 @@ export const MobileNavbar = ({
   } = useDisclosure();
 
   const { authenticated, ready } = usePrivy();
-  const posthog = usePostHog();
 
   const { user } = useUser();
   const { creditBalance } = useCreditBalance();

--- a/src/features/navbar/components/UserMenu.tsx
+++ b/src/features/navbar/components/UserMenu.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect } from 'react';
 
 import { SupportFormDialog } from '@/components/shared/SupportFormDialog';
@@ -22,7 +22,7 @@ import { EmailSettingsModal } from '@/features/talent/components/EmailSettingsMo
 
 export function UserMenu() {
   const router = useRouter();
-  const posthog = usePostHog();
+
   const { user } = useUser();
   const logout = useLogout();
   const { isOpen, onClose, onOpen } = useDisclosure();

--- a/src/features/sponsor-dashboard/components/Banner.tsx
+++ b/src/features/sponsor-dashboard/components/Banner.tsx
@@ -1,6 +1,6 @@
 import { Info, Pencil } from 'lucide-react';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { MdOutlineChatBubbleOutline } from 'react-icons/md';
 
 import { VerifiedBadgeLarge } from '@/components/shared/VerifiedBadge';
@@ -72,7 +72,7 @@ export function Banner({
   isLoading: boolean;
 }) {
   const { user } = useUser();
-  const posthog = usePostHog();
+
   const sponsorId = isHackathon ? user?.hackathonId : user?.currentSponsorId;
 
   const tooltipTextReward = !isHackathon

--- a/src/features/sponsor-dashboard/components/CreateListingModal.tsx
+++ b/src/features/sponsor-dashboard/components/CreateListingModal.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -16,7 +16,6 @@ export const CreateListingModal = ({
   isOpen: boolean;
   onClose: () => void;
 }) => {
-  const posthog = usePostHog();
   const router = useRouter();
 
   const handleCreateBounty = () => {

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/AiReview.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/AiReview.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { Check, InfoIcon, Wand2, XCircle } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -38,7 +38,6 @@ interface Props {
   grant: GrantWithApplicationCount | undefined;
 }
 export default function AiReviewModal({ applications, grant }: Props) {
-  const posthog = usePostHog();
   const [open, setOpen] = useState(false);
   const [state, setState] = useState<'INIT' | 'PROCESSING' | 'DONE' | 'ERROR'>(
     'INIT',

--- a/src/features/sponsor-dashboard/components/ListingTable.tsx
+++ b/src/features/sponsor-dashboard/components/ListingTable.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useState } from 'react';
 import { IoDuplicateOutline } from 'react-icons/io5';
 import { toast } from 'sonner';
@@ -88,7 +88,7 @@ export const ListingTable = ({
     useState<ListingWithSubmissions>({});
 
   const router = useRouter();
-  const posthog = usePostHog();
+
   const { user } = useUser();
 
   const {

--- a/src/features/sponsor-dashboard/components/PublishResults.tsx
+++ b/src/features/sponsor-dashboard/components/PublishResults.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue } from 'jotai';
 import { AlertTriangle, CheckCircle2 } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useState } from 'react';
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -47,7 +47,7 @@ export function PublishResults({
   const [isWinnersAnnounced, setIsWinnersAnnounced] = useState(
     bounty?.isWinnersAnnounced,
   );
-  const posthog = usePostHog();
+
   const isDeadlinePassed = dayjs().isAfter(bounty?.deadline);
   const isProject = bounty?.type === 'project';
   if (isProject) totalWinners = 1;

--- a/src/features/sponsor-dashboard/components/Scouts/InviteButton.tsx
+++ b/src/features/sponsor-dashboard/components/Scouts/InviteButton.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { Check, Plus } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React from 'react';
 import { toast } from 'sonner';
 
@@ -25,8 +25,6 @@ export function InviteButton({
   maxInvitesReached,
   invitesLeft,
 }: Props) {
-  const posthog = usePostHog();
-
   const inviteMutation = useMutation({
     mutationFn: async () => {
       const response = await api.post(

--- a/src/features/sponsor-dashboard/components/Scouts/ScoutTable.tsx
+++ b/src/features/sponsor-dashboard/components/Scouts/ScoutTable.tsx
@@ -1,6 +1,6 @@
 import { Info } from 'lucide-react';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { Button } from '@/components/ui/button';
 import { LocalImage } from '@/components/ui/local-image';
@@ -42,7 +42,6 @@ interface Props {
 }
 
 export function ScoutTable({ bountyId, scouts, setInvited }: Props) {
-  const posthog = usePostHog();
   const invitedCount = scouts.filter((scout) => scout.invited).length;
   const MAX_INVITES = scouts.length;
   const maxInvitesReached = invitedCount >= MAX_INVITES;

--- a/src/features/sponsor-dashboard/components/Submissions/PayoutButton.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/PayoutButton.tsx
@@ -16,7 +16,7 @@ import { useAtom } from 'jotai';
 import { Loader2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { log } from 'next-axiom';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -47,7 +47,7 @@ export const PayoutButton = ({ bounty }: Props) => {
   const { user } = useUser();
 
   const { connected, publicKey, sendTransaction } = useWallet();
-  const posthog = usePostHog();
+
   const { connection } = useConnection();
   const queryClient = useQueryClient();
 

--- a/src/features/sponsor/components/DesktopNavbar.tsx
+++ b/src/features/sponsor/components/DesktopNavbar.tsx
@@ -1,7 +1,7 @@
 import { usePrivy } from '@privy-io/react-auth';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -16,7 +16,7 @@ import { NAV_LINKS } from '../utils/constants';
 export const DesktopNavbar = () => {
   const { authenticated, ready } = usePrivy();
   const { user } = useUser();
-  const posthog = usePostHog();
+
   const router = useRouter();
 
   const isDashboardRoute = router.pathname.startsWith('/dashboard');

--- a/src/features/sponsor/components/Features.tsx
+++ b/src/features/sponsor/components/Features.tsx
@@ -1,4 +1,4 @@
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { cn } from '@/utils/cn';
 
@@ -55,8 +55,6 @@ interface Props {
 }
 
 export function Features({ showVideo }: Props) {
-  const posthog = usePostHog();
-
   return (
     <div
       className="relative mx-auto my-32 w-full px-[1.875rem] lg:px-[7rem] xl:px-[11rem]"

--- a/src/features/sponsor/components/Footer.tsx
+++ b/src/features/sponsor/components/Footer.tsx
@@ -1,6 +1,6 @@
 import { usePrivy } from '@privy-io/react-auth';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { Button } from '@/components/ui/button';
 import { useUser } from '@/store/user';
@@ -11,7 +11,6 @@ import { maxW2 } from '../utils/styles';
 export function Footer() {
   const { authenticated } = usePrivy();
   const { user } = useUser();
-  const posthog = usePostHog();
 
   function getStartedWhere(isAuthenticated: boolean, isSponsor: boolean) {
     if (!isAuthenticated) return '/new/sponsor';

--- a/src/features/sponsor/components/Hero.tsx
+++ b/src/features/sponsor/components/Hero.tsx
@@ -1,6 +1,6 @@
 import { usePrivy } from '@privy-io/react-auth';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 
 import { Button } from '@/components/ui/button';
 import { useUser } from '@/store/user';
@@ -16,8 +16,6 @@ export function Hero() {
   const { authenticated } = usePrivy();
 
   const { user } = useUser();
-
-  const posthog = usePostHog();
 
   const base = '/landingsponsor/sponsors/';
 

--- a/src/features/sponsor/components/MobileNavbar.tsx
+++ b/src/features/sponsor/components/MobileNavbar.tsx
@@ -1,7 +1,7 @@
 import { usePrivy } from '@privy-io/react-auth';
 import { Menu } from 'lucide-react';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useRef } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -23,7 +23,7 @@ export const MobileNavbar = () => {
 
   const { authenticated, ready } = usePrivy();
   const { user } = useUser();
-  const posthog = usePostHog();
+
   const btnRef = useRef<HTMLButtonElement>(null);
 
   const MobileSponsorDrawer = () => {

--- a/src/features/talent/components/EmailSettingsModal.tsx
+++ b/src/features/talent/components/EmailSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -39,7 +39,6 @@ export const EmailSettingsModal = ({
   onClose: () => void;
 }) => {
   const { user, refetchUser } = useUser();
-  const posthog = usePostHog();
 
   const emailSettings = user?.emailSettings || [];
   const [selectedCategories, setSelectedCategories] = useState<string[]>(

--- a/src/features/talent/components/onboarding-form/Form.tsx
+++ b/src/features/talent/components/onboarding-form/Form.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -33,7 +33,6 @@ import { SkillsField } from './fields/Skills';
 import { SocialsField } from './fields/Socials';
 import { UsernameField } from './fields/Username';
 export const TalentForm = () => {
-  const posthog = usePostHog();
   const router = useRouter();
   const { user, refetchUser } = useUser();
 

--- a/src/features/wallet/components/WalletDrawer.tsx
+++ b/src/features/wallet/components/WalletDrawer.tsx
@@ -1,7 +1,7 @@
 import { useMfaEnrollment, usePrivy } from '@privy-io/react-auth';
 import { ArrowLeft, ArrowUpRight, CopyIcon, X } from 'lucide-react';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -52,7 +52,7 @@ export function WalletDrawer({
 
   const { user } = useUser();
   const router = useRouter();
-  const posthog = usePostHog();
+
   const { user: privyUser } = usePrivy();
   const { showMfaEnrollmentModal } = useMfaEnrollment();
 

--- a/src/features/wallet/components/withdraw/WithdrawFundsFlow.tsx
+++ b/src/features/wallet/components/withdraw/WithdrawFundsFlow.tsx
@@ -8,7 +8,7 @@ import {
 import { PublicKey, VersionedTransaction } from '@solana/web3.js';
 import { useQueryClient } from '@tanstack/react-query';
 import { log } from 'next-axiom';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useCallback, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -48,7 +48,7 @@ export function WithdrawFundsFlow({
   setTxData,
 }: WithdrawFlowProps) {
   const { user } = useUser();
-  const posthog = usePostHog();
+
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string>('');
   const [ataCreationCost, setAtaCreationCost] = useState<number>(0);

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,6 +1,6 @@
 import posthog from 'posthog-js';
 
-import { getURL } from './src/utils/validUrl';
+import { getURL } from './utils/validUrl';
 
 posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   api_host: `${getURL()}docs-keep`,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -7,7 +7,9 @@ posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
   autocapture: false,
   loaded: (posthog) => {
-    if (process.env.NODE_ENV === 'development') posthog.debug();
+    if (process.env.NODE_ENV !== 'production') posthog.debug();
   },
   defaults: '2025-05-24',
+  capture_pageview: false,
+  capture_pageleave: false,
 });

--- a/src/layouts/Grants.tsx
+++ b/src/layouts/Grants.tsx
@@ -3,7 +3,7 @@ import { useAtom } from 'jotai';
 import { ExternalLink } from 'lucide-react';
 import Head from 'next/head';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useState } from 'react';
 
 import { EmptySection } from '@/components/shared/EmptySection';
@@ -35,7 +35,7 @@ export function GrantPageLayout({
 }: GrantPageProps) {
   const [grant] = useState<typeof initialGrant>(initialGrant);
   const encodedTitle = encodeURIComponent(initialGrant?.title || '');
-  const posthog = usePostHog();
+
   const [, setGrantSnackbar] = useAtom(grantSnackbarAtom);
   const { user } = useUser();
 

--- a/src/layouts/Listing.tsx
+++ b/src/layouts/Listing.tsx
@@ -4,7 +4,7 @@ import { ExternalLink } from 'lucide-react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useState } from 'react';
 
 import { ErrorSection } from '@/components/shared/ErrorSection';
@@ -37,7 +37,6 @@ export function ListingPageLayout({
   isTemplate = false,
 }: ListingPageProps) {
   const [, setBountySnackbar] = useAtom(bountySnackbarAtom);
-  const posthog = usePostHog();
 
   const { data: submissionNumber = 0 } = useQuery(
     submissionCountQuery(initialBounty?.id ?? ''),

--- a/src/layouts/Sponsor.tsx
+++ b/src/layouts/Sponsor.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Lock, MessageSquare, Plus, Users } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import {
   type ReactNode,
   useCallback,
@@ -61,7 +61,7 @@ export function SponsorLayout({
     onOpen: onSponsorInfoModalOpen,
     onClose: onSponsorInfoModalClose,
   } = useDisclosure();
-  const posthog = usePostHog();
+
   const [isEntityModalOpen, setIsEntityModalOpen] = useState(false);
   const { query } = router;
   const [isExpanded, setIsExpanded] = useState(!isCollapsible ? true : false);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,7 +2,7 @@ import { GoogleAnalytics } from '@next/third-parties/google';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
-import { Router, useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import posthog from 'posthog-js';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
@@ -30,26 +30,8 @@ const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps }: any) {
   const router = useRouter();
-  const oldUrlRef = useRef('');
   const { user, isLoading: isUserLoading } = useUser();
   const forcedRedirected = useRef(false);
-
-  useEffect(() => {
-    const handleRouteChange = () => posthog?.capture('$pageview');
-
-    const handleRouteChangeStart = () =>
-      posthog?.capture('$pageleave', {
-        $current_url: oldUrlRef.current,
-      });
-
-    Router.events.on('routeChangeComplete', handleRouteChange);
-    Router.events.on('routeChangeStart', handleRouteChangeStart);
-
-    return () => {
-      Router.events.off('routeChangeComplete', handleRouteChange);
-      Router.events.off('routeChangeStart', handleRouteChangeStart);
-    };
-  }, []);
 
   const forcedProfileRedirect = useCallback(
     (wait?: number) => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,14 +4,12 @@ import type { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import { Router, useRouter } from 'next/router';
 import posthog from 'posthog-js';
-import { PostHogProvider } from 'posthog-js/react';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
 
 import { TopLoader } from '@/components/ui/toploader';
 import { useUser } from '@/store/user';
 import { fontMono, fontSans } from '@/theme/fonts';
-import { getURL } from '@/utils/validUrl';
 
 import Providers from '@/features/privy/providers';
 
@@ -37,18 +35,6 @@ function MyApp({ Component, pageProps }: any) {
   const forcedRedirected = useRef(false);
 
   useEffect(() => {
-    if (!posthog.__loaded) {
-      posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
-        api_host: `${getURL()}docs-keep`,
-        autocapture: false,
-        ui_host:
-          process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
-        loaded: (posthog) => {
-          if (process.env.NODE_ENV === 'development') posthog.debug();
-        },
-      });
-    }
-
     const handleRouteChange = () => posthog?.capture('$pageview');
 
     const handleRouteChangeStart = () =>
@@ -151,23 +137,21 @@ function MyApp({ Component, pageProps }: any) {
 
 function App({ Component, pageProps }: AppProps) {
   return (
-    <PostHogProvider client={posthog}>
-      <QueryClientProvider client={queryClient}>
-        <style jsx global>{`
-          :root {
-            --font-sans: ${fontSans.style.fontFamily};
-            --font-mono: ${fontMono.style.fontFamily};
-          }
-          body {
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-          }
-        `}</style>
-        <Providers>
-          <MyApp Component={Component} pageProps={pageProps} />
-        </Providers>
-      </QueryClientProvider>
-    </PostHogProvider>
+    <QueryClientProvider client={queryClient}>
+      <style jsx global>{`
+        :root {
+          --font-sans: ${fontSans.style.fontFamily};
+          --font-mono: ${fontMono.style.fontFamily};
+        }
+        body {
+          -webkit-font-smoothing: antialiased;
+          -moz-osx-font-smoothing: grayscale;
+        }
+      `}</style>
+      <Providers>
+        <MyApp Component={Component} pageProps={pageProps} />
+      </Providers>
+    </QueryClientProvider>
   );
 }
 

--- a/src/pages/dashboard/hackathon/[listing]/submissions.tsx
+++ b/src/pages/dashboard/hackathon/[listing]/submissions.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { GetServerSideProps } from 'next';
 import { useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useMemo, useState } from 'react';
 
 import { LoadingSection } from '@/components/shared/LoadingSection';
@@ -55,7 +55,6 @@ export default function BountySubmissions({ listing }: Props) {
   >(undefined);
 
   const searchParams = useSearchParams();
-  const posthog = usePostHog();
 
   const { data: submissions, isLoading: isSubmissionsLoading } = useQuery(
     submissionsQuery(listing, true),

--- a/src/pages/dashboard/listings/[slug]/submissions.tsx
+++ b/src/pages/dashboard/listings/[slug]/submissions.tsx
@@ -5,7 +5,7 @@ import { Check, ChevronLeft, ChevronRight } from 'lucide-react';
 import type { GetServerSideProps } from 'next';
 import { useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { LoadingSection } from '@/components/shared/LoadingSection';
@@ -67,7 +67,7 @@ export default function BountySubmissions({ slug }: Props) {
   >(undefined);
 
   const searchParams = useSearchParams();
-  const posthog = usePostHog();
+
   const queryClient = useQueryClient();
 
   const [selectedSubmissionIds, setSelectedSubmissionIds] = useAtom(

--- a/src/pages/dashboard/local-profiles/index.tsx
+++ b/src/pages/dashboard/local-profiles/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useEffect, useRef, useState } from 'react';
 
 import { LoadingSection } from '@/components/shared/LoadingSection';
@@ -32,8 +32,6 @@ export default function LocalProfiles() {
   const { data: allUsers, isLoading } = useQuery(localProfilesQuery);
 
   const debouncedSetSearchText = useRef(debounce(setSearchText, 300)).current;
-
-  const posthog = usePostHog();
 
   useEffect(() => {
     posthog.capture('members tab_sponsor');

--- a/src/pages/dashboard/team-settings/index.tsx
+++ b/src/pages/dashboard/team-settings/index.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ChevronLeft, ChevronRight, Copy, Plus, Search } from 'lucide-react';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -53,8 +53,6 @@ const Index = () => {
   const queryClient = useQueryClient();
 
   const debouncedSetSearchText = useRef(debounce(setSearchText, 300)).current;
-
-  const posthog = usePostHog();
 
   useEffect(() => {
     posthog.capture('members tab_sponsor');

--- a/src/pages/grants/[slug]/index.tsx
+++ b/src/pages/grants/[slug]/index.tsx
@@ -1,5 +1,5 @@
 import type { GetServerSideProps } from 'next';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useEffect, useState } from 'react';
 
 import { GrantPageLayout } from '@/layouts/Grants';
@@ -16,8 +16,6 @@ interface InitialGrant {
 
 function Grants({ grant: initialGrant }: InitialGrant) {
   const [grant] = useState<typeof initialGrant>(initialGrant);
-
-  const posthog = usePostHog();
 
   useEffect(() => {
     posthog.capture('open_grant');

--- a/src/pages/hackathon/talent-olympics.tsx
+++ b/src/pages/hackathon/talent-olympics.tsx
@@ -2,7 +2,7 @@ import { type SubscribeHackathon } from '@prisma/client';
 import { Loader2 } from 'lucide-react';
 import type { GetServerSideProps } from 'next';
 import Link from 'next/link';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useRef, useState } from 'react';
 import Countdown from 'react-countdown';
 import { FaPlay } from 'react-icons/fa';
@@ -911,7 +911,7 @@ const SubscribeHackathon = () => {
     (SubscribeHackathon & { User: User | null })[]
   >([]);
   const { user } = useUser();
-  const posthog = usePostHog();
+
   const [update, setUpdate] = useState<boolean>(false);
 
   const handleToggleSubscribe = async () => {

--- a/src/pages/new/sponsor.tsx
+++ b/src/pages/new/sponsor.tsx
@@ -5,7 +5,7 @@ import axios from 'axios';
 import { Info, Loader2 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -51,7 +51,6 @@ const CreateSponsor = () => {
   const router = useRouter();
   const { ready, authenticated } = usePrivy();
   const { user, refetchUser } = useUser();
-  const posthog = usePostHog();
 
   const [selectedUserPhoto, setSelectedUserPhoto] = useState<File | null>(null);
   const [selectedLogo, setSelectedLogo] = useState<File | null>(null);

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -2,7 +2,7 @@ import debounce from 'lodash.debounce';
 import { type GetServerSideProps } from 'next';
 import { useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useCallback, useEffect, useState, useTransition } from 'react';
 
 import { Default } from '@/layouts/Default';
@@ -55,7 +55,6 @@ const Search = ({
   const searchParams = useSearchParams();
   const router = useRouter();
   const [, startTransition] = useTransition();
-  const posthog = usePostHog();
 
   const [results, setResults] = useState<SearchResult[]>(resultsP ?? []);
   const [query, setQuery] = useState(searchParams?.get('q') ?? '');

--- a/src/pages/t/[slug]/edit.tsx
+++ b/src/pages/t/[slug]/edit.tsx
@@ -3,7 +3,7 @@ import { usePrivy } from '@privy-io/react-auth';
 import { Edit, Info, Loader2, Plus, Trash } from 'lucide-react';
 import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
@@ -85,7 +85,6 @@ export default function EditProfilePage({ slug }: { slug: string }) {
   );
 
   const router = useRouter();
-  const posthog = usePostHog();
 
   const [pow, setPow] = useState<PoW[]>([]);
   const [selectedProject, setSelectedProject] = useState<number | null>(null);

--- a/src/pages/t/[slug]/index.tsx
+++ b/src/pages/t/[slug]/index.tsx
@@ -2,7 +2,7 @@ import { ChevronDown, ChevronUp, SquarePen } from 'lucide-react';
 import type { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import React, { type JSX, useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 
@@ -89,7 +89,6 @@ function TalentProfile({ talent, stats }: TalentProps) {
     });
   };
   const { user } = useUser();
-  const posthog = usePostHog();
 
   useEffect(() => {
     if (user?.id && talent?.id && user.id !== talent?.id)

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -2,7 +2,7 @@ import { usePrivy } from '@privy-io/react-auth';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { useRouter } from 'next/router';
-import { usePostHog } from 'posthog-js/react';
+import posthog from 'posthog-js';
 import { useEffect } from 'react';
 import { removeCookie, setCookie } from 'typescript-cookie';
 import { create } from 'zustand';
@@ -32,7 +32,6 @@ export const useUser = () => {
   const { user, setUser } = useUserStore();
   const { authenticated, ready, logout } = usePrivy();
   const router = useRouter();
-  const posthog = usePostHog();
 
   const { data, error, refetch, isLoading } = useQuery({
     queryKey: ['user'],
@@ -100,7 +99,6 @@ export const useLogout = () => {
   const { logout } = usePrivy();
   const queryClient = useQueryClient();
   const setUser = useUserStore((state) => state.setUser);
-  const posthog = usePostHog();
 
   return async () => {
     await logout();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated analytics integration to use a direct import for event tracking instead of a React hook across all components and pages.
  - Removed analytics provider and related initialization from the main app wrapper.
  - Centralized analytics client initialization for improved consistency and maintainability.
- **Chores**
  - Cleaned up unused imports and simplified analytics usage throughout the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->