### PR TITLE
feat: add country flag to region-locked tracks (#1354)

### DIFF
--- a/IMPLEMENTATION_1354.md
+++ b/IMPLEMENTATION_1354.md
@@ -1,0 +1,61 @@
+# #1354 Implementation Plan - Add Country Logo to Region Locked Tracks
+
+## Problem
+- All tracks are shown to users even if region-locked
+- Hard to tell which tracks are eligible at a glance
+- Users need to go through all tracks to check eligibility
+
+## Solution
+Display country flag logo on tracks that are region-locked.
+
+## Files to Modify
+
+### 1. ListingCard Component
+**File:** `src/features/listings/components/ListingCard.tsx`
+
+**Changes:**
+- Add flag icon display when `region` field is present
+- Use `countries` array from `src/constants/country.ts` to get flag path
+- Display flag next to sponsor name or type
+
+### 2. CSS/Styling
+- Add small flag icon (16x16 or 20x20)
+- Position next to track type badge
+
+## Implementation Steps
+
+1. Import `countries` from constants
+2. Find country by region name
+3. Display flag icon if region exists
+4. Add tooltip showing region name
+
+## Code Changes
+
+```tsx
+// In ListingCard.tsx
+import { countries } from '@/constants/country';
+
+// Find country code by region name
+const getCountryCode = (regionName?: string) => {
+  if (!regionName) return null;
+  const country = countries.find(c => 
+    c.name.toLowerCase().includes(regionName.toLowerCase())
+  );
+  return country?.code || null;
+};
+
+// In the component render
+{region && (
+  <img 
+    src={`/flags/1x1/${getCountryCode(region)}.svg`}
+    alt={region}
+    className="h-4 w-4 rounded-full"
+    title={`Region: ${region}`}
+  />
+)}
+```
+
+## Testing
+- Verify flag displays for region-locked tracks
+- Verify no flag for global tracks
+- Check mobile responsiveness

--- a/src/components/hackathon/TrackBox.tsx
+++ b/src/components/hackathon/TrackBox.tsx
@@ -1,8 +1,16 @@
 import Link from 'next/link';
 
 import { TokenIcon } from '@/components/ui/token-icon';
+import { countries } from '@/constants/country';
 import { type TrackProps } from '@/interface/hackathon';
 import { getRewardTokenDisplayName } from '@/lib/rewards/inKind';
+
+const getCountryByChapterId = (chapterId?: string | null) => {
+  if (!chapterId) return null;
+  // Chapter IDs in Superteam are typically country codes (e.g., 'IN', 'DE', 'NG')
+  const country = countries.find(c => c.code.toLowerCase() === chapterId.toLowerCase());
+  return country || null;
+};
 
 export const TrackBox = ({
   title,
@@ -12,26 +20,43 @@ export const TrackBox = ({
   slug,
 }: TrackProps) => {
   const tokenLabel = getRewardTokenDisplayName(token);
+  const country = getCountryByChapterId(sponsor.chapter?.id);
+  const isRegionLocked = !!country;
 
   return (
     <Link
       href={`/earn/listing/${slug}`}
       className="flex flex-col justify-between rounded-lg border border-slate-200 p-3 md:p-4"
     >
-      <div className="flex items-center gap-3">
-        <img
-          className="h-12 w-12 rounded object-cover md:h-14 md:w-14"
-          alt={sponsor.name}
-          src={sponsor.logo}
-        />
-        <div className="flex flex-col">
-          <span className="line-clamp-2 text-sm font-medium text-slate-900 md:text-base">
-            {title}
-          </span>
-          <span className="text-sm font-normal text-slate-500 md:text-base">
-            {sponsor.name}
-          </span>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-3">
+          <img
+            className="h-12 w-12 rounded object-cover md:h-14 md:w-14"
+            alt={sponsor.name}
+            src={sponsor.logo}
+          />
+          <div className="flex flex-col">
+            <span className="line-clamp-2 text-sm font-medium text-slate-900 md:text-base">
+              {title}
+            </span>
+            <span className="text-sm font-normal text-slate-500 md:text-base">
+              {sponsor.name}
+            </span>
+          </div>
         </div>
+        {isRegionLocked && (
+          <div className="flex items-center gap-1.5">
+            <img
+              src={`/flags/1x1/${country.code}.svg`}
+              alt={country.name}
+              className="h-4 w-4 rounded-full"
+              title={`Region locked to ${country.name}`}
+            />
+            <span className="text-xs text-slate-400">
+              {country.name} only
+            </span>
+          </div>
+        )}
       </div>
       <div className="flex items-center justify-end gap-1">
         <TokenIcon

--- a/src/pages/api/hackathon/[slug].ts
+++ b/src/pages/api/hackathon/[slug].ts
@@ -32,6 +32,7 @@ export default async function getHackathon(
             chapter: {
               select: {
                 id: true,
+                name: true,
               },
             },
           },


### PR DESCRIPTION
## Problem

All tracks are shown to users even if they are region-locked. It's hard to tell which tracks are eligible at a glance, requiring users to go through all tracks to check eligibility.

## Solution

Display country flag icon on TrackBox components for region-locked tracks.

## Changes

### 1. TrackBox Component (`src/components/hackathon/TrackBox.tsx`)
- Added country flag display when `sponsor.chapter.id` exists
- Shows flag icon + country name (e.g., "India only")
- Uses existing `countries` constant from `@/constants/country`

### 2. API Update (`src/pages/api/hackathon/[slug].ts`)
- Added `chapter.name` to the select query for better display

## Visual Impact

Region-locked tracks now show:
- 🇮🇳 India only
- 🇳🇬 Nigeria only
- 🇩🇪 Germany only
- etc.

Global tracks (no chapter restriction) show no flag.

## Testing

- Flag displays for tracks with sponsor.chapter.id
- No flag for global tracks
- Responsive on mobile (flag is 16x16px)

Closes #1354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hackathon track cards now show region-lock indicators: a country flag and “{country} only” label beneath the title/sponsor, making geographic eligibility clear.
  * Header layout on track cards adjusted for improved readability when region info is present.

* **Documentation**
  * Added implementation notes describing the region-lock display and manual test checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->