### PR TITLE
feat: add AI-assisted review transparency to public submissions page

### DIFF
--- a/src/features/listings/components/SubmissionsPage/AiReviewBanner.tsx
+++ b/src/features/listings/components/SubmissionsPage/AiReviewBanner.tsx
@@ -1,0 +1,91 @@
+import { Wand2 } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface Props {
+  show: boolean;
+}
+
+export function AiReviewBanner({ show }: Props) {
+  const [open, setOpen] = useState(false);
+
+  if (!show) return null;
+
+  return (
+    <>
+      <div className="mb-6 flex w-full items-center gap-2 rounded-md border border-indigo-200 bg-indigo-50 px-4 py-2">
+        <Wand2 className="h-3.5 w-3.5 shrink-0 text-indigo-500" />
+        <span className="text-sm font-medium text-indigo-600">
+          AI-Assisted Review
+        </span>
+        <button
+          type="button"
+          className="ml-1 text-xs text-indigo-400 underline underline-offset-2 hover:text-indigo-600 focus:outline-none"
+          onClick={() => setOpen(true)}
+        >
+          What does this mean?
+        </button>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>AI-Assisted Review</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 text-sm text-slate-600">
+            <p>
+              The sponsor used Earn&apos;s AI review tool to pre-sort
+              submissions before selecting winners.
+            </p>
+            <p>
+              The AI scored each submission on criteria match and quality, then
+              grouped them into tiers. The sponsor reviewed from the top tier
+              down.
+            </p>
+            <p>
+              The sponsor still manually selected all winners. AI was a sorting
+              aid, not the decision maker.
+            </p>
+            <div className="space-y-1.5 rounded-md border border-slate-100 bg-slate-50 p-3">
+              <p className="font-medium text-slate-700">What the labels mean</p>
+              <p>
+                <span className="font-medium text-indigo-600">Shortlisted</span>{' '}
+                — AI ranked this in the top ~10%
+              </p>
+              <p>
+                <span className="font-medium text-blue-600">Mid Quality</span> —
+                AI ranked this in the middle tier
+              </p>
+              <p>
+                <span className="font-medium text-orange-600">Low Quality</span>{' '}
+                — AI ranked this in the bottom 25%
+              </p>
+              <p>
+                <span className="font-medium text-yellow-700">
+                  Flagged for Review
+                </span>{' '}
+                — AI was uncertain, flagged for human review
+              </p>
+              <p>
+                <span className="font-medium text-red-500">
+                  Link Inaccessible
+                </span>{' '}
+                — AI could not open the submission link
+              </p>
+            </div>
+            <p className="text-xs text-slate-400">
+              AI can make mistakes. Labels reflect automated assessment at time
+              of review and may not capture the full quality of a submission.
+            </p>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/listings/components/SubmissionsPage/AiScoreTag.tsx
+++ b/src/features/listings/components/SubmissionsPage/AiScoreTag.tsx
@@ -1,0 +1,145 @@
+import { Info } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+export type PublicAiData = {
+  commited: true;
+  evaluation?: {
+    criteriaScore?: number;
+    qualityScore?: number;
+    totalScore?: number;
+    notes?: string;
+  };
+} | null;
+
+type VisibleLabel =
+  | 'Shortlisted'
+  | 'Mid_Quality'
+  | 'Low_Quality'
+  | 'Needs_Review'
+  | 'Inaccessible';
+
+const VISIBLE: VisibleLabel[] = [
+  'Shortlisted',
+  'Mid_Quality',
+  'Low_Quality',
+  'Needs_Review',
+  'Inaccessible',
+];
+
+const STYLES: Record<VisibleLabel, string> = {
+  Shortlisted: 'bg-indigo-50 text-indigo-600',
+  Mid_Quality: 'bg-blue-50 text-blue-600',
+  Low_Quality: 'bg-orange-50 text-orange-600',
+  Needs_Review: 'bg-yellow-50 text-yellow-700',
+  Inaccessible: 'bg-red-50 text-red-500',
+};
+
+const TEXT: Record<VisibleLabel, string> = {
+  Shortlisted: 'Shortlisted',
+  Mid_Quality: 'Mid Quality',
+  Low_Quality: 'Low Quality',
+  Needs_Review: 'Flagged for Review',
+  Inaccessible: 'Link Inaccessible',
+};
+
+interface Props {
+  label: string;
+  aiData: PublicAiData;
+}
+
+export function AiScoreTag({ label, aiData }: Props) {
+  const [open, setOpen] = useState(false);
+
+  if (!aiData?.commited || !VISIBLE.includes(label as VisibleLabel)) return null;
+
+  const typed = label as VisibleLabel;
+  const ev = aiData.evaluation;
+  const hasScores =
+    ev &&
+    (ev.criteriaScore !== undefined ||
+      ev.qualityScore !== undefined ||
+      ev.totalScore !== undefined ||
+      ev.notes);
+
+  return (
+    <>
+      <div
+        className={`inline-flex h-[1.2rem] w-fit items-center gap-1 rounded-full px-2 text-xs ${STYLES[typed]}`}
+      >
+        <span>{TEXT[typed]}</span>
+        {hasScores && (
+          <button
+            type="button"
+            className="flex items-center focus:outline-none"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setOpen(true);
+            }}
+          >
+            <Info className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>AI Review Scores</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-3 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-slate-500">Final Label</span>
+              <span
+                className={`inline-flex h-[1.2rem] items-center rounded-full px-2 text-xs ${STYLES[typed]}`}
+              >
+                {TEXT[typed]}
+              </span>
+            </div>
+            {ev?.criteriaScore !== undefined && (
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500">Criteria Score</span>
+                <span className="font-medium text-slate-800">
+                  {ev.criteriaScore}
+                </span>
+              </div>
+            )}
+            {ev?.qualityScore !== undefined && (
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500">Quality Score</span>
+                <span className="font-medium text-slate-800">
+                  {ev.qualityScore}
+                </span>
+              </div>
+            )}
+            {ev?.totalScore !== undefined && (
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500">Total Score</span>
+                <span className="font-medium text-slate-800">
+                  {ev.totalScore}
+                </span>
+              </div>
+            )}
+            {ev?.notes && (
+              <div className="border-t pt-3">
+                <p className="text-slate-500">AI Note</p>
+                <p className="mt-1 text-slate-700">{ev.notes}</p>
+              </div>
+            )}
+            <p className="pt-1 text-xs text-slate-400">
+              AI can make mistakes. These scores reflect automated assessment
+              only.
+            </p>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/features/listings/components/SubmissionsPage/SubmissionCard.tsx
+++ b/src/features/listings/components/SubmissionsPage/SubmissionCard.tsx
@@ -16,6 +16,7 @@ import { getURLSanitized } from '@/utils/getURLSanitized';
 import { EarnAvatar } from '@/features/talent/components/EarnAvatar';
 
 import { type Rewards } from '../../types';
+import { AiScoreTag, type PublicAiData } from './AiScoreTag';
 import { Badge } from './Badge';
 
 interface Props {
@@ -29,6 +30,8 @@ interface Props {
   id: string;
   onUpdate: () => void;
   link: string;
+  label?: string;
+  aiData?: PublicAiData;
 }
 
 export const SubmissionCard = ({
@@ -39,6 +42,8 @@ export const SubmissionCard = ({
   likes,
   onUpdate,
   link,
+  label,
+  aiData,
 }: Props) => {
   const { user } = useUser();
   const [isLoading, setIsLoading] = useState<boolean>(false);
@@ -91,6 +96,12 @@ export const SubmissionCard = ({
           </div>
         )}
       </div>
+
+      {label && aiData?.commited && (
+        <div className="mb-2">
+          <AiScoreTag label={label} aiData={aiData} />
+        </div>
+      )}
 
       <Link href={`/earn/feed/submission/${id}`} className="block w-full">
         <img

--- a/src/features/listings/components/SubmissionsPage/SubmissionCard.tsx
+++ b/src/features/listings/components/SubmissionsPage/SubmissionCard.tsx
@@ -16,7 +16,8 @@ import { getURLSanitized } from '@/utils/getURLSanitized';
 import { EarnAvatar } from '@/features/talent/components/EarnAvatar';
 
 import { type Rewards } from '../../types';
-import { AiScoreTag, type PublicAiData } from './AiScoreTag';
+import type { PublicAiData } from './AiScoreTag';
+import { AiScoreTag } from './AiScoreTag';
 import { Badge } from './Badge';
 
 interface Props {

--- a/src/features/listings/components/SubmissionsPage/SubmissionList.tsx
+++ b/src/features/listings/components/SubmissionsPage/SubmissionList.tsx
@@ -5,8 +5,8 @@ import type { SubmissionWithUser } from '@/interface/submission';
 import { dayjs } from '@/utils/dayjs';
 
 import { type Listing } from '../../types';
+import type { PublicAiData } from './AiScoreTag';
 import { AiReviewBanner } from './AiReviewBanner';
-import { type PublicAiData } from './AiScoreTag';
 import { SubmissionCard } from './SubmissionCard';
 
 interface Props {
@@ -27,9 +27,7 @@ export const SubmissionList = ({
     setIsEndTimePassed(dayjs(endTime).valueOf() < Date.now());
   }, [endTime]);
 
-  const hasAiReview = submissions.some(
-    (s) => (s.ai as unknown as PublicAiData)?.commited === true,
-  );
+  const hasAiReview = submissions.some((s) => s.ai?.commited === true);
 
   return (
     <div className="mt-4 flex min-h-screen w-full flex-col items-center md:items-start">

--- a/src/features/listings/components/SubmissionsPage/SubmissionList.tsx
+++ b/src/features/listings/components/SubmissionsPage/SubmissionList.tsx
@@ -5,6 +5,8 @@ import type { SubmissionWithUser } from '@/interface/submission';
 import { dayjs } from '@/utils/dayjs';
 
 import { type Listing } from '../../types';
+import { AiReviewBanner } from './AiReviewBanner';
+import { type PublicAiData } from './AiScoreTag';
 import { SubmissionCard } from './SubmissionCard';
 
 interface Props {
@@ -25,10 +27,17 @@ export const SubmissionList = ({
     setIsEndTimePassed(dayjs(endTime).valueOf() < Date.now());
   }, [endTime]);
 
+  const hasAiReview = submissions.some(
+    (s) => (s.ai as unknown as PublicAiData)?.commited === true,
+  );
+
   return (
     <div className="mt-4 flex min-h-screen w-full flex-col items-center md:items-start">
       {isEndTimePassed ? (
         <div className="mx-auto flex w-full max-w-7xl flex-col items-start gap-2">
+          <div className="w-full px-3 md:px-6">
+            <AiReviewBanner show={hasAiReview} />
+          </div>
           <div className="grid w-full grid-cols-1 gap-5 px-3 md:grid-cols-2 md:gap-20 md:px-6 xl:grid-cols-3">
             {submissions?.map((submission) => {
               return (
@@ -46,6 +55,8 @@ export const SubmissionList = ({
                   link={submission.link ?? ''}
                   onUpdate={onUpdate}
                   winnerPosition={submission.winnerPosition}
+                  label={submission.label}
+                  aiData={submission.ai as unknown as PublicAiData}
                 />
               );
             })}

--- a/src/pages/api/listings/submissions/[slug].ts
+++ b/src/pages/api/listings/submissions/[slug].ts
@@ -95,25 +95,43 @@ export async function getSubmissionsData(
 
   submission.sort(sortSubmissions);
 
+  interface RawAiData {
+    commited?: boolean;
+    evaluation?: {
+      criteriaScore?: number;
+      qualityScore?: number;
+      totalScore?: number;
+      notes?: string;
+    };
+    review?: {
+      scores?: {
+        skills?: number;
+        experience?: number;
+        application?: number;
+      };
+      shortNote?: string;
+    };
+  }
+
   const publicSubmissions = submission.map((s) => {
-    const raw = s.ai as any;
+    const raw = s.ai as RawAiData | null;
     const publicAi =
       raw?.commited === true
         ? {
             commited: true as const,
             evaluation: raw.evaluation
               ? {
-                  criteriaScore: raw.evaluation.criteriaScore as number | undefined,
-                  qualityScore: raw.evaluation.qualityScore as number | undefined,
-                  totalScore: raw.evaluation.totalScore as number | undefined,
-                  notes: raw.evaluation.notes as string | undefined,
+                  criteriaScore: raw.evaluation.criteriaScore,
+                  qualityScore: raw.evaluation.qualityScore,
+                  totalScore: raw.evaluation.totalScore,
+                  notes: raw.evaluation.notes,
                 }
               : raw.review?.scores
                 ? {
-                    criteriaScore: raw.review.scores.skills as number | undefined,
-                    qualityScore: raw.review.scores.experience as number | undefined,
-                    totalScore: raw.review.scores.application as number | undefined,
-                    notes: raw.review.shortNote as string | undefined,
+                    criteriaScore: raw.review.scores.skills,
+                    qualityScore: raw.review.scores.experience,
+                    totalScore: raw.review.scores.application,
+                    notes: raw.review.shortNote,
                   }
                 : undefined,
           }

--- a/src/pages/api/listings/submissions/[slug].ts
+++ b/src/pages/api/listings/submissions/[slug].ts
@@ -79,6 +79,8 @@ export async function getSubmissionsData(
       likeCount: true,
       rewardInUSD: true,
       createdAt: true,
+      label: true,
+      ai: true,
       user: {
         select: {
           id: true,
@@ -93,7 +95,34 @@ export async function getSubmissionsData(
 
   submission.sort(sortSubmissions);
 
-  return { bounty, submission };
+  const publicSubmissions = submission.map((s) => {
+    const raw = s.ai as any;
+    const publicAi =
+      raw?.commited === true
+        ? {
+            commited: true as const,
+            evaluation: raw.evaluation
+              ? {
+                  criteriaScore: raw.evaluation.criteriaScore as number | undefined,
+                  qualityScore: raw.evaluation.qualityScore as number | undefined,
+                  totalScore: raw.evaluation.totalScore as number | undefined,
+                  notes: raw.evaluation.notes as string | undefined,
+                }
+              : raw.review?.scores
+                ? {
+                    criteriaScore: raw.review.scores.skills as number | undefined,
+                    qualityScore: raw.review.scores.experience as number | undefined,
+                    totalScore: raw.review.scores.application as number | undefined,
+                    notes: raw.review.shortNote as string | undefined,
+                  }
+                : undefined,
+          }
+        : null;
+
+    return { ...s, ai: publicAi };
+  });
+
+  return { bounty, submission: publicSubmissions };
 }
 
 export default async function user(req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
## What does this PR do?
Adds transparency to the public submissions page for listings where the sponsor used AI-assisted review. Participants can now see that AI was involved in sorting, what label the AI assigned to each submission, and the raw scores behind that label.
Three things are added:
  - An "AI-Assisted Review" banner at the top of the submissions list, shown only when the sponsor committed AI reviews
  - A per-submission AI label pill (Shortlisted / Mid Quality / Low Quality / Flagged for Review / Link Inaccessible) matching the pill shape and color system already used for winner position
  badges
  - A score breakdown modal on each pill (where scores exist) showing Criteria Score, Quality Score, Total Score, and the AI's note

## Where should the reviewer start?
  1. src/pages/api/listings/submissions/[slug].ts: the API change that exposes label and a sanitized ai field (scores + note only, no analytics or private data)
  2. src/features/listings/components/SubmissionsPage/AiScoreTag.tsx: the label pill and score modal
  3. src/features/listings/components/SubmissionsPage/AiReviewBanner.tsx: the top banner and explainer modal
  4. SubmissionCard.tsx and SubmissionList.tsx: wiring

## How should this be manually tested?
  1. Find a listing where the sponsor ran and committed AI reviews (any submission will have ai.commited === true in the DB)
  2. Navigate to that listing's public submissions page after winners are announced
  3. Confirm the "AI-Assisted Review" banner appears at the top,click "What does this mean?" to verify the modal opens and explains all labels correctly
  4. Confirm each submission card shows its AI label pill below the name, styled by label type
  5. Click the ⓘ icon on a pill to verify the score breakdown modal shows the correct values
  6. Find a listing where AI was not used, confirm no banner and no label pills appear
  7. Confirm the winner position badges (1st, 2nd, 3rd) are unaffected

## Any background context you want to provide?
When a sponsor uses the "Review with AI" feature, the AI pre-sorts all submissions into tiers (Shortlisted, Mid Quality, Low Quality, etc.) before the sponsor selects winners. Until now,participants had no visibility into this, they only saw the final result with no explanation of the process.

There are only two reasons a submission gets a Low Quality label: the work was genuinely poor, or the AI assessed it incorrectly. Both cases deserve to be visible. In the first case the,participant gets honest feedback. In the second, the community can identify patterns of bad AI assessment and maintainers have a signal to act on.

The AI field already stores scores and notes per submission. This PR surfaces them selectively, private fields like Twitter analytics are stripped server-side before the public response.

## What are the relevant issues?
Closes #1381 

## Screenshots (if appropriate)
<img width="351" height="105" alt="image" src="https://github.com/user-attachments/assets/b55d63a3-0c07-4443-87f9-fc9fc21b6574" />
<img width="240" height="292" alt="image" src="https://github.com/user-attachments/assets/eb8a88f6-ffb5-4c29-b053-e7e7aca87a92" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-Assisted Review transparency: banner displays when submissions are AI-evaluated, and score tags show quality assessments with tier classifications and detailed scoring information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperteamDAO/earn/pull/1382)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->