### PR TITLE
Improve keyboard accessibility on home and listing pages

### DIFF
--- a/accessibility-demo.html
+++ b/accessibility-demo.html
@@ -36,10 +36,6 @@
         }
 
         /* Focus styles */
-        :focus {
-            outline: none;
-        }
-
         :focus-visible {
             outline: 2px solid #6366f1;
             outline-offset: 2px;
@@ -108,7 +104,7 @@
             color: #1e293b;
         }
 
-        .category-pill[aria-pressed="true"] {
+        .category-pill[aria-selected="true"] {
             background: #e0e7ff;
             border-color: #a5b4fc;
             color: #4f46e5;
@@ -269,19 +265,19 @@
         
         <!-- Category Pills with Tablist Pattern -->
         <div class="category-container" role="tablist" aria-label="Listing categories">
-            <button class="category-pill" role="tab" aria-selected="true" tabindex="0" aria-pressed="true">
+            <button class="category-pill" role="tab" aria-selected="true" tabindex="0">
                 For You
             </button>
-            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1" aria-pressed="false">
+            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1">
                 All
             </button>
-            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1" aria-pressed="false">
+            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1">
                 Content
             </button>
-            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1" aria-pressed="false">
+            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1">
                 Design
             </button>
-            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1" aria-pressed="false">
+            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1">
                 Development
             </button>
         </div>
@@ -347,7 +343,7 @@
                 categoryPills.forEach((p, i) => {
                     p.setAttribute('aria-selected', i === index);
                     p.setAttribute('tabindex', i === index ? '0' : '-1');
-                    p.setAttribute('aria-pressed', i === index);
+                    // Tabs use aria-selected, not aria-pressed
                 });
             });
 

--- a/accessibility-demo.html
+++ b/accessibility-demo.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Keyboard Accessibility Demo - Superteam Earn</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: white;
+            color: #1e293b;
+            line-height: 1.5;
+        }
+
+        /* Skip link */
+        .skip-link {
+            position: absolute;
+            top: -40px;
+            left: 6px;
+            background: #6366f1;
+            color: white;
+            padding: 8px;
+            text-decoration: none;
+            border-radius: 4px;
+            z-index: 1000;
+        }
+
+        .skip-link:focus {
+            top: 6px;
+        }
+
+        /* Focus styles */
+        :focus {
+            outline: none;
+        }
+
+        :focus-visible {
+            outline: 2px solid #6366f1;
+            outline-offset: 2px;
+        }
+
+        /* Header */
+        .header {
+            background: white;
+            border-bottom: 1px solid #e2e8f0;
+            padding: 1rem 0;
+        }
+
+        .header-content {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 1rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .logo {
+            font-size: 1.5rem;
+            font-weight: bold;
+            color: #6366f1;
+        }
+
+        /* Main content */
+        .main {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }
+
+        .section-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+            color: #1e293b;
+        }
+
+        /* Category pills */
+        .category-container {
+            display: flex;
+            gap: 0.5rem;
+            margin-bottom: 2rem;
+            overflow-x: auto;
+            padding: 0.5rem 0;
+        }
+
+        .category-pill {
+            background: white;
+            border: 1px solid #e2e8f0;
+            border-radius: 9999px;
+            padding: 0.5rem 1rem;
+            font-size: 0.875rem;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: all 0.1s;
+            text-decoration: none;
+            color: #64748b;
+        }
+
+        .category-pill:hover {
+            background: #f1f5f9;
+            color: #1e293b;
+        }
+
+        .category-pill[aria-pressed="true"] {
+            background: #e0e7ff;
+            border-color: #a5b4fc;
+            color: #4f46e5;
+        }
+
+        .category-pill:focus-visible {
+            outline: 2px solid #6366f1;
+            outline-offset: 2px;
+        }
+
+        /* Listing cards */
+        .listings {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .listing-card {
+            display: flex;
+            align-items: center;
+            padding: 1rem;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            text-decoration: none;
+            color: inherit;
+            transition: all 0.1s;
+        }
+
+        .listing-card:hover {
+            background: #f8fafc;
+            transform: translateY(-1px);
+            box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+        }
+
+        .listing-card:focus-visible {
+            outline: 2px solid #6366f1;
+            outline-offset: 2px;
+        }
+
+        .listing-logo {
+            width: 4rem;
+            height: 4rem;
+            border-radius: 8px;
+            background: #f1f5f9;
+            margin-right: 1rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.5rem;
+        }
+
+        .listing-content {
+            flex: 1;
+        }
+
+        .listing-title {
+            font-size: 1rem;
+            font-weight: 600;
+            margin-bottom: 0.25rem;
+        }
+
+        .listing-sponsor {
+            font-size: 0.875rem;
+            color: #64748b;
+            margin-bottom: 0.5rem;
+        }
+
+        .listing-meta {
+            display: flex;
+            gap: 1rem;
+            font-size: 0.75rem;
+            color: #64748b;
+        }
+
+        .listing-amount {
+            font-weight: 600;
+            color: #1e293b;
+        }
+
+        /* Tabs */
+        .tabs {
+            display: flex;
+            border-bottom: 1px solid #e2e8f0;
+            margin-bottom: 2rem;
+        }
+
+        .tab {
+            padding: 0.75rem 1rem;
+            text-decoration: none;
+            color: #64748b;
+            border-bottom: 2px solid transparent;
+            transition: all 0.1s;
+        }
+
+        .tab:hover {
+            color: #1e293b;
+        }
+
+        .tab[aria-current="page"] {
+            color: #6366f1;
+            border-bottom-color: #6366f1;
+        }
+
+        .tab:focus-visible {
+            outline: 2px solid #6366f1;
+            outline-offset: 2px;
+        }
+
+        /* Instructions */
+        .instructions {
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+
+        .instructions h3 {
+            margin-bottom: 0.5rem;
+            color: #1e293b;
+        }
+
+        .instructions ul {
+            margin-left: 1rem;
+        }
+
+        .instructions li {
+            margin-bottom: 0.25rem;
+        }
+    </style>
+</head>
+<body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    
+    <header class="header">
+        <div class="header-content">
+            <div class="logo">Superteam Earn</div>
+            <nav>
+                <a href="#" class="tab">Home</a>
+                <a href="#" class="tab">Bounties</a>
+                <a href="#" class="tab">Projects</a>
+            </nav>
+        </div>
+    </header>
+
+    <main id="main-content" class="main">
+        <div class="instructions">
+            <h3>Keyboard Accessibility Demo</h3>
+            <p>Use the following keys to test accessibility:</p>
+            <ul>
+                <li><strong>Tab</strong> - Navigate through interactive elements</li>
+                <li><strong>Enter/Space</strong> - Activate buttons and links</li>
+                <li><strong>Arrow Keys</strong> - Navigate within tab groups (category pills)</li>
+            </ul>
+        </div>
+
+        <h1 class="section-title">Browse Opportunities</h1>
+        
+        <!-- Category Pills with Tablist Pattern -->
+        <div class="category-container" role="tablist" aria-label="Listing categories">
+            <button class="category-pill" role="tab" aria-selected="true" tabindex="0" aria-pressed="true">
+                For You
+            </button>
+            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1" aria-pressed="false">
+                All
+            </button>
+            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1" aria-pressed="false">
+                Content
+            </button>
+            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1" aria-pressed="false">
+                Design
+            </button>
+            <button class="category-pill" role="tab" aria-selected="false" tabindex="-1" aria-pressed="false">
+                Development
+            </button>
+        </div>
+
+        <!-- Listing Cards -->
+        <div class="listings">
+            <a href="#" class="listing-card">
+                <div class="listing-logo">🏢</div>
+                <div class="listing-content">
+                    <div class="listing-title">Build a React Component Library</div>
+                    <div class="listing-sponsor">by Acme Corp</div>
+                    <div class="listing-meta">
+                        <span class="listing-amount">$2,000 USDC</span>
+                        <span>Due in 5 days</span>
+                        <span>Bounty</span>
+                    </div>
+                </div>
+            </a>
+
+            <a href="#" class="listing-card">
+                <div class="listing-logo">🎨</div>
+                <div class="listing-content">
+                    <div class="listing-title">Design a Mobile App Interface</div>
+                    <div class="listing-sponsor">by Design Studio</div>
+                    <div class="listing-meta">
+                        <span class="listing-amount">$1,500 USDC</span>
+                        <span>Due in 3 days</span>
+                        <span>Project</span>
+                    </div>
+                </div>
+            </a>
+
+            <a href="#" class="listing-card">
+                <div class="listing-logo">📝</div>
+                <div class="listing-content">
+                    <div class="listing-title">Write Technical Documentation</div>
+                    <div class="listing-sponsor">by Tech Corp</div>
+                    <div class="listing-meta">
+                        <span class="listing-amount">$800 USDC</span>
+                        <span>Due in 7 days</span>
+                        <span>Content</span>
+                    </div>
+                </div>
+            </a>
+        </div>
+
+        <!-- Listing Page Tabs -->
+        <h2 class="section-title" style="margin-top: 3rem;">Listing Page Tabs</h2>
+        <div class="tabs">
+            <a href="#" class="tab" aria-current="page">Details</a>
+            <a href="#" class="tab">Submissions</a>
+            <a href="#" class="tab">Comments</a>
+        </div>
+    </main>
+
+    <script>
+        // Simple tablist functionality for category pills
+        const categoryPills = document.querySelectorAll('.category-pill[role="tab"]');
+        
+        categoryPills.forEach((pill, index) => {
+            pill.addEventListener('click', () => {
+                // Update aria-selected and tabindex
+                categoryPills.forEach((p, i) => {
+                    p.setAttribute('aria-selected', i === index);
+                    p.setAttribute('tabindex', i === index ? '0' : '-1');
+                    p.setAttribute('aria-pressed', i === index);
+                });
+            });
+
+            // Handle keyboard navigation
+            pill.addEventListener('keydown', (e) => {
+                if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+                    e.preventDefault();
+                    const nextIndex = e.key === 'ArrowRight' 
+                        ? (index + 1) % categoryPills.length
+                        : (index - 1 + categoryPills.length) % categoryPills.length;
+                    
+                    categoryPills[nextIndex].focus();
+                    categoryPills[nextIndex].click();
+                }
+            });
+        });
+    </script>
+</body>
+</html>

--- a/src/features/leaderboard/components/Pagination.tsx
+++ b/src/features/leaderboard/components/Pagination.tsx
@@ -1,8 +1,9 @@
 import debounce from 'lodash.debounce';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { cn } from '@/utils/cn';
 
 interface Props {
@@ -13,10 +14,30 @@ interface Props {
 
 const SIZE = 6;
 export function Pagination({ page, setPage, count }: Props) {
+  const [jumpToPage, setJumpToPage] = useState('');
+  const [isJumping, setIsJumping] = useState(false);
+
   const handleClick = (newPage: number) => {
     setPage(newPage);
   };
   const debouncedHandleClick = useCallback(debounce(handleClick, 500), []);
+
+  const handleJumpToPage = () => {
+    const targetPage = parseInt(jumpToPage, 10);
+    if (targetPage >= 1 && targetPage <= totalPages) {
+      setIsJumping(true);
+      setPage(targetPage);
+      setJumpToPage('');
+      // Reset jumping state after a short delay
+      setTimeout(() => setIsJumping(false), 300);
+    }
+  };
+
+  const handleJumpKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleJumpToPage();
+    }
+  };
 
   if (count === 0) return <></>;
 
@@ -24,10 +45,14 @@ export function Pagination({ page, setPage, count }: Props) {
 
   const renderPageNumbers = () => {
     const pageNumbers = [];
-    for (let i = 1; i <= totalPages; i++) {
-      if (i === 1 || i === totalPages || (i >= page - 1 && i <= page + 1)) {
+    const maxVisiblePages = 7; // Show more pages for better UX
+
+    if (totalPages <= maxVisiblePages) {
+      // Show all pages if total is small
+      for (let i = 1; i <= totalPages; i++) {
         pageNumbers.push(
           <Button
+            key={i}
             className={cn(
               `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md px-4 py-2 text-xs`,
               'border',
@@ -42,19 +67,106 @@ export function Pagination({ page, setPage, count }: Props) {
             <span>{i}</span>
           </Button>,
         );
-      } else if (i === page - 2 || i === page + 2) {
+      }
+    } else {
+      // Show first page
+      pageNumbers.push(
+        <Button
+          key={1}
+          className={cn(
+            `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md px-4 py-2 text-xs`,
+            'border',
+            page === 1
+              ? 'border-brand-purple text-brand-purple'
+              : 'border-slate-200 text-slate-500',
+            page === 1 && 'active',
+          )}
+          onClick={() => debouncedHandleClick(1)}
+          variant="outline"
+        >
+          <span>1</span>
+        </Button>,
+      );
+
+      // Show ellipsis if needed
+      if (page > 4) {
         pageNumbers.push(
           <Button
+            key="ellipsis1"
             className={cn(
               `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md px-1 py-2 text-xs`,
               'border',
               'disabled:border-slate-200 disabled:text-slate-500',
             )}
-            key={i}
             disabled
             variant="outline"
           >
             ...
+          </Button>,
+        );
+      }
+
+      // Show pages around current page
+      const startPage = Math.max(2, page - 1);
+      const endPage = Math.min(totalPages - 1, page + 1);
+
+      for (let i = startPage; i <= endPage; i++) {
+        if (i !== 1 && i !== totalPages) {
+          pageNumbers.push(
+            <Button
+              key={i}
+              className={cn(
+                `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md px-4 py-2 text-xs`,
+                'border',
+                page === i
+                  ? 'border-brand-purple text-brand-purple'
+                  : 'border-slate-200 text-slate-500',
+                i === page && 'active',
+              )}
+              onClick={() => debouncedHandleClick(i)}
+              variant="outline"
+            >
+              <span>{i}</span>
+            </Button>,
+          );
+        }
+      }
+
+      // Show ellipsis if needed
+      if (page < totalPages - 3) {
+        pageNumbers.push(
+          <Button
+            key="ellipsis2"
+            className={cn(
+              `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md px-1 py-2 text-xs`,
+              'border',
+              'disabled:border-slate-200 disabled:text-slate-500',
+            )}
+            disabled
+            variant="outline"
+          >
+            ...
+          </Button>,
+        );
+      }
+
+      // Show last page
+      if (totalPages > 1) {
+        pageNumbers.push(
+          <Button
+            key={totalPages}
+            className={cn(
+              `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md px-4 py-2 text-xs`,
+              'border',
+              page === totalPages
+                ? 'border-brand-purple text-brand-purple'
+                : 'border-slate-200 text-slate-500',
+              page === totalPages && 'active',
+            )}
+            onClick={() => debouncedHandleClick(totalPages)}
+            variant="outline"
+          >
+            <span>{totalPages}</span>
           </Button>,
         );
       }
@@ -63,32 +175,63 @@ export function Pagination({ page, setPage, count }: Props) {
     return pageNumbers;
   };
   return (
-    <div className="my-4 flex flex-wrap gap-2">
-      <Button
-        className={cn(
-          `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md p-1`,
-          'disabled:pointer-events-none disabled:border-slate-300 disabled:bg-slate-300 disabled:text-slate-500 disabled:opacity-50',
-        )}
-        disabled={page === 1}
-        onClick={() => debouncedHandleClick(page - 1)}
-        variant="outline"
-      >
-        <ChevronLeft className="h-5 w-5" />
-      </Button>
+    <div className="my-4 flex flex-col gap-4">
+      {/* Main pagination controls */}
+      <div className="flex flex-wrap gap-2">
+        <Button
+          className={cn(
+            `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md p-1`,
+            'disabled:pointer-events-none disabled:border-slate-300 disabled:bg-slate-300 disabled:text-slate-500 disabled:opacity-50',
+          )}
+          disabled={page === 1}
+          onClick={() => debouncedHandleClick(page - 1)}
+          variant="outline"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Button>
 
-      {renderPageNumbers()}
+        {renderPageNumbers()}
 
-      <Button
-        className={cn(
-          `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md p-1`,
-          'disabled:pointer-events-none disabled:border-slate-300 disabled:bg-slate-300 disabled:text-slate-500 disabled:opacity-50',
-        )}
-        disabled={page === totalPages}
-        onClick={() => debouncedHandleClick(page + 1)}
-        variant="outline"
-      >
-        <ChevronRight className="h-5 w-5" />
-      </Button>
+        <Button
+          className={cn(
+            `w-[${SIZE}] h-[${SIZE}] min-w-0 rounded-md p-1`,
+            'disabled:pointer-events-none disabled:border-slate-300 disabled:bg-slate-300 disabled:text-slate-500 disabled:opacity-50',
+          )}
+          disabled={page === totalPages}
+          onClick={() => debouncedHandleClick(page + 1)}
+          variant="outline"
+        >
+          <ChevronRight className="h-5 w-5" />
+        </Button>
+      </div>
+
+      {/* Jump to page input */}
+      {totalPages > 5 && (
+        <div className="flex items-center gap-2 text-sm text-slate-600">
+          <span>Go to page:</span>
+          <Input
+            type="number"
+            min="1"
+            max={totalPages}
+            value={jumpToPage}
+            onChange={(e) => setJumpToPage(e.target.value)}
+            onKeyPress={handleJumpKeyPress}
+            placeholder="Page"
+            className="h-8 w-20 text-center"
+            disabled={isJumping}
+          />
+          <Button
+            onClick={handleJumpToPage}
+            disabled={!jumpToPage || isJumping}
+            size="sm"
+            variant="outline"
+            className="h-8 px-3"
+          >
+            {isJumping ? 'Jumping...' : 'Go'}
+          </Button>
+          <span className="text-slate-400">of {totalPages}</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/listings/components/CategoryPill.tsx
+++ b/src/features/listings/components/CategoryPill.tsx
@@ -18,10 +18,12 @@ export function CategoryPill({
   disabled = false,
 }: CategoryPillProps) {
   return (
-    <div
+    <button
+      type="button"
       className={cn(
         'ph-no-capture flex items-center gap-2 px-3.5 py-0.5 whitespace-nowrap select-none sm:py-0.5',
         'rounded-full border border-slate-200 text-[0.8rem] transition-colors duration-100 sm:text-sm',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/60 focus-visible:ring-offset-2',
         disabled
           ? 'cursor-not-allowed text-slate-400 opacity-50'
           : 'cursor-pointer',
@@ -31,6 +33,8 @@ export function CategoryPill({
             ? 'text-slate-500 hover:bg-indigo-100 hover:text-slate-700 hover:no-underline'
             : 'text-slate-400',
       )}
+      aria-pressed={isActive}
+      aria-disabled={disabled || undefined}
       onClick={() => {
         if (disabled) return;
 
@@ -41,6 +45,6 @@ export function CategoryPill({
       }}
     >
       {children}
-    </div>
+    </button>
   );
 }

--- a/src/features/listings/components/CategoryPill.tsx
+++ b/src/features/listings/components/CategoryPill.tsx
@@ -8,6 +8,9 @@ interface CategoryPillProps {
   isActive?: boolean;
   onClick?: () => void;
   disabled?: boolean;
+  role?: string;
+  'aria-selected'?: boolean;
+  tabIndex?: number;
 }
 
 export function CategoryPill({
@@ -16,6 +19,9 @@ export function CategoryPill({
   isActive,
   onClick,
   disabled = false,
+  role,
+  'aria-selected': ariaSelected,
+  tabIndex,
 }: CategoryPillProps) {
   return (
     <button
@@ -23,7 +29,7 @@ export function CategoryPill({
       className={cn(
         'ph-no-capture flex items-center gap-2 px-3.5 py-0.5 whitespace-nowrap select-none sm:py-0.5',
         'rounded-full border border-slate-200 text-[0.8rem] transition-colors duration-100 sm:text-sm',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/60 focus-visible:ring-offset-2',
+        'focus-visible:ring-brand-purple/60 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
         disabled
           ? 'cursor-not-allowed text-slate-400 opacity-50'
           : 'cursor-pointer',
@@ -33,8 +39,11 @@ export function CategoryPill({
             ? 'text-slate-500 hover:bg-indigo-100 hover:text-slate-700 hover:no-underline'
             : 'text-slate-400',
       )}
-      aria-pressed={isActive}
+      role={role}
+      aria-selected={role === 'tab' ? ariaSelected : undefined}
+      aria-pressed={role !== 'tab' ? isActive : undefined}
       aria-disabled={disabled || undefined}
+      tabIndex={tabIndex}
       onClick={() => {
         if (disabled) return;
 

--- a/src/features/listings/components/ListingPage/ListingTabLink.tsx
+++ b/src/features/listings/components/ListingPage/ListingTabLink.tsx
@@ -28,6 +28,7 @@ export const ListingTabLink = ({
       )}
       href={href}
       onClick={onClick}
+      aria-current={isActive ? 'page' : undefined}
     >
       {text}
       {subText && (

--- a/src/features/listings/components/ListingsSection.tsx
+++ b/src/features/listings/components/ListingsSection.tsx
@@ -220,12 +220,17 @@ export const ListingsSection = ({
         <div
           ref={scrollContainerRef}
           className="hide-scrollbar flex gap-1.5 overflow-x-auto px-2 py-1"
+          role="tablist"
+          aria-label="Listing categories"
         >
           {shouldShowForYou && (
             <CategoryPill
               key="foryou"
               phEvent="foryou_navpill"
               isActive={activeCategory === 'For You'}
+              // role=tab semantics are conveyed by the button with aria-pressed
+              // We complement with aria-selected for assistive tech expectations
+              // and manage tabIndex for roving focus
               onClick={() =>
                 handleCategoryChange(
                   'For You' as ListingCategory,
@@ -233,7 +238,13 @@ export const ListingsSection = ({
                 )
               }
             >
-              For You
+              <span
+                role="tab"
+                aria-selected={activeCategory === 'For You'}
+                tabIndex={activeCategory === 'For You' ? 0 : -1}
+              >
+                For You
+              </span>
             </CategoryPill>
           )}
           <CategoryPill
@@ -244,7 +255,13 @@ export const ListingsSection = ({
               handleCategoryChange('All' as ListingCategory, 'all_navpill')
             }
           >
-            All
+            <span
+              role="tab"
+              aria-selected={activeCategory === 'All'}
+              tabIndex={activeCategory === 'All' ? 0 : -1}
+            >
+              All
+            </span>
           </CategoryPill>
           {visibleCategoryNavItems?.map((navItem) => (
             <CategoryPill
@@ -258,7 +275,13 @@ export const ListingsSection = ({
                 )
               }
             >
-              {isMd ? navItem.label : navItem.mobileLabel || navItem.label}
+              <span
+                role="tab"
+                aria-selected={activeCategory === navItem.label}
+                tabIndex={activeCategory === navItem.label ? 0 : -1}
+              >
+                {isMd ? navItem.label : navItem.mobileLabel || navItem.label}
+              </span>
             </CategoryPill>
           ))}
         </div>

--- a/src/features/listings/components/ListingsSection.tsx
+++ b/src/features/listings/components/ListingsSection.tsx
@@ -228,9 +228,9 @@ export const ListingsSection = ({
               key="foryou"
               phEvent="foryou_navpill"
               isActive={activeCategory === 'For You'}
-              // role=tab semantics are conveyed by the button with aria-pressed
-              // We complement with aria-selected for assistive tech expectations
-              // and manage tabIndex for roving focus
+              role="tab"
+              aria-selected={activeCategory === 'For You'}
+              tabIndex={activeCategory === 'For You' ? 0 : -1}
               onClick={() =>
                 handleCategoryChange(
                   'For You' as ListingCategory,
@@ -238,36 +238,30 @@ export const ListingsSection = ({
                 )
               }
             >
-              <span
-                role="tab"
-                aria-selected={activeCategory === 'For You'}
-                tabIndex={activeCategory === 'For You' ? 0 : -1}
-              >
-                For You
-              </span>
+              For You
             </CategoryPill>
           )}
           <CategoryPill
             key="all"
             phEvent="all_navpill"
             isActive={activeCategory === 'All'}
+            role="tab"
+            aria-selected={activeCategory === 'All'}
+            tabIndex={activeCategory === 'All' ? 0 : -1}
             onClick={() =>
               handleCategoryChange('All' as ListingCategory, 'all_navpill')
             }
           >
-            <span
-              role="tab"
-              aria-selected={activeCategory === 'All'}
-              tabIndex={activeCategory === 'All' ? 0 : -1}
-            >
-              All
-            </span>
+            All
           </CategoryPill>
           {visibleCategoryNavItems?.map((navItem) => (
             <CategoryPill
               key={navItem.label}
               phEvent={navItem.pillPH}
               isActive={activeCategory === navItem.label}
+              role="tab"
+              aria-selected={activeCategory === navItem.label}
+              tabIndex={activeCategory === navItem.label ? 0 : -1}
               onClick={() =>
                 handleCategoryChange(
                   navItem.label as ListingCategory,
@@ -275,13 +269,7 @@ export const ListingsSection = ({
                 )
               }
             >
-              <span
-                role="tab"
-                aria-selected={activeCategory === navItem.label}
-                tabIndex={activeCategory === navItem.label ? 0 : -1}
-              >
-                {isMd ? navItem.label : navItem.mobileLabel || navItem.label}
-              </span>
+              {isMd ? navItem.label : navItem.mobileLabel || navItem.label}
             </CategoryPill>
           ))}
         </div>

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -37,8 +37,16 @@ export const Default = ({
     >
       {meta}
       <OutdatedBrowserWarning />
+      <a
+        href="#main-content"
+        className="skip-link sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[1000] focus:rounded-md focus:bg-white focus:px-3 focus:py-2 focus:text-slate-900 focus:shadow"
+      >
+        Skip to main content
+      </a>
       <Header />
-      <div className="flex flex-1 flex-col">{children}</div>
+      <main id="main-content" tabIndex={-1} className="flex flex-1 flex-col">
+        {children}
+      </main>
       {!hideFooter && <Footer />}
     </div>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -181,6 +181,29 @@
   }
 }
 
+/* Accessible focus styles */
+:focus {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-brand-purple, #6366f1);
+  outline-offset: 2px;
+}
+
+/* Skip link base utility (paired with focus styles above) */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 :root {
   interpolate-size: allow-keywords;
   --background: hsl(0 0% 100%);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -182,15 +182,9 @@
 }
 
 /* Accessible focus styles */
-:focus {
+:focus-visible {
   outline: 2px solid var(--color-brand-purple, #6366f1);
   outline-offset: 2px;
-}
-
-/* Enhanced focus for keyboard navigation */
-:focus:not(:focus-visible) {
-  outline: 1px solid var(--color-brand-purple, #6366f1);
-  outline-offset: 1px;
 }
 
 /* Skip link base utility (paired with focus styles above) */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -183,12 +183,14 @@
 
 /* Accessible focus styles */
 :focus {
-  outline: none;
-}
-
-:focus-visible {
   outline: 2px solid var(--color-brand-purple, #6366f1);
   outline-offset: 2px;
+}
+
+/* Enhanced focus for keyboard navigation */
+:focus:not(:focus-visible) {
+  outline: 1px solid var(--color-brand-purple, #6366f1);
+  outline-offset: 1px;
 }
 
 /* Skip link base utility (paired with focus styles above) */


### PR DESCRIPTION
Fixes #1243- Convert CategoryPill from div to button with proper ARIA attributes
- Add tablist semantics with aria-selected and tabIndex management
- Set aria-current on active ListingTabLink for screen readers
- Add skip link and main landmark in Default layout
- Implement global focus-visible styles for consistent focus indication
<img width="1624" height="974" alt="Screenshot 2025-09-30 at 10 19 32 PM" src="https://github.com/user-attachments/assets/8bc77341-3bfb-409f-83c9-912e7fe45c42" />
<img width="1624" height="974" alt="Screenshot 2025-09-30 at 10 19 41 PM" src="https://github.com/user-attachments/assets/77d9517c-9278-4efa-8b7b-5f01e4d07414" />
<img width="311" height="100" alt="Screenshot 2025-09-30 at 10 20 13 PM" src="https://github.com/user-attachments/assets/1104eaf0-a8d8-4f60-82e3-e7c8e90a2541" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Leaderboard pagination now supports jump-to-page (input + Go/Enter) and a condensed view with ellipses for large page counts.
* Accessibility
  * Category filters use button/tab semantics with ARIA, improved focus-visible styles, and keyboard-friendly behavior.
  * Listing tabs mark the active tab with aria-current.
  * Category navigation announced as a tablist with correct tab indices.
  * Added a skip-to-content link and a semantic main region.
* Documentation
  * New keyboard accessibility demo page showcasing patterns.
* Style
  * Global focus-visible outline and screen-reader-only utility added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->