### PR TITLE
[codex] Round USDG grant application amounts

### DIFF
--- a/src/features/grants/utils/grantApplicationSchema.ts
+++ b/src/features/grants/utils/grantApplicationSchema.ts
@@ -20,6 +20,18 @@ import {
 } from './stGrant';
 
 const X_USERNAME_REGEX = /^[A-Za-z0-9_]{1,15}$/;
+const USDG_TOKEN = 'USDG';
+
+const roundUsdGrantAmount = (value: unknown, token: string) => {
+  if (token !== USDG_TOKEN) return value;
+  if (value === '' || value === null || value === undefined) return value;
+
+  const numericValue = typeof value === 'number' ? value : Number(value);
+
+  if (!Number.isFinite(numericValue)) return value;
+
+  return Math.round(numericValue);
+};
 
 const twitterProfileSchema = z
   .string()
@@ -86,7 +98,7 @@ export const grantApplicationSchema = (
           if (value === '' || value === null || value === undefined) {
             return fixedAsk ?? value;
           }
-          return value;
+          return roundUsdGrantAmount(value, token);
         },
         z
           .number({


### PR DESCRIPTION
## Summary

Rounds grant application ask amounts to the nearest whole number when the grant token is USDG.

## Why

USDG grant applications can be submitted with decimal values like `779.87`, but downstream grant approval expects whole-number amounts. Rounding at application validation time stores `779.87` as `780` for USDG grants while leaving other grant tokens unchanged.

## Validation

- `npm run check-types`
- `npm run lint` (completed with existing warnings, 0 errors)
- Commit hook ran `oxlint --fix --quiet`, `oxfmt --write`, and `pnpm check-types` on the staged file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of grant amount inputs for USDG token to ensure values are properly rounded to the nearest integer, maintaining data integrity when processing submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->