### PR TITLE
fix: correct region URLs in JSON-LD schema (/earn/regions/ path)

### DIFF
--- a/src/utils/json-ld.ts
+++ b/src/utils/json-ld.ts
@@ -234,7 +234,7 @@ export function generateRegionalOrganizationSchema(region: {
     '@context': 'https://schema.org',
     '@type': 'Organization',
     name: `Superteam Earn ${region.displayValue}`,
-    url: `${baseUrl}regions/${region.slug}/`,
+    url: `${baseUrl}earn/regions/${region.slug}/`,
     description: `Superteam Earn ${region.displayValue} - Discover bounties and grants in the ${region.displayValue} crypto community`,
   };
 }
@@ -543,7 +543,7 @@ export function generateSuperteamChaptersSchema(
         '@context': 'https://schema.org',
         '@type': 'Organization' as const,
         name: st.name,
-        url: `${baseUrl}regions/${st.slug}/`,
+        url: `${baseUrl}earn/regions/${st.slug}/`,
         logo: st.icons || undefined,
         description: `${st.name} - Solana and Web3 talent community in ${areaServed}. Find crypto bounties, blockchain jobs, and grants.`,
         sameAs: sameAs.length > 0 ? sameAs : undefined,


### PR DESCRIPTION
## Summary
- Both `generateSuperteamChaptersSchema` and `generateRegionalOrganizationSchema` in `src/utils/json-ld.ts` were generating region URLs without the `/earn/` path segment (e.g. `/regions/india/` instead of `/earn/regions/india/`)
- This caused all 21 regional chapter Organization entities in the homepage `@graph` JSON-LD to point to 404 URLs, invalidating the schema in Google's eyes
- The regional pages' own Organization schema had the same bug

## Test plan
- [x] Started dev server and curled homepage — all 21 chapter `url` fields now correctly include `earn/regions/`
- [x] Curled a region page (`/earn/regions/india/`) — Organization schema `url` is correct
- [ ] Optionally verify with Google Rich Results Test by pasting homepage source

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated organization and regional chapter metadata URL paths to align with the platform's new routing structure. Schema URLs for organizations and superteam chapters now use standardized path prefixes for consistency. This improves organization across regional pages and ensures proper metadata indexing and discoverability throughout the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->