### PR TITLE
Revert PR #1367: agentic grant tranche form

### DIFF
--- a/src/features/grants/components/Modals/TrancheFormModal.tsx
+++ b/src/features/grants/components/Modals/TrancheFormModal.tsx
@@ -31,7 +31,11 @@ import { userApplicationQuery } from '../../queries/user-application';
 import { type Grant } from '../../types';
 import {
   AGENTIC_ENGINEERING_GRANT_COPY,
+  COLOSSEUM_ARENA_LABEL,
+  COLOSSEUM_ARENA_PREFIX,
+  extractArenaColosseumPath,
   extractGithubRepoPath,
+  getArenaColosseumDisplayValue,
   getGithubRepoDisplayValue,
   GITHUB_REPO_LABEL,
   GITHUB_REPO_PREFIX,
@@ -42,30 +46,6 @@ import {
   WALLET_ADDRESS_CONFLICT_CODE,
   WALLET_ADDRESS_CONFLICT_MESSAGE,
 } from '../../utils/walletAddressOwnership.constants';
-
-const normalizeProjectUrl = (value: string) => {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-
-  const urlCandidate =
-    trimmed.startsWith('http://') || trimmed.startsWith('https://')
-      ? trimmed
-      : `https://${trimmed}`;
-
-  try {
-    const parsed = new URL(urlCandidate);
-    if (
-      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
-      parsed.hostname.includes('.')
-    ) {
-      return parsed.toString();
-    }
-  } catch {
-    return null;
-  }
-
-  return null;
-};
 
 const createTrancheFormSchema = (
   isST: boolean,
@@ -133,12 +113,12 @@ const createTrancheFormSchema = (
       if (
         isAgenticEngineering &&
         data.colosseumLink &&
-        !normalizeProjectUrl(data.colosseumLink)
+        !extractArenaColosseumPath(data.colosseumLink)
       ) {
         ctx.addIssue({
           code: 'custom',
           path: ['colosseumLink'],
-          message: 'Please enter a valid project URL',
+          message: 'Please enter a valid Colosseum Arena URL',
         });
       }
 
@@ -222,9 +202,9 @@ export const TrancheFormModal = ({ grant, applicationId, onClose }: Props) => {
           socialPost: values.socialPost,
         }),
         ...(isAgenticEngineering && {
-          colosseumLink: normalizeProjectUrl(values.colosseumLink || ''),
+          colosseumLink: values.colosseumLink,
           githubRepo: values.githubRepo,
-          aiReceipts: values.aiReceipt,
+          aiReceipt: values.aiReceipt?.[0],
         }),
       });
       form.reset();
@@ -429,12 +409,31 @@ export const TrancheFormModal = ({ grant, applicationId, onClose }: Props) => {
                       </div>
                       <div>
                         <FormControl>
-                          <Input
-                            placeholder={
-                              trancheCopy?.colosseumLink?.placeholder
-                            }
-                            {...field}
-                          />
+                          <div className="flex h-10 items-center">
+                            <div className="flex h-full items-center justify-center rounded-l-md border border-r-0 border-slate-300 bg-slate-50 px-3 text-xs font-medium text-slate-600 shadow-xs md:text-sm">
+                              {COLOSSEUM_ARENA_LABEL}
+                            </div>
+                            <Input
+                              className="h-full rounded-l-none"
+                              placeholder={
+                                trancheCopy?.colosseumLink?.placeholder
+                              }
+                              value={getArenaColosseumDisplayValue(
+                                field.value || '',
+                              )}
+                              onChange={(e) => {
+                                const value = e.currentTarget.value;
+                                const path = extractArenaColosseumPath(value);
+                                field.onChange(
+                                  path
+                                    ? `${COLOSSEUM_ARENA_PREFIX}${path}`
+                                    : value
+                                      ? `${COLOSSEUM_ARENA_PREFIX}${value.replace(/^\/+/, '')}`
+                                      : '',
+                                );
+                              }}
+                            />
+                          </div>
                         </FormControl>
                         <FormMessage className="pt-1" />
                       </div>
@@ -496,7 +495,7 @@ export const TrancheFormModal = ({ grant, applicationId, onClose }: Props) => {
                         source="grant-agentic-receipts"
                         value={(field.value as string[]) || []}
                         onChange={field.onChange}
-                        maxImages={3}
+                        maxImages={1}
                         minImages={1}
                         label={trancheCopy?.aiReceipt?.label}
                         description={trancheCopy?.aiReceipt?.description}

--- a/src/features/grants/utils/createTranche.ts
+++ b/src/features/grants/utils/createTranche.ts
@@ -169,41 +169,6 @@ const normalizeSpecificHostUrl = (
   ).toString();
 };
 
-const normalizeGenericUrl = (
-  value: unknown,
-  {
-    label,
-    required,
-  }: {
-    label: string;
-    required: boolean;
-  },
-): string | undefined => {
-  if (value === undefined || value === null || value === '') {
-    if (required) {
-      throw new Error(`${label} is required.`);
-    }
-    return undefined;
-  }
-
-  if (typeof value !== 'string') {
-    throw new Error(`${label} must be a valid URL.`);
-  }
-
-  const trimmed = value.trim();
-  const urlCandidate =
-    trimmed.startsWith('http://') || trimmed.startsWith('https://')
-      ? trimmed
-      : `https://${trimmed}`;
-  const parsed = parseHttpUrl(urlCandidate);
-
-  if (!parsed || !parsed.hostname.includes('.')) {
-    throw new Error(`${label} must be a valid URL.`);
-  }
-
-  return parsed.toString();
-};
-
 type CreateTrancheProps = {
   applicationId: string;
   helpWanted?: string;
@@ -325,9 +290,11 @@ export async function createTranche({
     socialPost,
     requiresEventProof,
   );
-  const normalizedColosseumLink = normalizeGenericUrl(colosseumLink, {
-    label: 'Project URL',
+  const normalizedColosseumLink = normalizeSpecificHostUrl(colosseumLink, {
+    label: 'Colosseum link',
     required: requiresAgenticFinalProof,
+    host: 'arena.colosseum.org',
+    minPathSegments: 1,
   });
   const normalizedGithubRepo = normalizeSpecificHostUrl(githubRepo, {
     label: 'GitHub repo',

--- a/src/features/grants/utils/stGrant.ts
+++ b/src/features/grants/utils/stGrant.ts
@@ -473,11 +473,11 @@ export const AGENTIC_ENGINEERING_GRANT_COPY: {
     subtitle:
       'Submit the final proofs for your Agentic Engineering grant to unlock the second tranche.',
     description:
-      'Share your project URL, GitHub repository, AI subscription receipt, payout wallet, and anything else that will help the sponsor review the final tranche.',
+      'Share your Colosseum project link, GitHub repository, AI subscription receipt, payout wallet, and anything else that will help the sponsor review the final tranche.',
     colosseumLink: {
-      label: "Link to your project's URL",
-      description: 'URL that showcases your project',
-      placeholder: 'https://your-project-url.com',
+      label: "Link to your project's Colosseum profile",
+      description: 'Paste the path after the Colosseum Arena host.',
+      placeholder: 'projects/explore/your-project',
     },
     githubRepo: {
       label: 'Link to the Github Repo',
@@ -488,7 +488,7 @@ export const AGENTIC_ENGINEERING_GRANT_COPY: {
     aiReceipt: {
       label: 'Upload your AI Subscription Receipt',
       description:
-        'The receipt should mention your name or entity, and total to at least $200. Upload up to 3 PDFs or PNGs.',
+        'The receipt should mention your name or entity. Upload up to 3 PDFs or PNGs.',
     },
     walletAddress: {
       label: 'Solana Wallet Address',


### PR DESCRIPTION
## Summary
- Reverts the merge commit for PR #1367 (`6b7c2b8521c8ee38eec84d7a1ad21aa4b1b4b0c7`)
- Restores the grant tranche form behavior to the previous `main` state

## Context
PR #1367 was merged earlier than intended. The change is meant to go out on May 18, so this PR backs it out from `main` for now.

## Testing
- Not run; clean git revert only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for Colosseum Arena links in Agentic Engineering grant applications.
  * Reduced AI receipt upload limit from 3 to 1 file per submission.

* **UI Updates**
  * Updated form labels, descriptions, and guidance text to clarify Colosseum Arena path requirements and submission documentation guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->