### PR TITLE
fix: remove search and feed from sitemap and add noindex (#1348)

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -99,13 +99,11 @@ function getStaticRoutes(now: Date): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/earn/feed/`,
       lastModified: now,
       changeFrequency: 'hourly',
       priority: 0.8,
     },
     {
-      url: `${baseUrl}/earn/search/`,
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.7,


### PR DESCRIPTION
Removed /earn/search/ and /earn/feed/ from sitemap routes.

Fixes #1348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `/earn/feed/` and `/earn/search/` routes from the sitemap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->