### PR TITLE
feat: allow direct page entry in leaderboard pagination #1242

### DIFF
--- a/src/features/leaderboard/components/Pagination.tsx
+++ b/src/features/leaderboard/components/Pagination.tsx
@@ -2,8 +2,8 @@ import debounce from 'lodash.debounce';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import {
   type KeyboardEvent,
-  useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -22,12 +22,16 @@ export function Pagination({ page, setPage, count }: Props) {
   const [inputValue, setInputValue] = useState(String(page));
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleClick = (newPage: number) => {
-    setPage(newPage);
-  };
-  const debouncedHandleClick = useCallback(debounce(handleClick, 500), [
-    setPage,
-  ]);
+  const debouncedHandleClick = useMemo(
+    () => debounce((newPage: number) => setPage(newPage), 500),
+    [setPage],
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedHandleClick.cancel();
+    };
+  }, [debouncedHandleClick]);
 
   // Sync input value when page prop changes
   useEffect(() => {
@@ -89,6 +93,7 @@ export function Pagination({ page, setPage, count }: Props) {
                 type="text"
                 inputMode="numeric"
                 pattern="[0-9]*"
+                aria-label={`Enter a page number between 1 and ${totalPages}`}
                 className="border-brand-purple text-brand-purple ring-brand-purple/20 h-9 w-12 min-w-0 rounded-md border bg-white px-2 py-2 text-center text-xs ring-2 outline-none"
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
@@ -106,6 +111,7 @@ export function Pagination({ page, setPage, count }: Props) {
                 onClick={() => setIsEditing(true)}
                 variant="outline"
                 title="Click to jump to a specific page"
+                aria-label={`Current page ${i}. Click to enter a specific page number`}
               >
                 <span>{i}</span>
               </Button>


### PR DESCRIPTION
## What does this PR do?
Adds an inline editable page indicator to [Pagination.tsx](src/features/components/Pagination.tsx) letting users click the current page badge, type a page number, and jump directly without stepping through every page; keeps surrounding pagination controls intact and adjusts UX copy/tooltips.

## Where should the reviewer start?
Start with [Pagination.tsx](src/features/components/Pagination.tsx) to review the new editable-state logic.

## How should this be manually tested?
1) Visit /leaderboard; 2) Flip between pages with the arrows to confirm they still update instantly; 3) Click the current page button, type a valid page number, press Enter, and ensure the table navigates there; 4) Repeat with an out-of-range number to verify it clamps to the nearest valid page; 5) Hit Escape during editing to confirm it restores the prior value.

## Any background context you want to provide?
This answers the UX pain point highlighted in issue #1242, where users couldn’t efficiently jump to a specific leaderboard page; the editable chip keeps the control compact while allowing direct navigation.

## What are the relevant issues?
Fixes #1242.

## Screenshots (if appropriate)
![demo](https://github.com/user-attachments/assets/d5077b5a-5d90-4b38-96b1-a6edd19ac970)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Current page in the pagination control is now editable in-place with auto-focus and input selection.
  * Added page status text showing "Page X of Y."

* **Improvements**
  * Input validates and clamps to the valid page range; supports Enter to submit, Escape to cancel, and submits on blur.
  * Navigation to other pages is debounced for smoother interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->