### PR TITLE
fix: show hackathon bounty bookmarks on bookmarks page

### DIFF
--- a/src/features/listings/utils/query-builder.ts
+++ b/src/features/listings/utils/query-builder.ts
@@ -179,7 +179,7 @@ export async function buildListingQuery(
     isArchived: false,
     isPrivate: false,
     agentAccess: agentAccessFilter,
-    hackathonprize: false,
+    ...(context !== 'bookmarks' && { hackathonprize: false }),
   };
 
   const andConditions: BountiesWhereInput[] = [];
@@ -493,10 +493,14 @@ export async function buildListingQuery(
         where.type = 'project';
         break;
       case 'all':
-        where.OR = [
-          { type: { not: 'hackathon' } },
-          { type: 'hackathon', isFeatured: true },
-        ];
+        if (context === 'bookmarks') {
+          where.type = { in: ['bounty', 'project', 'hackathon'] };
+        } else {
+          where.OR = [
+            { type: { not: 'hackathon' } },
+            { type: 'hackathon', isFeatured: true },
+          ];
+        }
         break;
     }
   } else if (HACKATHONS.some((hackathon) => hackathon.slug === tab)) {


### PR DESCRIPTION
## Summary

Hackathon bounty bookmarks (e.g. Frontier tracks) weren't appearing on `/earn/bookmarks` despite being saved successfully. Two filters in `buildListingQuery()` were excluding them:

- `hackathonprize: false` in the base where clause filtered out all hackathon prize listings universally, including bookmarks
- The `tab: 'all'` filter excluded `type: 'hackathon'` listings unless `isFeatured: true`

Both filters make sense for discovery pages (home, all listings) but not for bookmarks, which is a user-curated list.

## Changes

- Skip the `hackathonprize: false` filter when `context === 'bookmarks'`
- Include `'hackathon'` in allowed types for the bookmarks context when `tab === 'all'`

## Test Plan

- Bookmark a hackathon bounty (e.g. a Frontier track listing)
- Navigate to `/earn/bookmarks` and confirm the hackathon bounty appears
- Confirm non-bookmarks pages (home, all listings) still exclude hackathon listings as before. a.k.a no breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated listing filter behavior to properly handle bookmarks context, now correctly displaying hackathons, bounties, and projects together without restrictions.
  * Applied context-aware filtering rules specifically to the bookmarks view, improving how content is organized and displayed.
  * Enhanced overall filter logic to ensure bookmarks and other listing views display content appropriately based on their respective contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->