### PR TITLE
fix: reduce SEO index bloat from zero-content profile pages

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -261,6 +261,13 @@ async function getTalentProfilesCount(): Promise<number> {
       },
       isTalentFilled: true,
       private: false,
+      TalentRankings: {
+        some: {
+          totalEarnedInUSD: {
+            gt: 0,
+          },
+        },
+      },
     },
   });
 }
@@ -605,6 +612,13 @@ export default async function sitemap(props: {
           },
           isTalentFilled: true,
           private: false,
+          TalentRankings: {
+            some: {
+              totalEarnedInUSD: {
+                gt: 0,
+              },
+            },
+          },
         },
         select: {
           username: true,

--- a/src/pages/earn/t/[slug]/index.tsx
+++ b/src/pages/earn/t/[slug]/index.tsx
@@ -72,6 +72,7 @@ interface TalentProps {
     totalWinnings: number;
   };
   bgIndex: number;
+  shouldNoIndex: boolean;
 }
 
 const getWorkPreferenceText = (workPrefernce?: string): string | null => {
@@ -164,7 +165,7 @@ const ProfileActionButton = memo(function ProfileActionButton({
   );
 });
 
-function TalentProfile({ talent, stats, bgIndex }: TalentProps) {
+function TalentProfile({ talent, stats, bgIndex, shouldNoIndex }: TalentProps) {
   const [activeTab, setActiveTab] = useState<'activity' | 'projects'>(
     'activity',
   );
@@ -392,7 +393,7 @@ function TalentProfile({ talent, stats, bgIndex }: TalentProps) {
                 />
               </>
             )}
-            {talent.private && (
+            {(talent.private || shouldNoIndex) && (
               <>
                 <meta name="robots" content="noindex, nofollow" />
                 <meta name="googlebot" content="noindex, nofollow" />
@@ -744,6 +745,9 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
     const username = Array.isArray(slug) ? slug[0] : (slug as string);
 
+    const threeMonthsAgo = new Date();
+    threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3);
+
     const [talent, submissionStats, grantStats] = await Promise.all([
       prisma.user.findUnique({
         where: { username },
@@ -806,6 +810,20 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
     const stats = { participations, wins, totalWinnings };
 
+    const isOnLeaderboard = totalWinnings > 0;
+    const hasRecentSubmission = isOnLeaderboard
+      ? false
+      : await prisma.submission
+          .findFirst({
+            where: {
+              userId: talent.id,
+              createdAt: { gte: threeMonthsAgo },
+            },
+            select: { id: true },
+          })
+          .then((r) => !!r);
+    const shouldNoIndex = !isOnLeaderboard && !hasRecentSubmission;
+
     const bgIndex = talent?.id ? hashStringToInt(talent.id) % 5 : 0;
     const bgNum = bgIndex + 1;
 
@@ -817,7 +835,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     }
 
     return {
-      props: { talent, stats, bgIndex },
+      props: { talent, stats, bgIndex, shouldNoIndex },
     };
   } catch (error) {
     console.error(error);

--- a/src/pages/earn/t/[slug]/index.tsx
+++ b/src/pages/earn/t/[slug]/index.tsx
@@ -811,18 +811,25 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const stats = { participations, wins, totalWinnings };
 
     const isOnLeaderboard = totalWinnings > 0;
-    const hasRecentSubmission = isOnLeaderboard
+    const hasRecentActivity = isOnLeaderboard
       ? false
-      : await prisma.submission
-          .findFirst({
+      : await Promise.all([
+          prisma.submission.findFirst({
             where: {
               userId: talent.id,
               createdAt: { gte: threeMonthsAgo },
             },
             select: { id: true },
-          })
-          .then((r) => !!r);
-    const shouldNoIndex = !isOnLeaderboard && !hasRecentSubmission;
+          }),
+          prisma.grantApplication.findFirst({
+            where: {
+              userId: talent.id,
+              createdAt: { gte: threeMonthsAgo },
+            },
+            select: { id: true },
+          }),
+        ]).then(([submission, grantApp]) => !!submission || !!grantApp);
+    const shouldNoIndex = !isOnLeaderboard && !hasRecentActivity;
 
     const bgIndex = talent?.id ? hashStringToInt(talent.id) % 5 : 0;
     const bgNum = bgIndex + 1;


### PR DESCRIPTION
## Problem
~50k+ `/earn/t/[username]/` profile pages with zero earnings and zero submissions were being indexed by Google and included in the sitemap. This wastes crawl budget and drags down sitewide quality signals, slowing indexing of pages that matter.

## Changes

### Fix 1 — Sitemap (`src/app/sitemap.ts`)
Talent profile sitemap now filters to leaderboard-only profiles (users with `totalEarnedInUSD > 0` in `TalentRankings`).
- Before: ~50k profiles in sitemap
- After: ~5k profiles (~90% reduction)

### Fix 2 — Profile page noindex (`src/pages/earn/t/[slug]/index.tsx`)
Profile pages now serve `noindex, nofollow` for users who are:
- Not on the leaderboard (totalWinnings = $0), **AND**
- Have not submitted anything in the last 3 months

Rule: **index if earned ≥$1 OR submitted at least once in last 3 months.**

#### Performance notes
- Leaderboard users (most-visited profiles) skip the extra DB query entirely
- Zero-activity profiles do one extra `findFirst` (LIMIT 1, hits existing index on `Submission.userId + createdAt`)
- Profile pages are cached at CDN (`s-maxage=60, stale-while-revalidate=600`), so the extra query only runs on cache misses

## Test plan
- [ ] Visit a profile with earnings > $0 — should be indexed normally
- [ ] Visit a profile with $0 earnings but a submission in the last 3 months — should be indexed normally
- [ ] Visit a profile with $0 earnings and no submissions in last 3 months — should have `noindex, nofollow` in `<head>`
- [ ] Verify sitemap only returns profiles with `totalEarnedInUSD > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selective search indexing: talent pages are now marked noindex when profiles have no recent activity and are not on leaderboards.
  * Sitemap refinement: talent sitemap and profile counts now only include profiles with verified earnings, improving relevance and discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->