### PR TITLE
fix: sluggied title max length added and placeholder color

### DIFF
--- a/src/components/tiptap/styles/index.module.css
+++ b/src/components/tiptap/styles/index.module.css
@@ -167,12 +167,12 @@
 }
 
 /* Placeholder */
-.editor .ProseMirror > p.is-editor-empty::before {
+.editor .ProseMirror > p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   pointer-events: none;
   float: left;
   height: 0;
-  color: var(--content-placeholder-color);
+  color: var(--content-placeholder-color) !important;
 }
 
 /* HLJS Syntax Highlighting for Code Blocks */

--- a/src/features/listing-builder/components/Form/TitleAndType.tsx
+++ b/src/features/listing-builder/components/Form/TitleAndType.tsx
@@ -66,10 +66,18 @@ export function TitleAndType() {
 
   const debouncedTitle = useDebounce(title);
   const slugifiedTitle = useMemo(() => {
-    return slugify(debouncedTitle, {
+    let slug = slugify(debouncedTitle, {
       lower: true,
       strict: true,
     });
+
+    if (slug.length > 120) {
+      slug = slug.substring(0, 120);
+    }
+
+    slug = slug.replace(/[^a-z0-9]+$/, '');
+
+    return slug;
   }, [debouncedTitle]);
 
   const { dirtyFields } = form.formState;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -463,8 +463,9 @@ h3.tiptap-heading + h2.tiptap-heading {
 }
 
 .tiptap p.is-editor-empty:first-child::before {
-  @apply text-accent-foreground pointer-events-none float-left h-0;
+  @apply pointer-events-none float-left h-0;
   content: attr(data-placeholder);
+  color: var(--content-placeholder-color, #94a3b8) !important;
 }
 
 .tiptap ul,

--- a/src/styles/listing-description.module.css
+++ b/src/styles/listing-description.module.css
@@ -62,7 +62,7 @@
   --content-code-color: #616161;
   --content-pre-bg: #0d0d0d;
   --content-pre-color: #fff;
-  --content-placeholder-color: #9d9d9f;
+  --content-placeholder-color: #94a3b8;
   --content-hr-color: #dcdcdc;
   --content-selection-bg: rgba(99, 102, 241, 0.25);
   --content-blockquote-bg: rgba(0, 0, 0, 0.05);
@@ -280,3 +280,12 @@
   height: auto;
   margin: 0 auto;
 } 
+
+
+.content p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  pointer-events: none;
+  float: left;
+  height: 0;
+  color: var(--content-placeholder-color) !important;
+}


### PR DESCRIPTION
## What does this PR do?

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Listing title slugs are now normalized: auto-trimmed to 120 characters and cleaned of trailing non-alphanumeric characters for cleaner URLs and more reliable availability checks.

* **Style**
  * Improved editor placeholder appearance: consistent color via a CSS variable, applied only to the first paragraph, and non-interactive.
  * Updated placeholder color to enhance readability across listing descriptions and rich-text editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->