### PR TITLE
fix: persist subscribe action through login flow (fixes #1251)

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,8 @@
     "unfurl.js": "^6.4.0",
     "unique-names-generator": "^4.7.1",
     "vaul": "^1.1.2",
-    "zod": "^3.25.71"
+    "zod": "^3.25.71",
+    "zustand": "^5.0.8"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
       zod:
         specifier: ^3.25.71
         version: 3.25.71
+      zustand:
+        specifier: ^5.0.8
+        version: 5.0.8(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.11
@@ -2600,7 +2603,7 @@ packages:
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
     peerDependencies:
-      '@types/react': 19.0.8
+      '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':

--- a/src/store/subscribeIntent.ts
+++ b/src/store/subscribeIntent.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface SubscribeIntentStore {
+  pendingListingId: string | null;
+  setIntent: (id: string | null) => void;
+}
+
+export const useSubscribeIntent = create<SubscribeIntentStore>((set) => ({
+  pendingListingId: null,
+  setIntent: (id) => set({ pendingListingId: id }),
+}));


### PR DESCRIPTION
### Description
Fixes issue #1251 — Bounty Notification UX: requiring double click on Subscribe for logged-out users.

### Problem
When a logged-out user clicks the Subscribe (bell) button on a bounty listing, they are prompted to log in. After logging in, they have to click Subscribe again to actually subscribe.

### Solution
This PR persists the user’s intended subscribe action through the login flow. After successful authentication, the system automatically toggles the subscription, removing the need for a second click.

### Changes Made
- Updated `SubscribeListing.tsx` to store the user’s subscribe intent.
- Automatically replay subscription toggle once the user logs in.
- Cleaned up and sorted imports via autofix.

### Testing
- Manually verified the subscribe/unsubscribe flow after login prompt (logged-out users).
- No regressions expected for already logged-in users.

---

✅ **Fixes #1251**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscribing to a listing while signed out is now remembered and automatically completed after you sign in.

* **Bug Fixes**
  * Improved reliability when loading your account-specific listings across sessions.

* **Chores**
  * Added an internal dependency to support lightweight state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->