### PR TITLE
Fixed region banners zoomed in issue

### DIFF
--- a/src/features/home/components/RegionBanner.tsx
+++ b/src/features/home/components/RegionBanner.tsx
@@ -40,9 +40,11 @@ export function RegionBanner({ st }: { st: ChapterDisplay }) {
         alt={st.name}
         width={1440}
         height={290}
-        className="h-full w-full object-cover object-center"
+        className="h-full w-full"
         style={{
-          ...customBannerPosition[st.region],
+          objectFit: customBannerPosition[st.region] ? 'cover' : 'fill',
+          objectPosition:
+            customBannerPosition[st.region]?.objectPosition ?? 'center',
         }}
       />
       <div className="absolute inset-0 block h-full w-full bg-[rgba(64,65,108,0.75)]" />

--- a/src/features/home/components/RegionBanner.tsx
+++ b/src/features/home/components/RegionBanner.tsx
@@ -30,6 +30,27 @@ const customBannerPosition: Partial<
   Singapore: {
     objectPosition: '50% 30%',
   },
+  Spain: {
+    objectFit: 'fill',
+  },
+  Poland: {
+    objectFit: 'fill',
+  },
+  Ukraine: {
+    objectFit: 'fill',
+  },
+  Netherlands: {
+    objectFit: 'fill',
+  },
+  Indonesia: {
+    objectFit: 'fill',
+  },
+  India: {
+    objectFit: 'fill',
+  },
+  Australia: {
+    objectFit: 'fill',
+  },
 };
 
 export function RegionBanner({ st }: { st: ChapterDisplay }) {
@@ -40,11 +61,9 @@ export function RegionBanner({ st }: { st: ChapterDisplay }) {
         alt={st.name}
         width={1440}
         height={290}
-        className="h-full w-full"
+        className="h-full w-full object-cover object-center"
         style={{
-          objectFit: customBannerPosition[st.region] ? 'cover' : 'fill',
-          objectPosition:
-            customBannerPosition[st.region]?.objectPosition ?? 'center',
+          ...customBannerPosition[st.region],
         }}
       />
       <div className="absolute inset-0 block h-full w-full bg-[rgba(64,65,108,0.75)]" />


### PR DESCRIPTION
## What does this PR do?
- Adds object-fill to particular superteam banners so they dont feel too zoomed in.
- Changed param from st.name to st.region, since the older code used the wrong reference and the positions were never set on the UI.


## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated banner image styling for Spain, Poland, Ukraine, the Netherlands, Indonesia, India, and Australia to improve regional visual presentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperteamDAO/earn/pull/1375)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->