### PR TITLE
feat: allow decimal inputs in quotes and compensation fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,8 +54,8 @@ model Bounties {
   isPrivate          Boolean            @default(false)
   hackathonId        String?
   compensationType   CompensationType   @default(fixed)
-  maxRewardAsk       Int?
-  minRewardAsk       Int?
+  maxRewardAsk       Float?
+  minRewardAsk       Float?
   template           BountiesTemplates? @relation(fields: [templateId], references: [id])
   sponsor            Sponsors           @relation(fields: [sponsorId], references: [id])
   poc                User               @relation("poc", fields: [pocId], references: [id])
@@ -134,8 +134,8 @@ model BountiesTemplates {
   referredBy       String?
   publishedAt      DateTime?
   compensationType CompensationType @default(fixed)
-  maxRewardAsk     Int?
-  minRewardAsk     Int?
+  maxRewardAsk     Float?
+  minRewardAsk     Float?
   language         String?
   rewardAmount     Float?
   rewards          Json?
@@ -339,7 +339,7 @@ model Submission {
   isPaid             Boolean          @default(false)
   paymentDetails     Json?
   otherInfo          String?          @db.Text
-  ask                Int?
+  ask                Float?
   label              SubmissionLabels @default(Unreviewed)
   rewardInUSD        Float            @default(0)
   listing            Bounties         @relation(fields: [listingId], references: [id])

--- a/src/components/ui/token-input.tsx
+++ b/src/components/ui/token-input.tsx
@@ -23,8 +23,22 @@ function TokenInput({
       return;
     }
 
-    const numericValue = inputValue.replace(/[^0-9]/g, '');
-    const finalValue = numericValue ? Number(numericValue) : null;
+    // Allow numbers and decimal point, limit to 4 decimal places
+    const numericValue = inputValue.replace(/[^0-9.]/g, '');
+
+    // Ensure only one decimal point
+    const parts = numericValue.split('.');
+    const formattedValue = parts.length > 2
+      ? `${parts[0]}.${parts.slice(1).join('')}`
+      : numericValue;
+
+    // Limit to 4 decimal places
+    const [integerPart, decimalPart] = formattedValue.split('.');
+    const limitedValue = decimalPart
+      ? `${integerPart}.${decimalPart.slice(0, 4)}`
+      : formattedValue;
+
+    const finalValue = limitedValue ? Number(limitedValue) : null;
 
     onChange?.(finalValue);
   };
@@ -56,13 +70,13 @@ function TokenInput({
         className="rounded-l-none"
         onChange={handleInputChange}
         type="number"
-        inputMode="numeric"
-        pattern="[0-9]*"
+        inputMode="decimal"
+        step="0.0001"
         value={value ?? ''}
         min="0"
         onKeyDown={(e) => {
           if (
-            !/[0-9]|\Backspace|\Tab|\Delete|\ArrowLeft|\ArrowRight/.test(e.key)
+            !/[0-9.]|\Backspace|\Tab|\Delete|\ArrowLeft|\ArrowRight/.test(e.key)
           ) {
             e.preventDefault();
           }

--- a/src/features/listing-builder/components/Form/Rewards/Types/Range.tsx
+++ b/src/features/listing-builder/components/Form/Rewards/Types/Range.tsx
@@ -25,6 +25,7 @@ export function Range() {
               <TokenNumberInput
                 {...field}
                 max={MAX_REWARD}
+                maxDecimals={4}
                 placeholder="5,000"
                 className="relative rounded-r-none focus-within:z-10"
                 onChange={(e) => {
@@ -49,6 +50,7 @@ export function Range() {
                 placeholder="10,000"
                 className="relative rounded-l-none pr-6 focus-within:z-10"
                 max={MAX_REWARD}
+                maxDecimals={4}
                 onChange={(e) => {
                   field.onChange(e);
                   form.saveDraft();

--- a/src/features/listing-builder/types/schema.ts
+++ b/src/features/listing-builder/types/schema.ts
@@ -223,8 +223,34 @@ export const createListingFormSchema = ({
         .nullable(),
       rewards: rewardsSchema.optional().nullable(),
       compensationType: z.nativeEnum(CompensationType).default('fixed'),
-      minRewardAsk: z.number().min(0).max(MAX_REWARD).optional().nullable(),
-      maxRewardAsk: z.number().min(0).max(MAX_REWARD).optional().nullable(),
+      minRewardAsk: z
+        .number()
+        .min(0)
+        .max(MAX_REWARD)
+        .refine(
+          (val) => {
+            if (val === null || val === undefined) return true;
+            const decimalPlaces = (val.toString().split('.')[1] || '').length;
+            return decimalPlaces <= 4;
+          },
+          { message: 'Maximum 4 decimal places allowed' },
+        )
+        .optional()
+        .nullable(),
+      maxRewardAsk: z
+        .number()
+        .min(0)
+        .max(MAX_REWARD)
+        .refine(
+          (val) => {
+            if (val === null || val === undefined) return true;
+            const decimalPlaces = (val.toString().split('.')[1] || '').length;
+            return decimalPlaces <= 4;
+          },
+          { message: 'Maximum 4 decimal places allowed' },
+        )
+        .optional()
+        .nullable(),
       maxBonusSpots: z
         .number({
           message: 'Required',

--- a/src/features/listings/utils/submissionFormSchema.ts
+++ b/src/features/listings/utils/submissionFormSchema.ts
@@ -31,7 +31,21 @@ const submissionSchema = (
         ])
         .optional(),
       otherInfo: z.string().optional(),
-      ask: z.union([z.number().int().min(0), z.null()]).optional(),
+      ask: z
+        .union([
+          z
+            .number()
+            .min(0)
+            .refine(
+              (val) => {
+                const decimalPlaces = (val.toString().split('.')[1] || '').length;
+                return decimalPlaces <= 4;
+              },
+              { message: 'Maximum 4 decimal places allowed' },
+            ),
+          z.null(),
+        ])
+        .optional(),
       eligibilityAnswers: z
         .array(
           z.object({


### PR DESCRIPTION
Fixes #1250

- Updated database schema to support decimal values:
  - Changed Submission.ask from Int to Float
  - Changed Bounties.minRewardAsk and maxRewardAsk from Int to Float
  - Changed BountiesTemplates.minRewardAsk and maxRewardAsk from Int to Float

- Updated validation schemas to accept decimals (max 4 decimal places):
  - Updated submissionFormSchema for submission ask field
  - Updated listing builder schema for minRewardAsk and maxRewardAsk

- Enhanced TokenInput component to handle decimal inputs:
  - Updated regex to allow decimal points
  - Added logic to limit to 4 decimal places
  - Changed inputMode from numeric to decimal
  - Updated onKeyDown handler to allow decimal point

- Updated Range component to support 4 decimal places:
  - Added maxDecimals={4} prop to TokenNumberInput components

Benefits:
- Enables users to provide more precise compensation and quotes
- Reduces rounding errors and improves user experience
- Supports payment flows with decimal values

## What does this PR do?

This PR adds support for decimal inputs (up to 4 decimal places) in quotes and compensation fields throughout the application. Users can now enter precise values like `100.25`, `50.1234`, or `0.0001` instead of being limited to whole numbers.

## Where should the reviewer start?

1. Review the database schema changes in `prisma/schema.prisma` - Float types for monetary fields
2. Check the `TokenInput` component (`src/components/ui/token-input.tsx`) for decimal handling logic
3. Review validation schemas in `src/features/listing-builder/types/schema.ts` and `src/features/listings/utils/submissionFormSchema.ts`
4. Test the decimal input functionality in the listing builder (compensation/rewards fields)

## How should this be manually tested?

1. Navigate to the listing builder page (create new bounty/project)
2. In the compensation/reward fields:
   - Enter `100.1234` - should accept exactly 4 decimal places
   - Enter `50.12` - should accept fewer than 4 decimals
   - Enter `75.123456` - should automatically limit to `75.1234`
   - Enter `123` - integers should work
   - Enter `0.0001` - minimum precision should work
3. Try entering letters or special characters - should be blocked
4. Try entering multiple decimal points - only one should be allowed
5. Submit a bounty with decimal values and verify they're saved correctly in the database

## Any background context you want to provide?

This feature was requested in issue #1250 to support more precise pricing and reduce rounding errors in payment calculations. The implementation limits decimal precision to 4 places to maintain consistency with common token decimal standards while preventing excessive precision that could cause UI/UX issues.

## What are the relevant issues?

Fixes #1250

N/A - Functionality can be tested by entering decimal values in compensation fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled decimal-precision rewards (up to 4 decimal places) for bounties, templates, and submissions, providing more granular control over reward amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->