### PR TITLE
fix: instantly show “submissions closed” when hackathon has ended.

### DIFF
--- a/src/pages/hackathon/cypherpunk.tsx
+++ b/src/pages/hackathon/cypherpunk.tsx
@@ -182,13 +182,14 @@ function HeroMini({
   const [countdownDate, setCountdownDate] = useState<Date>(
     dayjs.utc(START_DATE).toDate(),
   );
-  const [status, setStatus] = useState<'Start In' | 'Close In' | 'Closed'>(() =>
-  dayjs().isAfter(dayjs(CLOSE_DATE))
-    ? 'Closed'
-    : dayjs().isAfter(dayjs(START_DATE))
-    ? 'Close In'
-    : 'Start In'
-);
+  const [status, setStatus] = useState<'Start In' | 'Close In' | 'Closed'>(
+    () =>
+      dayjs().isAfter(dayjs(CLOSE_DATE))
+        ? 'Closed'
+        : dayjs().isAfter(dayjs(START_DATE))
+          ? 'Close In'
+          : 'Start In',
+  );
 
   useEffect(() => {
     console.log('start date', START_DATE);

--- a/src/pages/hackathon/cypherpunk.tsx
+++ b/src/pages/hackathon/cypherpunk.tsx
@@ -182,9 +182,13 @@ function HeroMini({
   const [countdownDate, setCountdownDate] = useState<Date>(
     dayjs.utc(START_DATE).toDate(),
   );
-  const [status, setStatus] = useState<'Start In' | 'Close In' | 'Closed'>(
-    'Start In',
-  );
+  const [status, setStatus] = useState<'Start In' | 'Close In' | 'Closed'>(() =>
+  dayjs().isAfter(dayjs(CLOSE_DATE))
+    ? 'Closed'
+    : dayjs().isAfter(dayjs(START_DATE))
+    ? 'Close In'
+    : 'Start In'
+);
 
   useEffect(() => {
     console.log('start date', START_DATE);


### PR DESCRIPTION
sets initial status using a lazy state check so the correct label shows right away on load. removes the flicker from “open soon” after deadline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hackathon event status so the page shows the correct timeline state (Start In, Close In, or Closed) immediately on load and keeps updating thereafter, preventing display of an outdated initial status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->