### PR TITLE
fix: render real user/sponsor counts in SSR for homepage banner

### DIFF
--- a/src/features/home/components/Banner/SponsorBanner.tsx
+++ b/src/features/home/components/Banner/SponsorBanner.tsx
@@ -9,9 +9,13 @@ import { sponsorCountQuery } from '../../queries/sponsor-count';
 
 interface HomeSponsorBannerProps {
   readonly totalUsers?: number | null;
+  readonly totalSponsors?: number | null;
 }
 
-export function HomeSponsorBanner({ totalUsers }: HomeSponsorBannerProps) {
+export function HomeSponsorBanner({
+  totalUsers,
+  totalSponsors,
+}: HomeSponsorBannerProps) {
   const { data } = useQuery(sponsorCountQuery);
   return (
     <Link
@@ -111,7 +115,7 @@ export function HomeSponsorBanner({ totalUsers }: HomeSponsorBannerProps) {
         Reach{' '}
         {roundToNearestTenThousand(totalUsers || 0, true)?.toLocaleString(
           'en-us',
-        ) || '0'}
+        )}
         + top-tier talent in under 5 clicks. Get high-quality work done across
         content, development, and design.
       </p>
@@ -125,12 +129,12 @@ export function HomeSponsorBanner({ totalUsers }: HomeSponsorBannerProps) {
           Get Started
         </button>
         <div className="flex w-fit items-center">
-          {data?.totalSponsors !== null && (
+          {(totalSponsors ?? data?.totalSponsors) != null && (
             <p className="relative ml-[0.6875rem] text-[0.8rem] text-black md:text-[0.875rem]">
               Join{' '}
-              {roundToNearestTenth(data?.totalSponsors || 0)?.toLocaleString(
-                'en-us',
-              )}
+              {roundToNearestTenth(
+                totalSponsors ?? data!.totalSponsors!,
+              )?.toLocaleString('en-us')}
               + others
             </p>
           )}

--- a/src/features/home/components/Banner/index.tsx
+++ b/src/features/home/components/Banner/index.tsx
@@ -20,13 +20,17 @@ import { HomeTalentBanner } from './TalentBanner';
 
 interface BannerCarouselProps {
   readonly totalUsers?: number | null;
+  readonly totalSponsors?: number | null;
 }
 
 /**
  * an optimized carousel that renders a static version first for performance,
  * and then progressively enhances to the full interactive version on the client.
  */
-export function BannerCarousel({ totalUsers }: BannerCarouselProps) {
+export function BannerCarousel({
+  totalUsers,
+  totalSponsors,
+}: BannerCarouselProps) {
   const plugin = useRef(
     Autoplay({
       delay: 4000,
@@ -68,7 +72,10 @@ export function BannerCarousel({ totalUsers }: BannerCarouselProps) {
           <HomeTalentBanner totalUsers={totalUsers} />
         </CarouselItem>
         <CarouselItem>
-          <HomeSponsorBanner totalUsers={totalUsers} />
+          <HomeSponsorBanner
+            totalUsers={totalUsers}
+            totalSponsors={totalSponsors}
+          />
         </CarouselItem>
       </CarouselContent>
       <CarouselDots

--- a/src/pages/earn/index.tsx
+++ b/src/pages/earn/index.tsx
@@ -7,6 +7,7 @@ import { JsonLd } from '@/components/shared/JsonLd';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
 import { Default } from '@/layouts/Default';
 import { Meta } from '@/layouts/Meta';
+import { prisma } from '@/prisma';
 import { useUser } from '@/store/user';
 import { cn } from '@/utils/cn';
 import {
@@ -58,11 +59,17 @@ const TalentAnnouncements = dynamic(
 
 interface HomePageProps {
   readonly potentialSession: boolean;
+  readonly totalUsers: number;
+  readonly totalSponsors: number;
 }
 
-export default function HomePage({ potentialSession }: HomePageProps) {
+export default function HomePage({
+  potentialSession,
+  totalUsers,
+  totalSponsors,
+}: HomePageProps) {
   const { authenticated } = usePrivy();
-  const { data: totalUsers } = useQuery(userCountQuery);
+  useQuery({ ...userCountQuery, initialData: { totalUsers } });
   const { user } = useUser();
   const isLg = useBreakpoint('lg');
 
@@ -113,7 +120,10 @@ export default function HomePage({ potentialSession }: HomePageProps) {
                       )}
                     </>
                   ) : (
-                    <BannerCarousel totalUsers={totalUsers?.totalUsers} />
+                    <BannerCarousel
+                      totalUsers={totalUsers}
+                      totalSponsors={totalSponsors}
+                    />
                   )}
                 </div>
                 <div className="w-full">
@@ -150,5 +160,15 @@ export const getServerSideProps: GetServerSideProps<HomePageProps> = async ({
 
   const cookieExists = /(^|;)\s*user-id-hint=/.test(cookies);
 
-  return { props: { potentialSession: cookieExists } };
+  const [userCount, sponsorCount] = await Promise.all([
+    prisma.user.count(),
+    prisma.sponsors.count(),
+  ]);
+
+  const totalUsers = Math.ceil((userCount - 289) / 10) * 10;
+  const totalSponsors = Math.ceil(sponsorCount / 10) * 10;
+
+  return {
+    props: { potentialSession: cookieExists, totalUsers, totalSponsors },
+  };
 };


### PR DESCRIPTION
## Summary
- Homepage banner was rendering `0+` for user count and sponsor count in SSR HTML because `useQuery` doesn't execute server-side
- Googlebot was seeing `Reach 0+ top-tier talent` and `Join 0+ others` instead of real numbers
- Fix: fetch `totalUsers` and `totalSponsors` via Prisma in `getServerSideProps`, pass as props so numbers are baked into the SSR HTML
- Pre-populate React Query cache with `initialData` so the sidebar `SponsorBanner` also avoids a `0+` flash on first client render

## Test plan
- [ ] Run `curl -s https://<deployed-url>/earn | grep -o "Reach.\{0,100\}"` — should show a real number, not `0+`
- [ ] Run `curl -s https://<deployed-url>/earn | grep -o "0+" | wc -l` — should output `0`
- [ ] Open `/earn` in incognito (unauthenticated), throttle to Slow 3G — banner should show real number from first paint with no flash of `0+`

🤖 Generated with [Claude Code](https://claude.com/claude-code)