### PR TITLE
chore: add ratelimit to comment get api

### DIFF
--- a/src/lib/ratelimit.ts
+++ b/src/lib/ratelimit.ts
@@ -2,7 +2,7 @@ import { Ratelimit } from '@upstash/ratelimit';
 
 import { redis } from './redis';
 
-export const commentRateLimiter = new Ratelimit({
+export const commentCreateRateLimiter = new Ratelimit({
   redis: redis,
   limiter: Ratelimit.fixedWindow(10, '1 m'),
   analytics: true,
@@ -28,4 +28,11 @@ export const uploadSignatureRateLimiter = new Ratelimit({
   limiter: Ratelimit.fixedWindow(10, '1 m'),
   analytics: true,
   prefix: 'ratelimit:upload_signature',
+});
+
+export const commentGetRateLimiter = new Ratelimit({
+  redis: redis,
+  limiter: Ratelimit.fixedWindow(10, '1 m'),
+  analytics: true,
+  prefix: 'ratelimit:comment_get',
 });

--- a/src/pages/api/comment/create.ts
+++ b/src/pages/api/comment/create.ts
@@ -1,7 +1,7 @@
 import type { NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
-import { commentRateLimiter } from '@/lib/ratelimit';
+import { commentCreateRateLimiter } from '@/lib/ratelimit';
 import { checkAndApplyRateLimit } from '@/lib/rateLimiterService';
 import { prisma } from '@/prisma';
 import { type CommentRefType } from '@/prisma/enums';
@@ -33,7 +33,7 @@ async function commentHandler(
   }
 
   const canProceed = await checkAndApplyRateLimit(res, {
-    limiter: commentRateLimiter,
+    limiter: commentCreateRateLimiter,
     identifier: userId,
     routeName: 'commentCreate',
   });


### PR DESCRIPTION
## What does this PR do?

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting to comment retrieval: up to 10 requests per minute per client; excess requests are temporarily blocked to improve stability.
  * Ensured consistent rate limiting across comment actions: comment creation remains limited to 10 requests per minute per client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->