### PR TITLE
fix(payments): prevent on-chain txId replay across winner submissions

### DIFF
--- a/src/pages/api/sponsor-dashboard/listings/verify-external-payment.ts
+++ b/src/pages/api/sponsor-dashboard/listings/verify-external-payment.ts
@@ -99,15 +99,37 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       });
     }
 
-    const allExistingTxIds = submissions
-      .flatMap((sub) =>
-        ((sub.paymentDetails as any[]) || []).map((payment) => payment.txId),
-      )
-      .filter(Boolean);
+    // Check globally across ALL submissions (paid and unpaid) to prevent
+    // transaction replay attacks where a txId from a paid submission is reused
+    // for a different winner.
+    if (txIds.length === 0) {
+      return res.status(400).json({ error: 'No valid transaction IDs provided' });
+    }
 
-    const alreadyUsedTxIds = txIds.filter((txId) =>
-      allExistingTxIds.includes(txId),
-    );
+    const submissionsUsingTxIds: Array<{
+      id: string;
+      paymentDetails: unknown;
+    }> = await prisma.submission.findMany({
+      where: {
+        OR: txIds.map((txId) => ({
+          paymentDetails: { string_contains: txId },
+        })),
+      },
+      select: { id: true, paymentDetails: true },
+    });
+
+    const alreadyUsedTxIds = [
+      ...new Set(
+        submissionsUsingTxIds
+          .flatMap((sub): (string | undefined)[] =>
+            (
+              (sub.paymentDetails as Array<{ txId?: string }> | null) ?? []
+            ).map((p) => p.txId),
+          )
+          .filter((txId): txId is string => !!txId && txIds.includes(txId)),
+      ),
+    ];
+
     if (alreadyUsedTxIds.length > 0) {
       return res.status(400).json({
         error: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,


### PR DESCRIPTION
 ## What does this PR do?

  Fixes a vulnerability in the `verify-external-payment` endpoint where the same on-chain transaction ID could be used to mark multiple winners as paid.

  The duplicate txId check was only scanning submissions fetched with `isPaid: false` in the current request. A txId from an **already-paid submission** was
  invisible to this check, so a sponsor could reuse the same real on-chain transaction to "verify" payment for additional winners.

  **Fix:** replaced the local check with a global `prisma.submission.findMany` query that scans **all submissions** (paid and unpaid) for any matching txId
  before processing the payment loop.

  ## Where should the reviewer start?

  `src/pages/api/sponsor-dashboard/listings/verify-external-payment.ts` — lines 102–131.

  The old code (removed):
  ```ts
  const allExistingTxIds = submissions   // only unpaid, only in this request
    .flatMap(sub => sub.paymentDetails.map(p => p.txId))
    .filter(Boolean);

  The new code (added):
  const submissionsUsingTxIds = await prisma.submission.findMany({
    where: { OR: txIds.map(txId => ({ paymentDetails: { string_contains: txId } })) },
    select: { id: true, paymentDetails: true },
  });
```
## How should this be manually tested?

  1. Create a bounty with 2 winners (position 1 and position 2).
  2. Pay winner 1 - note the txId used.
  3. In the verify-external-payment flow for winner 2, submit the same txId.
  4. Before fix: the payment would go through.
  5. After fix: you get 400 Transaction IDs already used: <txId>.

## Any background context you want to provide?

  The root cause is that the submissions variable used for the duplicate check is pre-filtered to isPaid: false, which excludes paid submissions from the scope
  of the check. The fix queries globally with no payment-status filter.

## What are the relevant issues?

  N/A (security find, no prior issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced sponsor metrics display on the home banner with improved data accuracy
  * Strengthened payment verification mechanisms to prevent transaction replay attacks
  * Updated SEO structured data schema URLs for regional content pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->