### PR TITLE
fix: bonus calculation post boost

### DIFF
--- a/src/features/listing-builder/components/Form/Rewards/Footer.tsx
+++ b/src/features/listing-builder/components/Form/Rewards/Footer.tsx
@@ -202,10 +202,9 @@ function RewardsFooter({
                         const nearestTen = Math.round(numeric / 10) * 10;
                         rounded[key] = nearestTen;
                       }
-                      const roundedSum = Object.values(rounded).reduce(
-                        (sum, n) =>
-                          sum + (Number.isFinite(n) ? (n as number) : 0),
-                        0,
+                      const roundedSum = calculateTotalRewardsForPodium(
+                        rounded,
+                        (maxBonusSpots as number) || 0,
                       );
                       form.setValue('rewards', rounded, {
                         shouldValidate: false,


### PR DESCRIPTION
## What does this PR do?

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected total rewards calculation in the listing builder when rewards are rounded and bonus spots are applied, improving accuracy of the computed reward amount.

* **Refactor**
  * Centralized the rewards total computation to a shared utility for consistent behavior across scenarios involving rounded rewards and bonus spots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->