### PR TITLE
fix: allow decimal values in quotes and compensation fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,8 +54,8 @@ model Bounties {
   isPrivate          Boolean            @default(false)
   hackathonId        String?
   compensationType   CompensationType   @default(fixed)
-  maxRewardAsk       Int?
-  minRewardAsk       Int?
+  maxRewardAsk       Float?
+  minRewardAsk       Float?
   template           BountiesTemplates? @relation(fields: [templateId], references: [id])
   sponsor            Sponsors           @relation(fields: [sponsorId], references: [id])
   poc                User               @relation("poc", fields: [pocId], references: [id])
@@ -134,8 +134,8 @@ model BountiesTemplates {
   referredBy       String?
   publishedAt      DateTime?
   compensationType CompensationType @default(fixed)
-  maxRewardAsk     Int?
-  minRewardAsk     Int?
+  maxRewardAsk     Float?
+  minRewardAsk     Float?
   language         String?
   rewardAmount     Float?
   rewards          Json?
@@ -339,7 +339,7 @@ model Submission {
   isPaid             Boolean          @default(false)
   paymentDetails     Json?
   otherInfo          String?          @db.Text
-  ask                Int?
+  ask                Float?
   label              SubmissionLabels @default(Unreviewed)
   rewardInUSD        Float            @default(0)
   listing            Bounties         @relation(fields: [listingId], references: [id])

--- a/src/components/ui/token-input.tsx
+++ b/src/components/ui/token-input.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { tokenList } from '@/constants/tokenList';
 
 import { Input } from './input';
 import { LocalImage } from './local-image';
+
+const MAX_DECIMALS = 4;
 
 function TokenInput({
   token,
@@ -11,23 +13,85 @@ function TokenInput({
   value,
   ...props
 }: React.ComponentProps<typeof Input> & {
-  token: string | undefined;
-  onChange?: (value: number | null) => void;
-  value?: number | null;
+  readonly token: string | undefined;
+  readonly onChange?: (value: number | null) => void;
+  readonly value?: number | null;
 }) {
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const inputValue = e.target.value;
+  const [inputValue, setInputValue] = useState<string>('');
+  const [isFocused, setIsFocused] = useState(false);
 
-    if (inputValue === '') {
-      onChange?.(null);
-      return;
+  const formatNumber = useCallback((num: number | null): string => {
+    if (num === null || num === undefined || isNaN(num)) return '';
+    return num.toLocaleString('en-US', {
+      maximumFractionDigits: MAX_DECIMALS,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isFocused) {
+      setInputValue(formatNumber(value ?? null));
     }
+  }, [value, isFocused, formatNumber]);
 
-    const numericValue = inputValue.replace(/[^0-9]/g, '');
-    const finalValue = numericValue ? Number(numericValue) : null;
+  const limitDecimals = useCallback((val: string): string => {
+    if (!val.includes('.')) return val;
+    if (val.endsWith('.')) return val;
+    const [integer, fraction] = val.split('.');
+    if (fraction && fraction.length > MAX_DECIMALS) {
+      return `${integer}.${fraction.substring(0, MAX_DECIMALS)}`;
+    }
+    return val;
+  }, []);
 
-    onChange?.(finalValue);
-  };
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const rawInput = e.target.value;
+
+      if (/^(\d*\.?\d*)$/.test(rawInput) || rawInput === '') {
+        const limitedInput = limitDecimals(rawInput);
+        setInputValue(limitedInput);
+
+        if (limitedInput === '' || limitedInput === '.') {
+          onChange?.(null);
+          return;
+        }
+
+        const parsed = parseFloat(limitedInput);
+        if (!isNaN(parsed)) {
+          onChange?.(parsed);
+        } else {
+          onChange?.(null);
+        }
+      }
+    },
+    [onChange, limitDecimals],
+  );
+
+  const handleFocus = useCallback(() => {
+    setIsFocused(true);
+    if (value !== null && value !== undefined && !isNaN(value)) {
+      setInputValue(limitDecimals(value.toString()));
+    } else {
+      setInputValue('');
+    }
+  }, [value, limitDecimals]);
+
+  const handleBlur = useCallback(() => {
+    setIsFocused(false);
+    if (value !== null && value !== undefined && !isNaN(value)) {
+      const rounded = Number(value.toFixed(MAX_DECIMALS));
+      setInputValue(formatNumber(rounded));
+      if (value !== rounded) {
+        onChange?.(rounded);
+      }
+    } else {
+      setInputValue('');
+    }
+  }, [value, formatNumber, onChange]);
+
+  const tokenIcon =
+    tokenList.find((e) => e?.tokenSymbol === token)?.icon ??
+    '/assets/dollar.svg';
 
   return (
     <div data-slot="token-input" className="flex">
@@ -39,10 +103,7 @@ function TokenInput({
           data-slot="token-input-icon"
           className="h-4 w-4 rounded-full"
           alt="token"
-          src={
-            tokenList.filter((e) => e?.tokenSymbol === token)[0]?.icon ??
-            '/assets/dollar.svg'
-          }
+          src={tokenIcon}
         />
         <p
           data-slot="token-input-symbol"
@@ -53,20 +114,13 @@ function TokenInput({
       </div>
       <Input
         data-slot="token-input-field"
-        className="rounded-l-none"
+        className="rounded-l-none [-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         onChange={handleInputChange}
-        type="number"
-        inputMode="numeric"
-        pattern="[0-9]*"
-        value={value ?? ''}
-        min="0"
-        onKeyDown={(e) => {
-          if (
-            !/[0-9]|\Backspace|\Tab|\Delete|\ArrowLeft|\ArrowRight/.test(e.key)
-          ) {
-            e.preventDefault();
-          }
-        }}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        type="text"
+        inputMode="decimal"
+        value={inputValue}
         {...props}
       />
     </div>

--- a/src/features/listings/utils/submissionFormSchema.ts
+++ b/src/features/listings/utils/submissionFormSchema.ts
@@ -31,7 +31,7 @@ const submissionSchema = (
         ])
         .optional(),
       otherInfo: z.string().optional(),
-      ask: z.union([z.number().int().min(0), z.null()]).optional(),
+      ask: z.union([z.number().min(0), z.null()]).optional(),
       eligibilityAnswers: z
         .array(
           z.object({


### PR DESCRIPTION
updates the submission drawer and listing builder to accept decimal numbers up to 4 decimal places for quotes and compensation fields. changes the database schema from int to float for ask, minRewardAsk, and maxRewardAsk fields. removes the integer constraint from zod validation and rewrites the token input component to properly handle decimal input with formatting.

closes #1250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added decimal value support for reward amounts and submissions, enabling more granular pricing control
  * Improved input component with automatic decimal formatting, precision control, and enhanced focus/blur handling for intuitive data entry
  * Updated form validation to accept decimal numbers for submission amounts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->