### PR TITLE
fix(grants): allow up to 3 AI subscription receipts for agentic grant tranche

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -224,6 +224,7 @@ const nextConfig: NextConfig = {
   },
   skipTrailingSlashRedirect: true,
   logging: {
+    // @ts-ignore — valid option, missing from Next.js type definitions
     browserToTerminal: true,
   },
 };

--- a/src/features/grants/components/Modals/TrancheFormModal.tsx
+++ b/src/features/grants/components/Modals/TrancheFormModal.tsx
@@ -80,7 +80,7 @@ const createTrancheFormSchema = (
         ? z
             .array(z.string())
             .min(1, 'AI subscription receipt is required')
-            .max(1, 'Only one AI subscription receipt can be uploaded')
+            .max(3, 'Up to 3 AI subscription receipts can be uploaded')
         : z.array(z.string()).optional(),
     })
     .superRefine((data, ctx) => {
@@ -204,7 +204,7 @@ export const TrancheFormModal = ({ grant, applicationId, onClose }: Props) => {
         ...(isAgenticEngineering && {
           colosseumLink: values.colosseumLink,
           githubRepo: values.githubRepo,
-          aiReceipt: values.aiReceipt?.[0],
+          aiReceipts: values.aiReceipt,
         }),
       });
       form.reset();
@@ -495,7 +495,7 @@ export const TrancheFormModal = ({ grant, applicationId, onClose }: Props) => {
                         source="grant-agentic-receipts"
                         value={(field.value as string[]) || []}
                         onChange={field.onChange}
-                        maxImages={1}
+                        maxImages={3}
                         minImages={1}
                         label={trancheCopy?.aiReceipt?.label}
                         description={trancheCopy?.aiReceipt?.description}


### PR DESCRIPTION
## Summary
- The UI copy on the agentic engineering grant tranche form said "Upload up to 3 PDFs or PNGs" but the uploader was capped at `maxImages={1}`
- The Zod schema rejected more than 1 file with `.max(1, ...)`
- Only the first file was being sent to the API (`values.aiReceipt?.[0]`)
- The backend already fully supported 3 receipts (`MAX_AGENTIC_RECEIPTS = 3` in `createTranche.ts`)

## Changes
- `maxImages={1}` → `maxImages={3}` in `TrancheFormModal.tsx`
- `.max(1)` → `.max(3)` in Zod schema
- Sends `aiReceipts: values.aiReceipt` (full array) instead of `aiReceipt: values.aiReceipt?.[0]` (single string) — the API already handles this via the `aiReceipts` array path

## Test plan
- [ ] Go to an agentic engineering grant tranche request form
- [ ] Verify you can upload up to 3 PDFs or PNGs (previously blocked at 1)
- [ ] Verify submitting with 1, 2, and 3 files all work
- [ ] Verify submitting with 0 files is still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI subscription receipt uploads for agentic engineering tranches now support up to 3 documents per submission, increased from 1. This allows applicants to attach multiple receipts to their submissions.

* **Chores**
  * Updated internal type-checking configuration for improved framework compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperteamDAO/earn/pull/1383)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->