### PR TITLE
log in modal otp state behaviour, extra space in otp modal, etc.

### DIFF
--- a/src/features/auth/components/Login.tsx
+++ b/src/features/auth/components/Login.tsx
@@ -104,6 +104,7 @@ export const Login = ({
           redirectTo={redirectTo}
           loginStep={loginStep}
           setLoginStep={setLoginStep}
+          onAuthSuccess={onClose}
         />
       </DialogContent>
     </Dialog>

--- a/src/features/auth/components/SignIn.tsx
+++ b/src/features/auth/components/SignIn.tsx
@@ -20,12 +20,14 @@ interface SigninProps {
   loginStep: number;
   setLoginStep: Dispatch<SetStateAction<number>>;
   redirectTo?: string;
+  onAuthSuccess?: () => void;
 }
 
 export const SignIn = ({
   loginStep,
   setLoginStep,
   redirectTo,
+  onAuthSuccess,
 }: SigninProps) => {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
@@ -116,7 +118,13 @@ export const SignIn = ({
                 : 'translate-y-5 opacity-0'
             }`}
           >
-            {loginStep === 1 && <EmailSignIn redirectTo={redirectTo} />}
+            {loginStep === 1 && (
+              <EmailSignIn
+                key={loginStep}
+                redirectTo={redirectTo}
+                onAuthSuccess={onAuthSuccess}
+              />
+            )}
           </div>
         </div>
 

--- a/src/features/listing-builder/components/ListingBuilder.tsx
+++ b/src/features/listing-builder/components/ListingBuilder.tsx
@@ -69,7 +69,11 @@ export function ListingBuilder({ route, slug }: ListingBuilderLayout) {
   }, []);
 
   if (ready && !authenticated) {
-    return <Login isOpen={true} onClose={() => {}} />;
+    const handleAuthSuccess = () => {
+      // Redirect to dashboard after successful authentication
+      router.push('/dashboard/listings');
+    };
+    return <Login isOpen={true} onClose={handleAuthSuccess} />;
   }
 
   if (!ready) {

--- a/src/layouts/Sponsor.tsx
+++ b/src/layouts/Sponsor.tsx
@@ -138,7 +138,11 @@ export function SponsorLayout({
   }
 
   if (ready && !authenticated) {
-    return <Login isOpen={true} onClose={() => {}} />;
+    const handleAuthSuccess = () => {
+      // Redirect to dashboard after successful authentication
+      router.push('/dashboard/listings');
+    };
+    return <Login isOpen={true} onClose={handleAuthSuccess} />;
   }
 
   const isHackathonRoute = router.asPath.startsWith('/dashboard/hackathon');

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -7,6 +8,7 @@ export default function SigninPage() {
   const [redirectPath, setRedirectPath] = useState<string | undefined>(
     undefined,
   );
+  const router = useRouter();
 
   useEffect(() => {
     const savedPath = window.localStorage.getItem('loginRedirectPath');
@@ -18,5 +20,16 @@ export default function SigninPage() {
     toast.error('There was an error. You need to sign in again.');
   }, []);
 
-  return <Login isOpen={true} onClose={() => {}} redirectTo={redirectPath} />;
+  const handleAuthSuccess = () => {
+    // Redirect to home page after successful authentication
+    router.push('/');
+  };
+
+  return (
+    <Login
+      isOpen={true}
+      onClose={handleAuthSuccess}
+      redirectTo={redirectPath}
+    />
+  );
 }


### PR DESCRIPTION
## What does this PR do?

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic redirect after successful sign-in: navigates to dashboard listings from sponsor and listing builder flows, and to home from the sign-in page.
  - Sign-in components now support a success callback, enabling modals to close and flows to continue seamlessly.
  - OTP step is shown only after requesting a code, clarifying the email sign-in flow.

- Bug Fixes
  - Prevents premature display of the OTP UI.
  - Resets loading state reliably after authentication, improving perceived responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->