### PR TITLE
fix(grants): block editing grant applications after a decision

### DIFF
--- a/src/app/api/grant-application/update/route.ts
+++ b/src/app/api/grant-application/update/route.ts
@@ -88,10 +88,10 @@ async function updateGrantApplication(
     throw new Error('Application not found');
   }
   if (
-    prevApplication.applicationStatus === 'Rejected' ||
+    prevApplication.applicationStatus !== 'Pending' ||
     prevApplication.label === 'Spam'
   ) {
-    throw new Error('Grant application cannot be edited after rejection');
+    throw new Error('Grant application can only be edited while pending review');
   }
 
   const formattedData = {


### PR DESCRIPTION
  ## What does this PR do?

  Fixes a missing guard in the grant application update endpoint. Only `Rejected` and `Spam` applications were blocked from editing (denylist).
  applications could still be edited, and any future status additions would also slip through.

  Flips the check from a denylist to a whitelist - only `Pending` applications can be edited now.

  ## Where should the reviewer start?

  `src/app/api/grant-application/update/route.ts` - line 90.

  ```diff
  - prevApplication.applicationStatus === 'Rejected' ||
  + prevApplication.applicationStatus !== 'Pending' ||
```
 ## How should this be manually tested?

  1. Create a grant application (status = Pending) → edit should work
  2. Get the application approved → edit should return 403
  3. Get the application to Completed status → edit should return 403 (this was previously allowed)

## Any background context you want to provide?

  There's already an outer guard in the POST handler that blocks Approved applications. This inner guard acts as defense-in- depth and now covers all non-Pending
   statuses including Completed and any future additions to the GrantApplicationStatus enum.

## What are the relevant issues?

  N/A (security find, no prior issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Modified grant application edit restrictions. Applications can now only be edited while in pending review status. Rejected applications are no longer editable. Error messages have been updated to provide clearer feedback about when applications can be modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->