### PR TITLE
Adds custom email options while approving/rejecting for Superteam grants(tranches)

### DIFF
--- a/src/app/api/sponsor-dashboard/grants/update-tranche-status/route.ts
+++ b/src/app/api/sponsor-dashboard/grants/update-tranche-status/route.ts
@@ -12,12 +12,14 @@ import { checkGrantSponsorAuth } from '@/features/auth/utils/checkGrantSponsorAu
 import { getSponsorSession } from '@/features/auth/utils/getSponsorSession';
 import { queueEmail } from '@/features/emails/utils/queueEmail';
 import { addPaymentInfoToAirtable } from '@/features/grants/utils/addPaymentInfoToAirtable';
+import { validateCustomEmailBody } from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
 
 const UpdateGrantTrancheSchema = z
   .object({
     id: z.string(),
     approvedAmount: z.number().positive().optional(),
     status: z.enum(['Approved', 'Rejected']),
+    emailBody: z.string().trim().min(1).max(5000).optional(),
   })
   .superRefine((value, ctx) => {
     if (value.status !== 'Approved') return;
@@ -57,7 +59,21 @@ export async function POST(request: NextRequest) {
       { status: session.status },
     );
   }
-  const { id, status, approvedAmount } = validationResult.data;
+  const { id, status, approvedAmount, emailBody } = validationResult.data;
+  const emailValidation = emailBody ? validateCustomEmailBody(emailBody) : null;
+
+  if (emailValidation && !emailValidation.isValid) {
+    logger.warn('Invalid custom email body:', emailValidation.error);
+    return NextResponse.json(
+      {
+        error: 'Invalid custom email body',
+        details: emailValidation.error,
+      },
+      { status: 400 },
+    );
+  }
+
+  const sanitizedEmailBody = emailValidation?.sanitized;
   const { userId, userSponsorId } = session.data;
   try {
     return await withRedisLock(
@@ -213,6 +229,11 @@ export async function POST(request: NextRequest) {
                 id: result.id,
                 userId: result.GrantApplication.userId,
                 triggeredBy: userId,
+                otherInfo: sanitizedEmailBody
+                  ? {
+                      customEmailBody: sanitizedEmailBody,
+                    }
+                  : undefined,
               });
             }
 
@@ -222,6 +243,11 @@ export async function POST(request: NextRequest) {
                 id: result.id,
                 userId: result.GrantApplication.userId,
                 triggeredBy: userId,
+                otherInfo: sanitizedEmailBody
+                  ? {
+                      customEmailBody: sanitizedEmailBody,
+                    }
+                  : undefined,
               });
             }
           })(),

--- a/src/app/api/sponsor-dashboard/grants/update-tranche-status/route.ts
+++ b/src/app/api/sponsor-dashboard/grants/update-tranche-status/route.ts
@@ -12,14 +12,18 @@ import { checkGrantSponsorAuth } from '@/features/auth/utils/checkGrantSponsorAu
 import { getSponsorSession } from '@/features/auth/utils/getSponsorSession';
 import { queueEmail } from '@/features/emails/utils/queueEmail';
 import { addPaymentInfoToAirtable } from '@/features/grants/utils/addPaymentInfoToAirtable';
-import { validateCustomEmailBody } from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
+import { validateCustomEmailNote } from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
+import {
+  getTrancheApprovedEmailBody,
+  getTrancheRejectedEmailBody,
+} from '@/features/sponsor-dashboard/utils/grantEmailCopy';
 
 const UpdateGrantTrancheSchema = z
   .object({
     id: z.string(),
     approvedAmount: z.number().finite().positive().optional(),
     status: z.enum(['Approved', 'Rejected']),
-    emailBody: z.string().trim().min(1).max(5000).optional(),
+    customNote: z.string().trim().min(1).max(5000).optional(),
   })
   .superRefine((value, ctx) => {
     if (value.status !== 'Approved') return;
@@ -59,21 +63,7 @@ export async function POST(request: NextRequest) {
       { status: session.status },
     );
   }
-  const { id, status, approvedAmount, emailBody } = validationResult.data;
-  const emailValidation = emailBody ? validateCustomEmailBody(emailBody) : null;
-
-  if (emailValidation && !emailValidation.isValid) {
-    logger.warn('Invalid custom email body:', emailValidation.error);
-    return NextResponse.json(
-      {
-        error: 'Invalid custom email body',
-        details: emailValidation.error,
-      },
-      { status: 400 },
-    );
-  }
-
-  const sanitizedEmailBody = emailValidation?.sanitized;
+  const { id, status, approvedAmount, customNote } = validationResult.data;
   const { userId, userSponsorId } = session.data;
   try {
     return await withRedisLock(
@@ -81,6 +71,22 @@ export async function POST(request: NextRequest) {
       async () => {
         const currentTranche = await prisma.grantTranche.findUniqueOrThrow({
           where: { id },
+          include: {
+            Grant: {
+              include: {
+                sponsor: true,
+              },
+            },
+            GrantApplication: {
+              include: {
+                user: {
+                  select: {
+                    firstName: true,
+                  },
+                },
+              },
+            },
+          },
         });
 
         const { error } = await checkGrantSponsorAuth(
@@ -92,6 +98,43 @@ export async function POST(request: NextRequest) {
             { error: error.message },
             { status: error.status },
           );
+        }
+
+        let sanitizedCustomNote: string | undefined;
+        if (customNote) {
+          const fullEmailHtml =
+            status === 'Approved'
+              ? getTrancheApprovedEmailBody({
+                  granteeName: currentTranche.GrantApplication.user?.firstName,
+                  projectTitle: currentTranche.GrantApplication.projectTitle,
+                  sponsorName: currentTranche.Grant.sponsor.name,
+                  approvedAmount,
+                  token: currentTranche.Grant.token || 'USDC',
+                  salutation: currentTranche.Grant.emailSalutation,
+                  reviewerNote: customNote,
+                })
+              : getTrancheRejectedEmailBody({
+                  granteeName: currentTranche.GrantApplication.user?.firstName,
+                  projectTitle: currentTranche.GrantApplication.projectTitle,
+                  sponsorName: currentTranche.Grant.sponsor.name,
+                  salutation: currentTranche.Grant.emailSalutation,
+                  reviewerNote: customNote,
+                });
+          const noteValidation = validateCustomEmailNote({
+            noteHtml: customNote,
+            fullEmailHtml,
+          });
+          if (!noteValidation.isValid) {
+            logger.warn('Invalid custom note:', noteValidation.error);
+            return NextResponse.json(
+              {
+                error: 'Invalid custom note',
+                details: noteValidation.error,
+              },
+              { status: 400 },
+            );
+          }
+          sanitizedCustomNote = noteValidation.sanitized;
         }
 
         const updateData: any = {
@@ -239,9 +282,9 @@ export async function POST(request: NextRequest) {
                 id: result.id,
                 userId: result.GrantApplication.userId,
                 triggeredBy: userId,
-                otherInfo: sanitizedEmailBody
+                otherInfo: sanitizedCustomNote
                   ? {
-                      customEmailBody: sanitizedEmailBody,
+                      customEmailNote: sanitizedCustomNote,
                     }
                   : undefined,
               });
@@ -253,9 +296,9 @@ export async function POST(request: NextRequest) {
                 id: result.id,
                 userId: result.GrantApplication.userId,
                 triggeredBy: userId,
-                otherInfo: sanitizedEmailBody
+                otherInfo: sanitizedCustomNote
                   ? {
-                      customEmailBody: sanitizedEmailBody,
+                      customEmailNote: sanitizedCustomNote,
                     }
                   : undefined,
               });

--- a/src/features/grants/types/index.ts
+++ b/src/features/grants/types/index.ts
@@ -46,6 +46,7 @@ interface Grant {
   historicalApplications: number;
   avgResponseTime?: string;
   airtableId?: string;
+  emailSalutation?: string | null;
   isNative?: boolean;
   ai?: GrantsAi;
   isPro?: boolean;

--- a/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
+++ b/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
@@ -29,6 +29,14 @@ interface Props {
   slug: string;
 }
 
+const isEditableKeyboardTarget = (target: EventTarget | null) => {
+  if (!(target instanceof Element)) return false;
+
+  return !!target.closest(
+    'input, textarea, select, [contenteditable="true"], [role="textbox"]',
+  );
+};
+
 export const ApplicationsTab = ({ slug }: Props) => {
   const [searchText, setSearchText] = useState('');
   const [selectedFilters, setSelectedFilters] = useState<
@@ -148,6 +156,7 @@ export const ApplicationsTab = ({ slug }: Props) => {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!applications.length) return;
+      if (isEditableKeyboardTarget(e.target)) return;
 
       const currentIndex = applications.findIndex(
         (sub) => sub.id === selectedApplication?.id,
@@ -181,15 +190,19 @@ export const ApplicationsTab = ({ slug }: Props) => {
     mutationFn: async ({
       applicationId,
       approvedAmount,
+      emailBody,
     }: {
       applicationId: string;
       approvedAmount: number;
+      emailBody?: string;
     }) => {
+      const customEmailBody = emailBody?.trim();
       const response = await api.post(
         '/api/sponsor-dashboard/grants/update-application-status',
         {
           data: [{ id: applicationId, approvedAmount }],
           applicationStatus: 'Approved',
+          ...(customEmailBody ? { emailBody: customEmailBody } : {}),
         },
       );
       return response.data;
@@ -344,15 +357,19 @@ export const ApplicationsTab = ({ slug }: Props) => {
     }
   };
 
-  const handleRejectGrant = (applicationId: string) => {
-    rejectGrantApplications.mutate([applicationId]);
+  const handleRejectGrant = (applicationId: string, emailBody?: string) => {
+    rejectGrantApplications.mutate({
+      applicationIds: [applicationId],
+      emailBody,
+    });
   };
 
   const handleApproveGrant = (
     applicationId: string,
     approvedAmount: number,
+    emailBody?: string,
   ) => {
-    approveGrantMutation.mutate({ applicationId, approvedAmount });
+    approveGrantMutation.mutate({ applicationId, approvedAmount, emailBody });
   };
 
   const handleModalAction = (actionType: 'reject' | 'spam') => {
@@ -501,7 +518,11 @@ export const ApplicationsTab = ({ slug }: Props) => {
         rejectOnClose={rejectedOnClose}
         ask={selectedApplication?.ask}
         granteeName={selectedApplication?.user?.firstName}
+        grantTitle={grant?.title}
+        projectTitle={selectedApplication?.projectTitle}
+        salutation={grant?.emailSalutation}
         token={grant?.token || 'USDC'}
+        enableCustomEmail={grant?.isNative === true}
         onRejectGrant={handleRejectGrant}
       />
 
@@ -511,7 +532,11 @@ export const ApplicationsTab = ({ slug }: Props) => {
         approveOnClose={approveOnClose}
         ask={selectedApplication?.ask}
         granteeName={selectedApplication?.user?.firstName}
+        grantTitle={grant?.title}
+        projectTitle={selectedApplication?.projectTitle}
+        salutation={grant?.emailSalutation}
         token={grant?.token || 'USDC'}
+        enableCustomEmail={grant?.isNative === true}
         onApproveGrant={handleApproveGrant}
         max={grant?.maxReward}
       />

--- a/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
+++ b/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
@@ -190,19 +190,19 @@ export const ApplicationsTab = ({ slug }: Props) => {
     mutationFn: async ({
       applicationId,
       approvedAmount,
-      emailBody,
+      customNote,
     }: {
       applicationId: string;
       approvedAmount: number;
-      emailBody?: string;
+      customNote?: string;
     }) => {
-      const customEmailBody = emailBody?.trim();
+      const reviewerNote = customNote?.trim();
       const response = await api.post(
         '/api/sponsor-dashboard/grants/update-application-status',
         {
           data: [{ id: applicationId, approvedAmount }],
           applicationStatus: 'Approved',
-          ...(customEmailBody ? { emailBody: customEmailBody } : {}),
+          ...(reviewerNote ? { customNote: reviewerNote } : {}),
         },
       );
       return response.data;
@@ -357,19 +357,19 @@ export const ApplicationsTab = ({ slug }: Props) => {
     }
   };
 
-  const handleRejectGrant = (applicationId: string, emailBody?: string) => {
+  const handleRejectGrant = (applicationId: string, customNote?: string) => {
     rejectGrantApplications.mutate({
       applicationIds: [applicationId],
-      emailBody,
+      customNote,
     });
   };
 
   const handleApproveGrant = (
     applicationId: string,
     approvedAmount: number,
-    emailBody?: string,
+    customNote?: string,
   ) => {
-    approveGrantMutation.mutate({ applicationId, approvedAmount, emailBody });
+    approveGrantMutation.mutate({ applicationId, approvedAmount, customNote });
   };
 
   const handleModalAction = (actionType: 'reject' | 'spam') => {

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/ApproveModal.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/ApproveModal.tsx
@@ -275,6 +275,7 @@ export const ApproveModal = ({
               id="approve-grant-custom-note"
               value={customNote}
               previewHtml={previewEmailBody}
+              emailType="approval"
               error={emailError}
               onChange={(value) => {
                 const sanitizedNote = sanitizeCustomEmailBody(value);

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/ApproveModal.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/ApproveModal.tsx
@@ -2,11 +2,24 @@ import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 import posthog from 'posthog-js';
 import React, { useEffect, useState } from 'react';
 
+import { RichEditor } from '@/components/shared/RichEditor';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
+
+import {
+  getCustomEmailPlainText,
+  validateCustomEmailBody,
+} from '../../../utils/customEmailSanitizer';
+import { getGrantApprovedEmailBody } from '../../../utils/grantEmailCopy';
 
 const CustomNumberInput = ({
   value,
@@ -97,8 +110,16 @@ interface ApproveModalProps {
   applicationId: string | undefined;
   ask: number | undefined;
   granteeName: string | null | undefined;
+  grantTitle: string | undefined;
+  projectTitle: string | null | undefined;
+  salutation: string | null | undefined;
   token: string;
-  onApproveGrant: (applicationId: string, approvedAmount: number) => void;
+  enableCustomEmail: boolean;
+  onApproveGrant: (
+    applicationId: string,
+    approvedAmount: number,
+    emailBody?: string,
+  ) => void;
   max: number | undefined;
 }
 
@@ -108,13 +129,30 @@ export const ApproveModal = ({
   approveOnClose,
   ask,
   granteeName,
+  grantTitle,
+  projectTitle,
+  salutation,
   token,
+  enableCustomEmail,
   onApproveGrant,
   max,
 }: ApproveModalProps) => {
   const [approvedAmount, setApprovedAmount] = useState<number | undefined>(ask);
+  const [emailBody, setEmailBody] = useState('');
+  const [hasEditedEmail, setHasEditedEmail] = useState(false);
+  const [isCustomEmailOpen, setIsCustomEmailOpen] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
+
+  const defaultEmailBody = getGrantApprovedEmailBody({
+    granteeName,
+    grantTitle,
+    projectTitle,
+    approvedAmount,
+    token,
+    salutation,
+  });
 
   const handleAmountChange = (value: number) => {
     if (value > (ask as number)) {
@@ -125,16 +163,41 @@ export const ApproveModal = ({
       setWarningMessage(null);
     }
     setApprovedAmount(value);
+    if (!hasEditedEmail) {
+      setEmailBody(
+        getGrantApprovedEmailBody({
+          granteeName,
+          grantTitle,
+          projectTitle,
+          approvedAmount: value,
+          token,
+          salutation,
+        }),
+      );
+    }
   };
 
   const approveGrant = async () => {
     if (approvedAmount === undefined || approvedAmount === 0 || !applicationId)
       return;
 
+    const customEmailBody = emailBody.trim();
+    const emailValidation = validateCustomEmailBody(customEmailBody);
+    if (enableCustomEmail && isCustomEmailOpen && !emailValidation.isValid) {
+      setEmailError(emailValidation.error);
+      return;
+    }
+
     setLoading(true);
     try {
       posthog.capture('approve_grant application');
-      await onApproveGrant(applicationId, approvedAmount);
+      await onApproveGrant(
+        applicationId,
+        approvedAmount,
+        enableCustomEmail && isCustomEmailOpen
+          ? emailValidation.sanitized
+          : undefined,
+      );
       approveOnClose();
     } catch (e) {
       console.error(e);
@@ -145,9 +208,30 @@ export const ApproveModal = ({
 
   useEffect(() => {
     setApprovedAmount(ask);
+    setEmailBody(
+      getGrantApprovedEmailBody({
+        granteeName,
+        grantTitle,
+        projectTitle,
+        approvedAmount: ask,
+        token,
+        salutation,
+      }),
+    );
+    setHasEditedEmail(false);
+    setIsCustomEmailOpen(false);
+    setEmailError(null);
     setWarningMessage(null);
     setLoading(false);
-  }, [applicationId, ask]);
+  }, [
+    applicationId,
+    ask,
+    granteeName,
+    grantTitle,
+    projectTitle,
+    salutation,
+    token,
+  ]);
 
   return (
     <Dialog open={approveIsOpen} onOpenChange={approveOnClose}>
@@ -204,30 +288,111 @@ export const ApproveModal = ({
             </p>
           )}
 
+          {enableCustomEmail && isCustomEmailOpen && (
+            <div className="mb-6">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <p className="font-medium text-slate-600">Email Body</p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="h-auto px-2 py-1 text-xs font-semibold text-slate-500"
+                  onClick={() => {
+                    setEmailBody(defaultEmailBody);
+                    setHasEditedEmail(false);
+                    setEmailError(null);
+                  }}
+                  disabled={loading || emailBody === defaultEmailBody}
+                >
+                  Reset
+                </Button>
+              </div>
+              <RichEditor
+                id="approve-grant-email-body"
+                height="h-[190px]"
+                value={emailBody}
+                onChange={(value) => {
+                  setEmailBody(value);
+                  setHasEditedEmail(true);
+                  setEmailError(validateCustomEmailBody(value).error);
+                }}
+                error={!!emailError}
+                placeholder="Write the email body"
+              />
+              {emailError && (
+                <p className="mt-2 text-sm text-red-500">{emailError}</p>
+              )}
+            </div>
+          )}
+
           <div className="flex gap-3">
             <div className="w-1/2" />
             <Button variant="ghost" onClick={approveOnClose} disabled={loading}>
               Close
             </Button>
-            <Button
-              className="flex-1 rounded-lg border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
-              disabled={loading || approvedAmount === 0}
-              onClick={approveGrant}
-            >
-              {loading ? (
-                <>
-                  <span className="loading loading-spinner mr-2" />
-                  <span>Approving</span>
-                </>
-              ) : (
-                <>
-                  <div className="mr-2 rounded-full bg-emerald-600 p-0.5">
-                    <Check className="size-2.5 text-white" />
-                  </div>
-                  <span>Approve Grant</span>
-                </>
+            <div className="flex flex-1">
+              <Button
+                className="flex-1 rounded-l-lg rounded-r-none border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
+                disabled={
+                  loading ||
+                  approvedAmount === 0 ||
+                  (enableCustomEmail &&
+                    isCustomEmailOpen &&
+                    (!getCustomEmailPlainText(emailBody) || !!emailError))
+                }
+                onClick={approveGrant}
+              >
+                {loading ? (
+                  <>
+                    <span className="loading loading-spinner mr-2" />
+                    <span>
+                      {isCustomEmailOpen
+                        ? 'Approving with Custom Email'
+                        : 'Approving'}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <div className="mr-2 rounded-full bg-emerald-600 p-0.5">
+                      <Check className="size-2.5 text-white" />
+                    </div>
+                    <span>
+                      {isCustomEmailOpen
+                        ? 'Approve with Custom Email'
+                        : 'Approve Grant'}
+                    </span>
+                  </>
+                )}
+              </Button>
+              {enableCustomEmail && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      className="rounded-l-none rounded-r-lg border border-l-0 border-emerald-500 bg-emerald-50 px-2 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
+                      disabled={loading}
+                      aria-label="Approve options"
+                    >
+                      <ChevronDown className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="z-70 w-56">
+                    {isCustomEmailOpen ? (
+                      <DropdownMenuItem
+                        onClick={() => setIsCustomEmailOpen(false)}
+                      >
+                        Approve
+                      </DropdownMenuItem>
+                    ) : (
+                      <DropdownMenuItem
+                        onClick={() => setIsCustomEmailOpen(true)}
+                      >
+                        Approve with custom email
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
               )}
-            </Button>
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/ApproveModal.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/ApproveModal.tsx
@@ -15,13 +15,14 @@ import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
 import { cn } from '@/utils/cn';
 
+import { useCustomNoteCloseGuard } from '@/features/sponsor-dashboard/components/GrantApplications/hooks/useCustomNoteCloseGuard';
+import { CustomNoteEditor } from '@/features/sponsor-dashboard/components/GrantApplications/Modals/CustomNoteEditor';
 import {
   getCustomEmailPlainText,
   sanitizeCustomEmailBody,
   validateCustomEmailNote,
-} from '../../../utils/customEmailSanitizer';
-import { getGrantApprovedEmailBody } from '../../../utils/grantEmailCopy';
-import { CustomNoteEditor } from './CustomNoteEditor';
+} from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
+import { getGrantApprovedEmailBody } from '@/features/sponsor-dashboard/utils/grantEmailCopy';
 
 const CustomNumberInput = ({
   value,
@@ -156,6 +157,20 @@ export const ApproveModal = ({
     reviewerNote: sanitizeCustomEmailBody(customNote),
   });
 
+  const closeAndDiscardCustomNote = () => {
+    setCustomNote('');
+    setIsCustomEmailOpen(false);
+    setEmailError(null);
+    approveOnClose();
+  };
+
+  const { closeWithoutGuard, discardChangesDialog, requestClose } =
+    useCustomNoteCloseGuard({
+      customNote,
+      isEnabled: enableCustomEmail && isCustomEmailOpen,
+      onDiscard: closeAndDiscardCustomNote,
+    });
+
   const handleAmountChange = (value: number) => {
     if (value > (ask as number)) {
       setWarningMessage(
@@ -190,7 +205,7 @@ export const ApproveModal = ({
           ? noteValidation.sanitized
           : undefined,
       );
-      approveOnClose();
+      closeWithoutGuard();
     } catch (e) {
       console.error(e);
     } finally {
@@ -216,165 +231,173 @@ export const ApproveModal = ({
   ]);
 
   return (
-    <Dialog open={approveIsOpen} onOpenChange={approveOnClose}>
-      <DialogContent className="m-0 p-0" hideCloseIcon>
-        <DialogTitle className="text-md -mb-1 px-6 pt-4 font-semibold text-slate-900">
-          Approve Grant Payment
-        </DialogTitle>
-        <Separator />
-        <div className="px-6 pb-6 text-[0.95rem]">
-          <p className="mb-4 text-slate-500">
-            You are about to approve {granteeName}&apos;s grant request. They
-            will be notified via email.
-          </p>
-
-          <div className="mb-6 flex items-center justify-between">
-            <p className="text-slate-500">Grant Request</p>
-            <div className="flex items-center">
-              <TokenIcon
-                className="h-5 w-5 rounded-full"
-                alt={`${token} icon`}
-                symbol={token}
-              />
-              <p className="ml-1 font-semibold text-slate-600">
-                {ask} <span className="text-slate-400">{token}</span>
-              </p>
-            </div>
-          </div>
-
-          <div className="mb-6 flex w-full items-center justify-between">
-            <p className="w-full whitespace-nowrap text-slate-500">
-              Approved Amount
+    <>
+      <Dialog
+        open={approveIsOpen}
+        onOpenChange={(open) => {
+          if (!open) requestClose();
+        }}
+      >
+        <DialogContent className="m-0 p-0" hideCloseIcon>
+          <DialogTitle className="text-md -mb-1 px-6 pt-4 font-semibold text-slate-900">
+            Approve Grant Payment
+          </DialogTitle>
+          <Separator />
+          <div className="px-6 pb-6 text-[0.95rem]">
+            <p className="mb-4 text-slate-500">
+              You are about to approve {granteeName}&apos;s grant request. They
+              will be notified via email.
             </p>
-            <div className="flex">
-              <CustomNumberInput
-                value={approvedAmount || 0}
-                onChange={handleAmountChange}
-                min={1}
-                max={max}
-              />
-              <div className="flex items-center rounded-r-md border border-l-0 bg-white px-3 text-[0.95rem] text-slate-400">
+
+            <div className="mb-6 flex items-center justify-between">
+              <p className="text-slate-500">Grant Request</p>
+              <div className="flex items-center">
                 <TokenIcon
-                  className="mr-1 h-5 w-5 rounded-full"
+                  className="h-5 w-5 rounded-full"
                   alt={`${token} icon`}
                   symbol={token}
                 />
-                {token}
+                <p className="ml-1 font-semibold text-slate-600">
+                  {ask} <span className="text-slate-400">{token}</span>
+                </p>
+              </div>
+            </div>
+
+            <div className="mb-6 flex w-full items-center justify-between">
+              <p className="w-full whitespace-nowrap text-slate-500">
+                Approved Amount
+              </p>
+              <div className="flex">
+                <CustomNumberInput
+                  value={approvedAmount || 0}
+                  onChange={handleAmountChange}
+                  min={1}
+                  max={max}
+                />
+                <div className="flex items-center rounded-r-md border border-l-0 bg-white px-3 text-[0.95rem] text-slate-400">
+                  <TokenIcon
+                    className="mr-1 h-5 w-5 rounded-full"
+                    alt={`${token} icon`}
+                    symbol={token}
+                  />
+                  {token}
+                </div>
+              </div>
+            </div>
+
+            {warningMessage && (
+              <p className="mb-4 text-center text-sm text-yellow-500">
+                {warningMessage}
+              </p>
+            )}
+
+            {enableCustomEmail && isCustomEmailOpen && (
+              <CustomNoteEditor
+                id="approve-grant-custom-note"
+                value={customNote}
+                previewHtml={previewEmailBody}
+                emailType="approval"
+                error={emailError}
+                onChange={(value) => {
+                  const sanitizedNote = sanitizeCustomEmailBody(value);
+                  setCustomNote(value);
+                  setEmailError(
+                    validateCustomEmailNote({
+                      noteHtml: value,
+                      fullEmailHtml: getGrantApprovedEmailBody({
+                        granteeName,
+                        grantTitle,
+                        projectTitle,
+                        approvedAmount,
+                        token,
+                        salutation,
+                        reviewerNote: sanitizedNote,
+                      }),
+                    }).error,
+                  );
+                }}
+              />
+            )}
+
+            <div className="flex gap-3">
+              <div className="w-1/2" />
+              <Button variant="ghost" onClick={requestClose} disabled={loading}>
+                Close
+              </Button>
+              <div className="flex flex-1">
+                <Button
+                  className={cn(
+                    'flex-1 border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600',
+                    enableCustomEmail
+                      ? 'rounded-l-lg rounded-r-none'
+                      : 'rounded-lg',
+                  )}
+                  disabled={
+                    loading ||
+                    approvedAmount === 0 ||
+                    (enableCustomEmail &&
+                      isCustomEmailOpen &&
+                      (!getCustomEmailPlainText(customNote) || !!emailError))
+                  }
+                  onClick={approveGrant}
+                >
+                  {loading ? (
+                    <>
+                      <span className="loading loading-spinner mr-2" />
+                      <span>
+                        {isCustomEmailOpen
+                          ? 'Approving with Custom Note'
+                          : 'Approving'}
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <div className="mr-2 rounded-full bg-emerald-600 p-0.5">
+                        <Check className="size-2.5 text-white" />
+                      </div>
+                      <span>
+                        {isCustomEmailOpen
+                          ? 'Approve with Custom Note'
+                          : 'Approve Grant'}
+                      </span>
+                    </>
+                  )}
+                </Button>
+                {enableCustomEmail && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        className="rounded-l-none rounded-r-lg border border-l-0 border-emerald-500 bg-emerald-50 px-2 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
+                        disabled={loading}
+                        aria-label="Approve options"
+                      >
+                        <ChevronDown className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="z-70 w-56">
+                      {isCustomEmailOpen ? (
+                        <DropdownMenuItem
+                          onClick={() => setIsCustomEmailOpen(false)}
+                        >
+                          Approve
+                        </DropdownMenuItem>
+                      ) : (
+                        <DropdownMenuItem
+                          onClick={() => setIsCustomEmailOpen(true)}
+                        >
+                          Approve with custom note
+                        </DropdownMenuItem>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
               </div>
             </div>
           </div>
-
-          {warningMessage && (
-            <p className="mb-4 text-center text-sm text-yellow-500">
-              {warningMessage}
-            </p>
-          )}
-
-          {enableCustomEmail && isCustomEmailOpen && (
-            <CustomNoteEditor
-              id="approve-grant-custom-note"
-              value={customNote}
-              previewHtml={previewEmailBody}
-              emailType="approval"
-              error={emailError}
-              onChange={(value) => {
-                const sanitizedNote = sanitizeCustomEmailBody(value);
-                setCustomNote(value);
-                setEmailError(
-                  validateCustomEmailNote({
-                    noteHtml: value,
-                    fullEmailHtml: getGrantApprovedEmailBody({
-                      granteeName,
-                      grantTitle,
-                      projectTitle,
-                      approvedAmount,
-                      token,
-                      salutation,
-                      reviewerNote: sanitizedNote,
-                    }),
-                  }).error,
-                );
-              }}
-            />
-          )}
-
-          <div className="flex gap-3">
-            <div className="w-1/2" />
-            <Button variant="ghost" onClick={approveOnClose} disabled={loading}>
-              Close
-            </Button>
-            <div className="flex flex-1">
-              <Button
-                className={cn(
-                  'flex-1 border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600',
-                  enableCustomEmail
-                    ? 'rounded-l-lg rounded-r-none'
-                    : 'rounded-lg',
-                )}
-                disabled={
-                  loading ||
-                  approvedAmount === 0 ||
-                  (enableCustomEmail &&
-                    isCustomEmailOpen &&
-                    (!getCustomEmailPlainText(customNote) || !!emailError))
-                }
-                onClick={approveGrant}
-              >
-                {loading ? (
-                  <>
-                    <span className="loading loading-spinner mr-2" />
-                    <span>
-                      {isCustomEmailOpen
-                        ? 'Approving with Custom Note'
-                        : 'Approving'}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <div className="mr-2 rounded-full bg-emerald-600 p-0.5">
-                      <Check className="size-2.5 text-white" />
-                    </div>
-                    <span>
-                      {isCustomEmailOpen
-                        ? 'Approve with Custom Note'
-                        : 'Approve Grant'}
-                    </span>
-                  </>
-                )}
-              </Button>
-              {enableCustomEmail && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      className="rounded-l-none rounded-r-lg border border-l-0 border-emerald-500 bg-emerald-50 px-2 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
-                      disabled={loading}
-                      aria-label="Approve options"
-                    >
-                      <ChevronDown className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="z-70 w-56">
-                    {isCustomEmailOpen ? (
-                      <DropdownMenuItem
-                        onClick={() => setIsCustomEmailOpen(false)}
-                      >
-                        Approve
-                      </DropdownMenuItem>
-                    ) : (
-                      <DropdownMenuItem
-                        onClick={() => setIsCustomEmailOpen(true)}
-                      >
-                        Approve with custom note
-                      </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-            </div>
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+      {discardChangesDialog}
+    </>
   );
 };

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/ApproveModal.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/ApproveModal.tsx
@@ -2,7 +2,6 @@ import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 import posthog from 'posthog-js';
 import React, { useEffect, useState } from 'react';
 
-import { RichEditor } from '@/components/shared/RichEditor';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import {
@@ -14,12 +13,15 @@ import {
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
+import { cn } from '@/utils/cn';
 
 import {
   getCustomEmailPlainText,
-  validateCustomEmailBody,
+  sanitizeCustomEmailBody,
+  validateCustomEmailNote,
 } from '../../../utils/customEmailSanitizer';
 import { getGrantApprovedEmailBody } from '../../../utils/grantEmailCopy';
+import { CustomNoteEditor } from './CustomNoteEditor';
 
 const CustomNumberInput = ({
   value,
@@ -118,7 +120,7 @@ interface ApproveModalProps {
   onApproveGrant: (
     applicationId: string,
     approvedAmount: number,
-    emailBody?: string,
+    customNote?: string,
   ) => void;
   max: number | undefined;
 }
@@ -138,20 +140,20 @@ export const ApproveModal = ({
   max,
 }: ApproveModalProps) => {
   const [approvedAmount, setApprovedAmount] = useState<number | undefined>(ask);
-  const [emailBody, setEmailBody] = useState('');
-  const [hasEditedEmail, setHasEditedEmail] = useState(false);
+  const [customNote, setCustomNote] = useState('');
   const [isCustomEmailOpen, setIsCustomEmailOpen] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
 
-  const defaultEmailBody = getGrantApprovedEmailBody({
+  const previewEmailBody = getGrantApprovedEmailBody({
     granteeName,
     grantTitle,
     projectTitle,
     approvedAmount,
     token,
     salutation,
+    reviewerNote: sanitizeCustomEmailBody(customNote),
   });
 
   const handleAmountChange = (value: number) => {
@@ -163,28 +165,18 @@ export const ApproveModal = ({
       setWarningMessage(null);
     }
     setApprovedAmount(value);
-    if (!hasEditedEmail) {
-      setEmailBody(
-        getGrantApprovedEmailBody({
-          granteeName,
-          grantTitle,
-          projectTitle,
-          approvedAmount: value,
-          token,
-          salutation,
-        }),
-      );
-    }
   };
 
   const approveGrant = async () => {
     if (approvedAmount === undefined || approvedAmount === 0 || !applicationId)
       return;
 
-    const customEmailBody = emailBody.trim();
-    const emailValidation = validateCustomEmailBody(customEmailBody);
-    if (enableCustomEmail && isCustomEmailOpen && !emailValidation.isValid) {
-      setEmailError(emailValidation.error);
+    const noteValidation = validateCustomEmailNote({
+      noteHtml: customNote.trim(),
+      fullEmailHtml: previewEmailBody,
+    });
+    if (enableCustomEmail && isCustomEmailOpen && !noteValidation.isValid) {
+      setEmailError(noteValidation.error);
       return;
     }
 
@@ -195,7 +187,7 @@ export const ApproveModal = ({
         applicationId,
         approvedAmount,
         enableCustomEmail && isCustomEmailOpen
-          ? emailValidation.sanitized
+          ? noteValidation.sanitized
           : undefined,
       );
       approveOnClose();
@@ -208,17 +200,7 @@ export const ApproveModal = ({
 
   useEffect(() => {
     setApprovedAmount(ask);
-    setEmailBody(
-      getGrantApprovedEmailBody({
-        granteeName,
-        grantTitle,
-        projectTitle,
-        approvedAmount: ask,
-        token,
-        salutation,
-      }),
-    );
-    setHasEditedEmail(false);
+    setCustomNote('');
     setIsCustomEmailOpen(false);
     setEmailError(null);
     setWarningMessage(null);
@@ -289,39 +271,30 @@ export const ApproveModal = ({
           )}
 
           {enableCustomEmail && isCustomEmailOpen && (
-            <div className="mb-6">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <p className="font-medium text-slate-600">Email Body</p>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="h-auto px-2 py-1 text-xs font-semibold text-slate-500"
-                  onClick={() => {
-                    setEmailBody(defaultEmailBody);
-                    setHasEditedEmail(false);
-                    setEmailError(null);
-                  }}
-                  disabled={loading || emailBody === defaultEmailBody}
-                >
-                  Reset
-                </Button>
-              </div>
-              <RichEditor
-                id="approve-grant-email-body"
-                height="h-[190px]"
-                value={emailBody}
-                onChange={(value) => {
-                  setEmailBody(value);
-                  setHasEditedEmail(true);
-                  setEmailError(validateCustomEmailBody(value).error);
-                }}
-                error={!!emailError}
-                placeholder="Write the email body"
-              />
-              {emailError && (
-                <p className="mt-2 text-sm text-red-500">{emailError}</p>
-              )}
-            </div>
+            <CustomNoteEditor
+              id="approve-grant-custom-note"
+              value={customNote}
+              previewHtml={previewEmailBody}
+              error={emailError}
+              onChange={(value) => {
+                const sanitizedNote = sanitizeCustomEmailBody(value);
+                setCustomNote(value);
+                setEmailError(
+                  validateCustomEmailNote({
+                    noteHtml: value,
+                    fullEmailHtml: getGrantApprovedEmailBody({
+                      granteeName,
+                      grantTitle,
+                      projectTitle,
+                      approvedAmount,
+                      token,
+                      salutation,
+                      reviewerNote: sanitizedNote,
+                    }),
+                  }).error,
+                );
+              }}
+            />
           )}
 
           <div className="flex gap-3">
@@ -331,13 +304,18 @@ export const ApproveModal = ({
             </Button>
             <div className="flex flex-1">
               <Button
-                className="flex-1 rounded-l-lg rounded-r-none border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
+                className={cn(
+                  'flex-1 border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600',
+                  enableCustomEmail
+                    ? 'rounded-l-lg rounded-r-none'
+                    : 'rounded-lg',
+                )}
                 disabled={
                   loading ||
                   approvedAmount === 0 ||
                   (enableCustomEmail &&
                     isCustomEmailOpen &&
-                    (!getCustomEmailPlainText(emailBody) || !!emailError))
+                    (!getCustomEmailPlainText(customNote) || !!emailError))
                 }
                 onClick={approveGrant}
               >
@@ -346,7 +324,7 @@ export const ApproveModal = ({
                     <span className="loading loading-spinner mr-2" />
                     <span>
                       {isCustomEmailOpen
-                        ? 'Approving with Custom Email'
+                        ? 'Approving with Custom Note'
                         : 'Approving'}
                     </span>
                   </>
@@ -357,7 +335,7 @@ export const ApproveModal = ({
                     </div>
                     <span>
                       {isCustomEmailOpen
-                        ? 'Approve with Custom Email'
+                        ? 'Approve with Custom Note'
                         : 'Approve Grant'}
                     </span>
                   </>
@@ -386,7 +364,7 @@ export const ApproveModal = ({
                       <DropdownMenuItem
                         onClick={() => setIsCustomEmailOpen(true)}
                       >
-                        Approve with custom email
+                        Approve with custom note
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/CustomNoteEditor.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/CustomNoteEditor.tsx
@@ -1,0 +1,89 @@
+import { Eye } from 'lucide-react';
+import { useState } from 'react';
+
+import { RichEditor } from '@/components/shared/RichEditor';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+
+import {
+  CUSTOM_EMAIL_MAX_CHARS,
+  getCustomEmailPlainText,
+} from '../../../utils/customEmailSanitizer';
+
+interface CustomNoteEditorProps {
+  id: string;
+  value: string;
+  previewHtml: string;
+  error: string | null;
+  onChange: (value: string) => void;
+}
+
+export const CustomNoteEditor = ({
+  id,
+  value,
+  previewHtml,
+  error,
+  onChange,
+}: CustomNoteEditorProps) => {
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const emailCharCount = getCustomEmailPlainText(previewHtml).length;
+
+  return (
+    <div className="mb-6">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <div>
+          <p className="font-medium text-slate-600">Custom Note</p>
+          <p className="text-xs text-slate-400">
+            Email preview: {emailCharCount.toLocaleString()} /{' '}
+            {CUSTOM_EMAIL_MAX_CHARS.toLocaleString()} characters
+          </p>
+        </div>
+        <Dialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen}>
+          <DialogTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-auto px-2 py-1 text-xs font-semibold text-slate-500"
+            >
+              <Eye className="size-3.5" />
+              Preview
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-h-[86vh] max-w-2xl gap-0 overflow-hidden p-0">
+            <div className="border-b border-slate-200 px-5 py-4">
+              <DialogTitle className="text-base font-semibold text-slate-700">
+                Email Preview
+              </DialogTitle>
+              <p className="mt-1 text-xs text-slate-400">
+                {emailCharCount.toLocaleString()} /{' '}
+                {CUSTOM_EMAIL_MAX_CHARS.toLocaleString()} characters
+              </p>
+            </div>
+            <div className="max-h-[70vh] overflow-y-auto bg-slate-50 px-4 py-5">
+              <div className="mx-auto rounded-md border border-slate-200 bg-white px-5 py-4 shadow-sm">
+                <div
+                  className="prose prose-sm max-w-none text-slate-600"
+                  dangerouslySetInnerHTML={{ __html: previewHtml }}
+                />
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+      <RichEditor
+        id={id}
+        height="h-[160px]"
+        value={value}
+        onChange={onChange}
+        error={!!error}
+        placeholder="Add a note from the grant reviewer"
+      />
+      {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+    </div>
+  );
+};

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/CustomNoteEditor.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/CustomNoteEditor.tsx
@@ -19,6 +19,7 @@ interface CustomNoteEditorProps {
   id: string;
   value: string;
   previewHtml: string;
+  emailType: 'approval' | 'rejection';
   error: string | null;
   onChange: (value: string) => void;
 }
@@ -27,20 +28,21 @@ export const CustomNoteEditor = ({
   id,
   value,
   previewHtml,
+  emailType,
   error,
   onChange,
 }: CustomNoteEditorProps) => {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const emailCharCount = getCustomEmailPlainText(previewHtml).length;
+  const noteCharCount = getCustomEmailPlainText(value).length;
 
   return (
     <div className="mb-6">
-      <div className="mb-2 flex items-center justify-between gap-3">
+      <div className="mb-2 flex items-center justify-between">
         <div>
           <p className="font-medium text-slate-600">Custom Note</p>
           <p className="text-xs text-slate-400">
-            Email preview: {emailCharCount.toLocaleString()} /{' '}
-            {CUSTOM_EMAIL_MAX_CHARS.toLocaleString()} characters
+            This custom note will be sent to the applicant as part of the{' '}
+            {emailType} email.
           </p>
         </div>
         <Dialog open={isPreviewOpen} onOpenChange={setIsPreviewOpen}>
@@ -59,10 +61,6 @@ export const CustomNoteEditor = ({
               <DialogTitle className="text-base font-semibold text-slate-700">
                 Email Preview
               </DialogTitle>
-              <p className="mt-1 text-xs text-slate-400">
-                {emailCharCount.toLocaleString()} /{' '}
-                {CUSTOM_EMAIL_MAX_CHARS.toLocaleString()} characters
-              </p>
             </div>
             <div className="max-h-[70vh] overflow-y-auto bg-slate-50 px-4 py-5">
               <div className="mx-auto rounded-md border border-slate-200 bg-white px-5 py-4 shadow-sm">
@@ -83,6 +81,10 @@ export const CustomNoteEditor = ({
         error={!!error}
         placeholder="Add a note from the grant reviewer"
       />
+      <p className="mt-1 text-right text-xs text-slate-400">
+        {noteCharCount.toLocaleString()} /{' '}
+        {CUSTOM_EMAIL_MAX_CHARS.toLocaleString()}
+      </p>
       {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
     </div>
   );

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
@@ -14,13 +14,14 @@ import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
 import { cn } from '@/utils/cn';
 
+import { useCustomNoteCloseGuard } from '@/features/sponsor-dashboard/components/GrantApplications/hooks/useCustomNoteCloseGuard';
+import { CustomNoteEditor } from '@/features/sponsor-dashboard/components/GrantApplications/Modals/CustomNoteEditor';
 import {
   getCustomEmailPlainText,
   sanitizeCustomEmailBody,
   validateCustomEmailNote,
-} from '../../../utils/customEmailSanitizer';
-import { getGrantRejectedEmailBody } from '../../../utils/grantEmailCopy';
-import { CustomNoteEditor } from './CustomNoteEditor';
+} from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
+import { getGrantRejectedEmailBody } from '@/features/sponsor-dashboard/utils/grantEmailCopy';
 
 interface RejectModalProps {
   rejectIsOpen: boolean;
@@ -62,6 +63,20 @@ export const RejectGrantApplicationModal = ({
     reviewerNote: sanitizeCustomEmailBody(customNote),
   });
 
+  const closeAndDiscardCustomNote = () => {
+    setCustomNote('');
+    setIsCustomEmailOpen(false);
+    setEmailError(null);
+    rejectOnClose();
+  };
+
+  const { closeWithoutGuard, discardChangesDialog, requestClose } =
+    useCustomNoteCloseGuard({
+      customNote,
+      isEnabled: enableCustomEmail && isCustomEmailOpen,
+      onDiscard: closeAndDiscardCustomNote,
+    });
+
   const rejectGrant = async () => {
     if (!applicationId) return;
 
@@ -87,7 +102,7 @@ export const RejectGrantApplicationModal = ({
       console.error(e);
     } finally {
       setLoading(false);
-      rejectOnClose();
+      closeWithoutGuard();
     }
   };
 
@@ -99,134 +114,142 @@ export const RejectGrantApplicationModal = ({
   }, [applicationId]);
 
   return (
-    <Dialog open={rejectIsOpen} onOpenChange={rejectOnClose}>
-      <DialogContent className="m-0 p-0" hideCloseIcon>
-        <DialogTitle className="text-md -mb-1 px-6 pt-4 font-semibold text-slate-900">
-          Reject Grant Payment
-        </DialogTitle>
-        <Separator />
-        <div className="px-6 pb-6 text-[0.95rem]">
-          <p className="mb-4 text-slate-500">
-            You are about to reject {granteeName}&apos;s grant request. They
-            will be notified via email.
-          </p>
+    <>
+      <Dialog
+        open={rejectIsOpen}
+        onOpenChange={(open) => {
+          if (!open) requestClose();
+        }}
+      >
+        <DialogContent className="m-0 p-0" hideCloseIcon>
+          <DialogTitle className="text-md -mb-1 px-6 pt-4 font-semibold text-slate-900">
+            Reject Grant Payment
+          </DialogTitle>
+          <Separator />
+          <div className="px-6 pb-6 text-[0.95rem]">
+            <p className="mb-4 text-slate-500">
+              You are about to reject {granteeName}&apos;s grant request. They
+              will be notified via email.
+            </p>
 
-          <div className="mb-6 flex items-center justify-between">
-            <p className="text-slate-500">Grant Request</p>
-            <div className="flex items-center">
-              <TokenIcon
-                className="h-5 w-5 rounded-full"
-                alt={`${token} icon`}
-                symbol={token}
+            <div className="mb-6 flex items-center justify-between">
+              <p className="text-slate-500">Grant Request</p>
+              <div className="flex items-center">
+                <TokenIcon
+                  className="h-5 w-5 rounded-full"
+                  alt={`${token} icon`}
+                  symbol={token}
+                />
+                <p className="ml-1 font-semibold text-slate-600">
+                  {ask} <span className="text-slate-400">{token}</span>
+                </p>
+              </div>
+            </div>
+
+            {enableCustomEmail && isCustomEmailOpen && (
+              <CustomNoteEditor
+                id="reject-grant-custom-note"
+                value={customNote}
+                previewHtml={previewEmailBody}
+                emailType="rejection"
+                error={emailError}
+                onChange={(value) => {
+                  const sanitizedNote = sanitizeCustomEmailBody(value);
+                  setCustomNote(value);
+                  setEmailError(
+                    validateCustomEmailNote({
+                      noteHtml: value,
+                      fullEmailHtml: getGrantRejectedEmailBody({
+                        granteeName,
+                        grantTitle,
+                        projectTitle,
+                        salutation,
+                        reviewerNote: sanitizedNote,
+                      }),
+                    }).error,
+                  );
+                }}
               />
-              <p className="ml-1 font-semibold text-slate-600">
-                {ask} <span className="text-slate-400">{token}</span>
-              </p>
-            </div>
-          </div>
+            )}
 
-          {enableCustomEmail && isCustomEmailOpen && (
-            <CustomNoteEditor
-              id="reject-grant-custom-note"
-              value={customNote}
-              previewHtml={previewEmailBody}
-              emailType="rejection"
-              error={emailError}
-              onChange={(value) => {
-                const sanitizedNote = sanitizeCustomEmailBody(value);
-                setCustomNote(value);
-                setEmailError(
-                  validateCustomEmailNote({
-                    noteHtml: value,
-                    fullEmailHtml: getGrantRejectedEmailBody({
-                      granteeName,
-                      grantTitle,
-                      projectTitle,
-                      salutation,
-                      reviewerNote: sanitizedNote,
-                    }),
-                  }).error,
-                );
-              }}
-            />
-          )}
-
-          <div className="flex gap-3">
-            <div className="w-1/2" />
-            <Button variant="ghost" onClick={rejectOnClose} disabled={loading}>
-              Close
-            </Button>
-            <div className="flex flex-1">
-              <Button
-                className={cn(
-                  'flex-1 border border-red-500 bg-red-50 text-red-600 hover:bg-red-100',
-                  enableCustomEmail
-                    ? 'rounded-l-lg rounded-r-none'
-                    : 'rounded-lg',
-                )}
-                disabled={
-                  loading ||
-                  (enableCustomEmail &&
-                    isCustomEmailOpen &&
-                    (!getCustomEmailPlainText(customNote) || !!emailError))
-                }
-                onClick={rejectGrant}
-              >
-                {loading ? (
-                  <>
-                    <span className="loading loading-spinner mr-2" />
-                    <span>
-                      {isCustomEmailOpen
-                        ? 'Rejecting with Custom Note'
-                        : 'Rejecting'}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <div className="rounded-full bg-red-600 p-0.5">
-                      <X className="size-2 text-white" />
-                    </div>
-                    <span>
-                      {isCustomEmailOpen
-                        ? 'Reject with Custom Note'
-                        : 'Reject Grant'}
-                    </span>
-                  </>
-                )}
+            <div className="flex gap-3">
+              <div className="w-1/2" />
+              <Button variant="ghost" onClick={requestClose} disabled={loading}>
+                Close
               </Button>
-              {enableCustomEmail && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      className="rounded-l-none rounded-r-lg border border-l-0 border-red-500 bg-red-50 px-2 text-red-600 hover:bg-red-100"
-                      disabled={loading}
-                      aria-label="Reject options"
-                    >
-                      <ChevronDown className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="z-70 w-56">
-                    {isCustomEmailOpen ? (
-                      <DropdownMenuItem
-                        onClick={() => setIsCustomEmailOpen(false)}
+              <div className="flex flex-1">
+                <Button
+                  className={cn(
+                    'flex-1 border border-red-500 bg-red-50 text-red-600 hover:bg-red-100',
+                    enableCustomEmail
+                      ? 'rounded-l-lg rounded-r-none'
+                      : 'rounded-lg',
+                  )}
+                  disabled={
+                    loading ||
+                    (enableCustomEmail &&
+                      isCustomEmailOpen &&
+                      (!getCustomEmailPlainText(customNote) || !!emailError))
+                  }
+                  onClick={rejectGrant}
+                >
+                  {loading ? (
+                    <>
+                      <span className="loading loading-spinner mr-2" />
+                      <span>
+                        {isCustomEmailOpen
+                          ? 'Rejecting with Custom Note'
+                          : 'Rejecting'}
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <div className="rounded-full bg-red-600 p-0.5">
+                        <X className="size-2 text-white" />
+                      </div>
+                      <span>
+                        {isCustomEmailOpen
+                          ? 'Reject with Custom Note'
+                          : 'Reject Grant'}
+                      </span>
+                    </>
+                  )}
+                </Button>
+                {enableCustomEmail && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        className="rounded-l-none rounded-r-lg border border-l-0 border-red-500 bg-red-50 px-2 text-red-600 hover:bg-red-100"
+                        disabled={loading}
+                        aria-label="Reject options"
                       >
-                        Use default email
-                      </DropdownMenuItem>
-                    ) : (
-                      <DropdownMenuItem
-                        onClick={() => setIsCustomEmailOpen(true)}
-                      >
-                        Reject with custom note
-                      </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
+                        <ChevronDown className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="z-70 w-56">
+                      {isCustomEmailOpen ? (
+                        <DropdownMenuItem
+                          onClick={() => setIsCustomEmailOpen(false)}
+                        >
+                          Use default email
+                        </DropdownMenuItem>
+                      ) : (
+                        <DropdownMenuItem
+                          onClick={() => setIsCustomEmailOpen(true)}
+                        >
+                          Reject with custom note
+                        </DropdownMenuItem>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+      {discardChangesDialog}
+    </>
   );
 };

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
@@ -130,6 +130,7 @@ export const RejectGrantApplicationModal = ({
               id="reject-grant-custom-note"
               value={customNote}
               previewHtml={previewEmailBody}
+              emailType="rejection"
               error={emailError}
               onChange={(value) => {
                 const sanitizedNote = sanitizeCustomEmailBody(value);

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
@@ -1,11 +1,24 @@
-import { X } from 'lucide-react';
+import { ChevronDown, X } from 'lucide-react';
 import posthog from 'posthog-js';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import { RichEditor } from '@/components/shared/RichEditor';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
+
+import {
+  getCustomEmailPlainText,
+  validateCustomEmailBody,
+} from '../../../utils/customEmailSanitizer';
+import { getGrantRejectedEmailBody } from '../../../utils/grantEmailCopy';
 
 interface RejectModalProps {
   rejectIsOpen: boolean;
@@ -13,8 +26,12 @@ interface RejectModalProps {
   applicationId: string | undefined;
   ask: number | undefined;
   granteeName: string | null | undefined;
+  grantTitle: string | undefined;
+  projectTitle: string | null | undefined;
+  salutation: string | null | undefined;
   token: string;
-  onRejectGrant: (applicationId: string) => void;
+  enableCustomEmail: boolean;
+  onRejectGrant: (applicationId: string, emailBody?: string) => void;
 }
 
 export const RejectGrantApplicationModal = ({
@@ -23,18 +40,44 @@ export const RejectGrantApplicationModal = ({
   rejectOnClose,
   ask,
   granteeName,
+  grantTitle,
+  projectTitle,
+  salutation,
   token,
+  enableCustomEmail,
   onRejectGrant,
 }: RejectModalProps) => {
   const [loading, setLoading] = useState<boolean>(false);
+  const [emailBody, setEmailBody] = useState('');
+  const [isCustomEmailOpen, setIsCustomEmailOpen] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  const defaultEmailBody = getGrantRejectedEmailBody({
+    granteeName,
+    grantTitle,
+    projectTitle,
+    salutation,
+  });
 
   const rejectGrant = async () => {
     if (!applicationId) return;
 
+    const customEmailBody = emailBody.trim();
+    const emailValidation = validateCustomEmailBody(customEmailBody);
+    if (enableCustomEmail && isCustomEmailOpen && !emailValidation.isValid) {
+      setEmailError(emailValidation.error);
+      return;
+    }
+
     setLoading(true);
     try {
       posthog.capture('reject_grant application');
-      await onRejectGrant(applicationId);
+      await onRejectGrant(
+        applicationId,
+        enableCustomEmail && isCustomEmailOpen
+          ? emailValidation.sanitized
+          : undefined,
+      );
     } catch (e) {
       console.error(e);
     } finally {
@@ -42,6 +85,13 @@ export const RejectGrantApplicationModal = ({
       rejectOnClose();
     }
   };
+
+  useEffect(() => {
+    setEmailBody(defaultEmailBody);
+    setIsCustomEmailOpen(false);
+    setEmailError(null);
+    setLoading(false);
+  }, [applicationId, defaultEmailBody]);
 
   return (
     <Dialog open={rejectIsOpen} onOpenChange={rejectOnClose}>
@@ -70,30 +120,108 @@ export const RejectGrantApplicationModal = ({
             </div>
           </div>
 
+          {enableCustomEmail && isCustomEmailOpen && (
+            <div className="mb-6">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <p className="font-medium text-slate-600">Email Body</p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="h-auto px-2 py-1 text-xs font-semibold text-slate-500"
+                  onClick={() => {
+                    setEmailBody(defaultEmailBody);
+                    setEmailError(null);
+                  }}
+                  disabled={loading || emailBody === defaultEmailBody}
+                >
+                  Reset
+                </Button>
+              </div>
+              <RichEditor
+                id="reject-grant-email-body"
+                height="h-[190px]"
+                value={emailBody}
+                onChange={(value) => {
+                  setEmailBody(value);
+                  setEmailError(validateCustomEmailBody(value).error);
+                }}
+                error={!!emailError}
+                placeholder="Write the email body"
+              />
+              {emailError && (
+                <p className="mt-2 text-sm text-red-500">{emailError}</p>
+              )}
+            </div>
+          )}
+
           <div className="flex gap-3">
             <div className="w-1/2" />
             <Button variant="ghost" onClick={rejectOnClose} disabled={loading}>
               Close
             </Button>
-            <Button
-              className="flex-1 rounded-lg border border-red-500 bg-red-50 text-red-600 hover:bg-red-100"
-              disabled={loading}
-              onClick={rejectGrant}
-            >
-              {loading ? (
-                <>
-                  <span className="loading loading-spinner mr-2" />
-                  <span>Rejecting</span>
-                </>
-              ) : (
-                <>
-                  <div className="rounded-full bg-red-600 p-0.5">
-                    <X className="size-2 text-white" />
-                  </div>
-                  <span>Reject Grant</span>
-                </>
+            <div className="flex flex-1">
+              <Button
+                className="flex-1 rounded-l-lg rounded-r-none border border-red-500 bg-red-50 text-red-600 hover:bg-red-100"
+                disabled={
+                  loading ||
+                  (enableCustomEmail &&
+                    isCustomEmailOpen &&
+                    (!getCustomEmailPlainText(emailBody) || !!emailError))
+                }
+                onClick={rejectGrant}
+              >
+                {loading ? (
+                  <>
+                    <span className="loading loading-spinner mr-2" />
+                    <span>
+                      {isCustomEmailOpen
+                        ? 'Rejecting with Custom Email'
+                        : 'Rejecting'}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <div className="rounded-full bg-red-600 p-0.5">
+                      <X className="size-2 text-white" />
+                    </div>
+                    <span>
+                      {isCustomEmailOpen
+                        ? 'Reject with Custom Email'
+                        : 'Reject Grant'}
+                    </span>
+                  </>
+                )}
+              </Button>
+              {enableCustomEmail && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      className="rounded-l-none rounded-r-lg border border-l-0 border-red-500 bg-red-50 px-2 text-red-600 hover:bg-red-100"
+                      disabled={loading}
+                      aria-label="Reject options"
+                    >
+                      <ChevronDown className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="z-70 w-56">
+                    {isCustomEmailOpen ? (
+                      <DropdownMenuItem
+                        onClick={() => setIsCustomEmailOpen(false)}
+                      >
+                        Use default email
+                      </DropdownMenuItem>
+                    ) : (
+                      <DropdownMenuItem
+                        onClick={() => setIsCustomEmailOpen(true)}
+                      >
+                        Reject with custom email
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
               )}
-            </Button>
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
@@ -2,7 +2,6 @@ import { ChevronDown, X } from 'lucide-react';
 import posthog from 'posthog-js';
 import { useEffect, useState } from 'react';
 
-import { RichEditor } from '@/components/shared/RichEditor';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import {
@@ -13,12 +12,15 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
+import { cn } from '@/utils/cn';
 
 import {
   getCustomEmailPlainText,
-  validateCustomEmailBody,
+  sanitizeCustomEmailBody,
+  validateCustomEmailNote,
 } from '../../../utils/customEmailSanitizer';
 import { getGrantRejectedEmailBody } from '../../../utils/grantEmailCopy';
+import { CustomNoteEditor } from './CustomNoteEditor';
 
 interface RejectModalProps {
   rejectIsOpen: boolean;
@@ -31,7 +33,7 @@ interface RejectModalProps {
   salutation: string | null | undefined;
   token: string;
   enableCustomEmail: boolean;
-  onRejectGrant: (applicationId: string, emailBody?: string) => void;
+  onRejectGrant: (applicationId: string, customNote?: string) => void;
 }
 
 export const RejectGrantApplicationModal = ({
@@ -48,24 +50,27 @@ export const RejectGrantApplicationModal = ({
   onRejectGrant,
 }: RejectModalProps) => {
   const [loading, setLoading] = useState<boolean>(false);
-  const [emailBody, setEmailBody] = useState('');
+  const [customNote, setCustomNote] = useState('');
   const [isCustomEmailOpen, setIsCustomEmailOpen] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
 
-  const defaultEmailBody = getGrantRejectedEmailBody({
+  const previewEmailBody = getGrantRejectedEmailBody({
     granteeName,
     grantTitle,
     projectTitle,
     salutation,
+    reviewerNote: sanitizeCustomEmailBody(customNote),
   });
 
   const rejectGrant = async () => {
     if (!applicationId) return;
 
-    const customEmailBody = emailBody.trim();
-    const emailValidation = validateCustomEmailBody(customEmailBody);
-    if (enableCustomEmail && isCustomEmailOpen && !emailValidation.isValid) {
-      setEmailError(emailValidation.error);
+    const noteValidation = validateCustomEmailNote({
+      noteHtml: customNote.trim(),
+      fullEmailHtml: previewEmailBody,
+    });
+    if (enableCustomEmail && isCustomEmailOpen && !noteValidation.isValid) {
+      setEmailError(noteValidation.error);
       return;
     }
 
@@ -75,7 +80,7 @@ export const RejectGrantApplicationModal = ({
       await onRejectGrant(
         applicationId,
         enableCustomEmail && isCustomEmailOpen
-          ? emailValidation.sanitized
+          ? noteValidation.sanitized
           : undefined,
       );
     } catch (e) {
@@ -87,11 +92,11 @@ export const RejectGrantApplicationModal = ({
   };
 
   useEffect(() => {
-    setEmailBody(defaultEmailBody);
+    setCustomNote('');
     setIsCustomEmailOpen(false);
     setEmailError(null);
     setLoading(false);
-  }, [applicationId, defaultEmailBody]);
+  }, [applicationId]);
 
   return (
     <Dialog open={rejectIsOpen} onOpenChange={rejectOnClose}>
@@ -121,37 +126,28 @@ export const RejectGrantApplicationModal = ({
           </div>
 
           {enableCustomEmail && isCustomEmailOpen && (
-            <div className="mb-6">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <p className="font-medium text-slate-600">Email Body</p>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="h-auto px-2 py-1 text-xs font-semibold text-slate-500"
-                  onClick={() => {
-                    setEmailBody(defaultEmailBody);
-                    setEmailError(null);
-                  }}
-                  disabled={loading || emailBody === defaultEmailBody}
-                >
-                  Reset
-                </Button>
-              </div>
-              <RichEditor
-                id="reject-grant-email-body"
-                height="h-[190px]"
-                value={emailBody}
-                onChange={(value) => {
-                  setEmailBody(value);
-                  setEmailError(validateCustomEmailBody(value).error);
-                }}
-                error={!!emailError}
-                placeholder="Write the email body"
-              />
-              {emailError && (
-                <p className="mt-2 text-sm text-red-500">{emailError}</p>
-              )}
-            </div>
+            <CustomNoteEditor
+              id="reject-grant-custom-note"
+              value={customNote}
+              previewHtml={previewEmailBody}
+              error={emailError}
+              onChange={(value) => {
+                const sanitizedNote = sanitizeCustomEmailBody(value);
+                setCustomNote(value);
+                setEmailError(
+                  validateCustomEmailNote({
+                    noteHtml: value,
+                    fullEmailHtml: getGrantRejectedEmailBody({
+                      granteeName,
+                      grantTitle,
+                      projectTitle,
+                      salutation,
+                      reviewerNote: sanitizedNote,
+                    }),
+                  }).error,
+                );
+              }}
+            />
           )}
 
           <div className="flex gap-3">
@@ -161,12 +157,17 @@ export const RejectGrantApplicationModal = ({
             </Button>
             <div className="flex flex-1">
               <Button
-                className="flex-1 rounded-l-lg rounded-r-none border border-red-500 bg-red-50 text-red-600 hover:bg-red-100"
+                className={cn(
+                  'flex-1 border border-red-500 bg-red-50 text-red-600 hover:bg-red-100',
+                  enableCustomEmail
+                    ? 'rounded-l-lg rounded-r-none'
+                    : 'rounded-lg',
+                )}
                 disabled={
                   loading ||
                   (enableCustomEmail &&
                     isCustomEmailOpen &&
-                    (!getCustomEmailPlainText(emailBody) || !!emailError))
+                    (!getCustomEmailPlainText(customNote) || !!emailError))
                 }
                 onClick={rejectGrant}
               >
@@ -175,7 +176,7 @@ export const RejectGrantApplicationModal = ({
                     <span className="loading loading-spinner mr-2" />
                     <span>
                       {isCustomEmailOpen
-                        ? 'Rejecting with Custom Email'
+                        ? 'Rejecting with Custom Note'
                         : 'Rejecting'}
                     </span>
                   </>
@@ -186,7 +187,7 @@ export const RejectGrantApplicationModal = ({
                     </div>
                     <span>
                       {isCustomEmailOpen
-                        ? 'Reject with Custom Email'
+                        ? 'Reject with Custom Note'
                         : 'Reject Grant'}
                     </span>
                   </>
@@ -215,7 +216,7 @@ export const RejectGrantApplicationModal = ({
                       <DropdownMenuItem
                         onClick={() => setIsCustomEmailOpen(true)}
                       >
-                        Reject with custom email
+                        Reject with custom note
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>

--- a/src/features/sponsor-dashboard/components/GrantApplications/hooks/useCustomNoteCloseGuard.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/hooks/useCustomNoteCloseGuard.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+import { getCustomEmailPlainText } from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
+
+interface UseCustomNoteCloseGuardProps {
+  customNote: string;
+  isEnabled: boolean;
+  onDiscard: () => void;
+}
+
+export const useCustomNoteCloseGuard = ({
+  customNote,
+  isEnabled,
+  onDiscard,
+}: UseCustomNoteCloseGuardProps) => {
+  const [isDiscardDialogOpen, setIsDiscardDialogOpen] = useState(false);
+  const hasUnsavedCustomNote =
+    isEnabled && getCustomEmailPlainText(customNote).length > 0;
+
+  useEffect(() => {
+    if (!hasUnsavedCustomNote) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [hasUnsavedCustomNote]);
+
+  const requestClose = () => {
+    if (hasUnsavedCustomNote) {
+      setIsDiscardDialogOpen(true);
+      return;
+    }
+
+    onDiscard();
+  };
+
+  const confirmClose = () => {
+    setIsDiscardDialogOpen(false);
+    onDiscard();
+  };
+
+  const discardChangesDialog = (
+    <AlertDialog
+      open={isDiscardDialogOpen}
+      onOpenChange={setIsDiscardDialogOpen}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Your changes will be lost if you close this window.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={confirmClose}>Confirm</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  return {
+    discardChangesDialog,
+    requestClose,
+    closeWithoutGuard: onDiscard,
+  };
+};

--- a/src/features/sponsor-dashboard/components/Traches/ApproveTrancheModal.tsx
+++ b/src/features/sponsor-dashboard/components/Traches/ApproveTrancheModal.tsx
@@ -14,13 +14,14 @@ import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
 import { cn } from '@/utils/cn';
 
+import { useCustomNoteCloseGuard } from '@/features/sponsor-dashboard/components/GrantApplications/hooks/useCustomNoteCloseGuard';
+import { CustomNoteEditor } from '@/features/sponsor-dashboard/components/GrantApplications/Modals/CustomNoteEditor';
 import {
   getCustomEmailPlainText,
   sanitizeCustomEmailBody,
   validateCustomEmailNote,
-} from '../../utils/customEmailSanitizer';
-import { getTrancheApprovedEmailBody } from '../../utils/grantEmailCopy';
-import { CustomNoteEditor } from '../GrantApplications/Modals/CustomNoteEditor';
+} from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
+import { getTrancheApprovedEmailBody } from '@/features/sponsor-dashboard/utils/grantEmailCopy';
 
 const CustomNumberInput = ({
   value,
@@ -165,6 +166,20 @@ export const ApproveTrancheModal = ({
     reviewerNote: sanitizeCustomEmailBody(customNote),
   });
 
+  const closeAndDiscardCustomNote = () => {
+    setCustomNote('');
+    setIsCustomEmailOpen(false);
+    setEmailError(null);
+    approveOnClose();
+  };
+
+  const { closeWithoutGuard, discardChangesDialog, requestClose } =
+    useCustomNoteCloseGuard({
+      customNote,
+      isEnabled: enableCustomEmail && isCustomEmailOpen,
+      onDiscard: closeAndDiscardCustomNote,
+    });
+
   const handleAmountChange = (value: number) => {
     if (value > remainingAmount) {
       setWarningMessage(
@@ -199,7 +214,7 @@ export const ApproveTrancheModal = ({
           ? noteValidation.sanitized
           : undefined,
       );
-      approveOnClose();
+      closeWithoutGuard();
     } catch (e) {
       console.error(e);
     } finally {
@@ -225,165 +240,173 @@ export const ApproveTrancheModal = ({
   ]);
 
   return (
-    <Dialog open={approveIsOpen} onOpenChange={approveOnClose}>
-      <DialogContent className="m-0 p-0" hideCloseIcon>
-        <DialogTitle className="text-md -mb-1 px-6 pt-4 font-semibold text-slate-900">
-          Approve Tranche Payment
-        </DialogTitle>
-        <Separator />
-        <div className="px-6 pb-6 text-[0.95rem]">
-          <p className="mb-4 text-slate-500">
-            You are about to approve {granteeName}&apos;s tranche payment. They
-            will be notified via email.
-          </p>
-
-          <div className="mb-6 flex items-center justify-between">
-            <p className="text-slate-500">Tranche Payment</p>
-            <div className="flex items-center">
-              <TokenIcon
-                className="h-5 w-5 rounded-full"
-                alt={`${token} icon`}
-                symbol={token}
-              />
-              <p className="ml-1 font-semibold text-slate-600">
-                {ask} <span className="text-slate-400">{token}</span>
-              </p>
-            </div>
-          </div>
-
-          <div className="mb-6 flex w-full items-center justify-between">
-            <p className="w-full whitespace-nowrap text-slate-500">
-              Approved Amount
+    <>
+      <Dialog
+        open={approveIsOpen}
+        onOpenChange={(open) => {
+          if (!open) requestClose();
+        }}
+      >
+        <DialogContent className="m-0 p-0" hideCloseIcon>
+          <DialogTitle className="text-md -mb-1 px-6 pt-4 font-semibold text-slate-900">
+            Approve Tranche Payment
+          </DialogTitle>
+          <Separator />
+          <div className="px-6 pb-6 text-[0.95rem]">
+            <p className="mb-4 text-slate-500">
+              You are about to approve {granteeName}&apos;s tranche payment.
+              They will be notified via email.
             </p>
-            <div className="flex">
-              <CustomNumberInput
-                value={approvedAmount || 0}
-                onChange={handleAmountChange}
-                min={1}
-                max={maxApprovalAmount}
-              />
-              <div className="flex items-center rounded-r-md border border-l-0 bg-white px-3 text-[0.95rem] text-slate-400">
+
+            <div className="mb-6 flex items-center justify-between">
+              <p className="text-slate-500">Tranche Payment</p>
+              <div className="flex items-center">
                 <TokenIcon
-                  className="mr-1 h-5 w-5 rounded-full"
+                  className="h-5 w-5 rounded-full"
                   alt={`${token} icon`}
                   symbol={token}
                 />
-                {token}
+                <p className="ml-1 font-semibold text-slate-600">
+                  {ask} <span className="text-slate-400">{token}</span>
+                </p>
+              </div>
+            </div>
+
+            <div className="mb-6 flex w-full items-center justify-between">
+              <p className="w-full whitespace-nowrap text-slate-500">
+                Approved Amount
+              </p>
+              <div className="flex">
+                <CustomNumberInput
+                  value={approvedAmount || 0}
+                  onChange={handleAmountChange}
+                  min={1}
+                  max={maxApprovalAmount}
+                />
+                <div className="flex items-center rounded-r-md border border-l-0 bg-white px-3 text-[0.95rem] text-slate-400">
+                  <TokenIcon
+                    className="mr-1 h-5 w-5 rounded-full"
+                    alt={`${token} icon`}
+                    symbol={token}
+                  />
+                  {token}
+                </div>
+              </div>
+            </div>
+
+            {warningMessage && (
+              <p className="mb-4 text-center text-sm text-yellow-500">
+                {warningMessage}
+              </p>
+            )}
+
+            {enableCustomEmail && isCustomEmailOpen && (
+              <CustomNoteEditor
+                id="approve-tranche-custom-note"
+                value={customNote}
+                previewHtml={previewEmailBody}
+                emailType="approval"
+                error={emailError}
+                onChange={(value) => {
+                  const sanitizedNote = sanitizeCustomEmailBody(value);
+                  setCustomNote(value);
+                  setEmailError(
+                    validateCustomEmailNote({
+                      noteHtml: value,
+                      fullEmailHtml: getTrancheApprovedEmailBody({
+                        granteeName,
+                        projectTitle,
+                        sponsorName,
+                        approvedAmount,
+                        token,
+                        salutation,
+                        reviewerNote: sanitizedNote,
+                      }),
+                    }).error,
+                  );
+                }}
+              />
+            )}
+
+            <div className="flex gap-3">
+              <div className="w-1/2" />
+              <Button variant="ghost" onClick={requestClose} disabled={loading}>
+                Close
+              </Button>
+              <div className="flex flex-1">
+                <Button
+                  className={cn(
+                    'flex-1 border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600',
+                    enableCustomEmail
+                      ? 'rounded-l-lg rounded-r-none'
+                      : 'rounded-lg',
+                  )}
+                  disabled={
+                    loading ||
+                    isInvalidApprovalAmount ||
+                    (enableCustomEmail &&
+                      isCustomEmailOpen &&
+                      (!getCustomEmailPlainText(customNote) || !!emailError))
+                  }
+                  onClick={approveTranche}
+                >
+                  {loading ? (
+                    <>
+                      <span className="loading loading-spinner mr-2" />
+                      <span>
+                        {isCustomEmailOpen
+                          ? 'Approving with Custom Note'
+                          : 'Approving'}
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <div className="mr-2 rounded-full bg-emerald-600 p-0.5">
+                        <Check className="size-2.5 text-white" />
+                      </div>
+                      <span>
+                        {isCustomEmailOpen
+                          ? 'Approve with Custom Note'
+                          : 'Approve Tranche'}
+                      </span>
+                    </>
+                  )}
+                </Button>
+                {enableCustomEmail && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        className="rounded-l-none rounded-r-lg border border-l-0 border-emerald-500 bg-emerald-50 px-2 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
+                        disabled={loading}
+                        aria-label="Approve tranche options"
+                      >
+                        <ChevronDown className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="z-70 w-56">
+                      {isCustomEmailOpen ? (
+                        <DropdownMenuItem
+                          onClick={() => setIsCustomEmailOpen(false)}
+                        >
+                          Use default email
+                        </DropdownMenuItem>
+                      ) : (
+                        <DropdownMenuItem
+                          onClick={() => setIsCustomEmailOpen(true)}
+                        >
+                          Approve with custom note
+                        </DropdownMenuItem>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
               </div>
             </div>
           </div>
-
-          {warningMessage && (
-            <p className="mb-4 text-center text-sm text-yellow-500">
-              {warningMessage}
-            </p>
-          )}
-
-          {enableCustomEmail && isCustomEmailOpen && (
-            <CustomNoteEditor
-              id="approve-tranche-custom-note"
-              value={customNote}
-              previewHtml={previewEmailBody}
-              emailType="approval"
-              error={emailError}
-              onChange={(value) => {
-                const sanitizedNote = sanitizeCustomEmailBody(value);
-                setCustomNote(value);
-                setEmailError(
-                  validateCustomEmailNote({
-                    noteHtml: value,
-                    fullEmailHtml: getTrancheApprovedEmailBody({
-                      granteeName,
-                      projectTitle,
-                      sponsorName,
-                      approvedAmount,
-                      token,
-                      salutation,
-                      reviewerNote: sanitizedNote,
-                    }),
-                  }).error,
-                );
-              }}
-            />
-          )}
-
-          <div className="flex gap-3">
-            <div className="w-1/2" />
-            <Button variant="ghost" onClick={approveOnClose} disabled={loading}>
-              Close
-            </Button>
-            <div className="flex flex-1">
-              <Button
-                className={cn(
-                  'flex-1 border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600',
-                  enableCustomEmail
-                    ? 'rounded-l-lg rounded-r-none'
-                    : 'rounded-lg',
-                )}
-                disabled={
-                  loading ||
-                  isInvalidApprovalAmount ||
-                  (enableCustomEmail &&
-                    isCustomEmailOpen &&
-                    (!getCustomEmailPlainText(customNote) || !!emailError))
-                }
-                onClick={approveTranche}
-              >
-                {loading ? (
-                  <>
-                    <span className="loading loading-spinner mr-2" />
-                    <span>
-                      {isCustomEmailOpen
-                        ? 'Approving with Custom Note'
-                        : 'Approving'}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <div className="mr-2 rounded-full bg-emerald-600 p-0.5">
-                      <Check className="size-2.5 text-white" />
-                    </div>
-                    <span>
-                      {isCustomEmailOpen
-                        ? 'Approve with Custom Note'
-                        : 'Approve Tranche'}
-                    </span>
-                  </>
-                )}
-              </Button>
-              {enableCustomEmail && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      className="rounded-l-none rounded-r-lg border border-l-0 border-emerald-500 bg-emerald-50 px-2 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
-                      disabled={loading}
-                      aria-label="Approve tranche options"
-                    >
-                      <ChevronDown className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="z-70 w-56">
-                    {isCustomEmailOpen ? (
-                      <DropdownMenuItem
-                        onClick={() => setIsCustomEmailOpen(false)}
-                      >
-                        Use default email
-                      </DropdownMenuItem>
-                    ) : (
-                      <DropdownMenuItem
-                        onClick={() => setIsCustomEmailOpen(true)}
-                      >
-                        Approve with custom note
-                      </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-            </div>
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+      {discardChangesDialog}
+    </>
   );
 };

--- a/src/features/sponsor-dashboard/components/Traches/ApproveTrancheModal.tsx
+++ b/src/features/sponsor-dashboard/components/Traches/ApproveTrancheModal.tsx
@@ -1,7 +1,6 @@
 import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 
-import { RichEditor } from '@/components/shared/RichEditor';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import {
@@ -13,12 +12,15 @@ import {
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
+import { cn } from '@/utils/cn';
 
 import {
   getCustomEmailPlainText,
-  validateCustomEmailBody,
+  sanitizeCustomEmailBody,
+  validateCustomEmailNote,
 } from '../../utils/customEmailSanitizer';
 import { getTrancheApprovedEmailBody } from '../../utils/grantEmailCopy';
+import { CustomNoteEditor } from '../GrantApplications/Modals/CustomNoteEditor';
 
 const CustomNumberInput = ({
   value,
@@ -117,7 +119,7 @@ interface ApproveModalProps {
   onApproveTranche: (
     trancheId: string,
     approvedAmount: number,
-    emailBody?: string,
+    customNote?: string,
   ) => void;
   grantApprovedAmount: number;
   grantTotalPaid: number;
@@ -139,8 +141,7 @@ export const ApproveTrancheModal = ({
   grantTotalPaid,
 }: ApproveModalProps) => {
   const [approvedAmount, setApprovedAmount] = useState<number | undefined>(ask);
-  const [emailBody, setEmailBody] = useState('');
-  const [hasEditedEmail, setHasEditedEmail] = useState(false);
+  const [customNote, setCustomNote] = useState('');
   const [isCustomEmailOpen, setIsCustomEmailOpen] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
@@ -154,13 +155,14 @@ export const ApproveTrancheModal = ({
     !Number.isFinite(approvedAmount) ||
     approvedAmount === 0 ||
     approvedAmount > maxApprovalAmount;
-  const defaultEmailBody = getTrancheApprovedEmailBody({
+  const previewEmailBody = getTrancheApprovedEmailBody({
     granteeName,
     projectTitle,
     sponsorName,
     approvedAmount,
     token,
     salutation,
+    reviewerNote: sanitizeCustomEmailBody(customNote),
   });
 
   const handleAmountChange = (value: number) => {
@@ -174,27 +176,17 @@ export const ApproveTrancheModal = ({
       setWarningMessage(null);
     }
     setApprovedAmount(value);
-    if (!hasEditedEmail) {
-      setEmailBody(
-        getTrancheApprovedEmailBody({
-          granteeName,
-          projectTitle,
-          sponsorName,
-          approvedAmount: value,
-          token,
-          salutation,
-        }),
-      );
-    }
   };
 
   const approveTranche = async () => {
     if (isInvalidApprovalAmount || !trancheId) return;
 
-    const customEmailBody = emailBody.trim();
-    const emailValidation = validateCustomEmailBody(customEmailBody);
-    if (enableCustomEmail && isCustomEmailOpen && !emailValidation.isValid) {
-      setEmailError(emailValidation.error);
+    const noteValidation = validateCustomEmailNote({
+      noteHtml: customNote.trim(),
+      fullEmailHtml: previewEmailBody,
+    });
+    if (enableCustomEmail && isCustomEmailOpen && !noteValidation.isValid) {
+      setEmailError(noteValidation.error);
       return;
     }
 
@@ -204,7 +196,7 @@ export const ApproveTrancheModal = ({
         trancheId,
         approvedAmount,
         enableCustomEmail && isCustomEmailOpen
-          ? emailValidation.sanitized
+          ? noteValidation.sanitized
           : undefined,
       );
       approveOnClose();
@@ -217,17 +209,7 @@ export const ApproveTrancheModal = ({
 
   useEffect(() => {
     setApprovedAmount(ask);
-    setEmailBody(
-      getTrancheApprovedEmailBody({
-        granteeName,
-        projectTitle,
-        sponsorName,
-        approvedAmount: ask,
-        token,
-        salutation,
-      }),
-    );
-    setHasEditedEmail(false);
+    setCustomNote('');
     setIsCustomEmailOpen(false);
     setEmailError(null);
     setWarningMessage(null);
@@ -298,38 +280,30 @@ export const ApproveTrancheModal = ({
           )}
 
           {enableCustomEmail && isCustomEmailOpen && (
-            <div className="mb-6">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <p className="font-medium text-slate-600">Email Body</p>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="h-auto px-2 py-1 text-xs font-semibold text-slate-500"
-                  onClick={() => {
-                    setEmailBody(defaultEmailBody);
-                    setHasEditedEmail(false);
-                  }}
-                  disabled={loading || emailBody === defaultEmailBody}
-                >
-                  Reset
-                </Button>
-              </div>
-              <RichEditor
-                id="approve-tranche-email-body"
-                height="h-[190px]"
-                value={emailBody}
-                onChange={(value) => {
-                  setEmailBody(value);
-                  setHasEditedEmail(true);
-                  setEmailError(validateCustomEmailBody(value).error);
-                }}
-                error={!!emailError}
-                placeholder="Write the email body"
-              />
-              {emailError && (
-                <p className="mt-2 text-sm text-red-500">{emailError}</p>
-              )}
-            </div>
+            <CustomNoteEditor
+              id="approve-tranche-custom-note"
+              value={customNote}
+              previewHtml={previewEmailBody}
+              error={emailError}
+              onChange={(value) => {
+                const sanitizedNote = sanitizeCustomEmailBody(value);
+                setCustomNote(value);
+                setEmailError(
+                  validateCustomEmailNote({
+                    noteHtml: value,
+                    fullEmailHtml: getTrancheApprovedEmailBody({
+                      granteeName,
+                      projectTitle,
+                      sponsorName,
+                      approvedAmount,
+                      token,
+                      salutation,
+                      reviewerNote: sanitizedNote,
+                    }),
+                  }).error,
+                );
+              }}
+            />
           )}
 
           <div className="flex gap-3">
@@ -339,13 +313,18 @@ export const ApproveTrancheModal = ({
             </Button>
             <div className="flex flex-1">
               <Button
-                className="flex-1 rounded-l-lg rounded-r-none border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
+                className={cn(
+                  'flex-1 border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600',
+                  enableCustomEmail
+                    ? 'rounded-l-lg rounded-r-none'
+                    : 'rounded-lg',
+                )}
                 disabled={
                   loading ||
                   isInvalidApprovalAmount ||
                   (enableCustomEmail &&
                     isCustomEmailOpen &&
-                    (!getCustomEmailPlainText(emailBody) || !!emailError))
+                    (!getCustomEmailPlainText(customNote) || !!emailError))
                 }
                 onClick={approveTranche}
               >
@@ -354,7 +333,7 @@ export const ApproveTrancheModal = ({
                     <span className="loading loading-spinner mr-2" />
                     <span>
                       {isCustomEmailOpen
-                        ? 'Approving with Custom Email'
+                        ? 'Approving with Custom Note'
                         : 'Approving'}
                     </span>
                   </>
@@ -365,7 +344,7 @@ export const ApproveTrancheModal = ({
                     </div>
                     <span>
                       {isCustomEmailOpen
-                        ? 'Approve with Custom Email'
+                        ? 'Approve with Custom Note'
                         : 'Approve Tranche'}
                     </span>
                   </>
@@ -394,7 +373,7 @@ export const ApproveTrancheModal = ({
                       <DropdownMenuItem
                         onClick={() => setIsCustomEmailOpen(true)}
                       >
-                        Approve with custom email
+                        Approve with custom note
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>

--- a/src/features/sponsor-dashboard/components/Traches/ApproveTrancheModal.tsx
+++ b/src/features/sponsor-dashboard/components/Traches/ApproveTrancheModal.tsx
@@ -1,11 +1,24 @@
 import { Check, ChevronDown, ChevronUp } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 
+import { RichEditor } from '@/components/shared/RichEditor';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
+
+import {
+  getCustomEmailPlainText,
+  validateCustomEmailBody,
+} from '../../utils/customEmailSanitizer';
+import { getTrancheApprovedEmailBody } from '../../utils/grantEmailCopy';
 
 const CustomNumberInput = ({
   value,
@@ -96,8 +109,16 @@ interface ApproveModalProps {
   trancheId: string | undefined;
   ask: number | undefined;
   granteeName: string | null | undefined;
+  projectTitle: string | null | undefined;
+  sponsorName: string | null | undefined;
+  salutation: string | null | undefined;
   token: string;
-  onApproveTranche: (trancheId: string, approvedAmount: number) => void;
+  enableCustomEmail: boolean;
+  onApproveTranche: (
+    trancheId: string,
+    approvedAmount: number,
+    emailBody?: string,
+  ) => void;
   grantApprovedAmount: number;
   grantTotalPaid: number;
 }
@@ -108,16 +129,32 @@ export const ApproveTrancheModal = ({
   approveOnClose,
   ask,
   granteeName,
+  projectTitle,
+  sponsorName,
+  salutation,
   token,
+  enableCustomEmail,
   onApproveTranche,
   grantApprovedAmount,
   grantTotalPaid,
 }: ApproveModalProps) => {
   const [approvedAmount, setApprovedAmount] = useState<number | undefined>(ask);
+  const [emailBody, setEmailBody] = useState('');
+  const [hasEditedEmail, setHasEditedEmail] = useState(false);
+  const [isCustomEmailOpen, setIsCustomEmailOpen] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [warningMessage, setWarningMessage] = useState<string | null>(null);
 
   const remainingAmount = grantApprovedAmount - grantTotalPaid;
+  const defaultEmailBody = getTrancheApprovedEmailBody({
+    granteeName,
+    projectTitle,
+    sponsorName,
+    approvedAmount,
+    token,
+    salutation,
+  });
 
   const handleAmountChange = (value: number) => {
     if (value > remainingAmount) {
@@ -130,15 +167,40 @@ export const ApproveTrancheModal = ({
       setWarningMessage(null);
     }
     setApprovedAmount(value);
+    if (!hasEditedEmail) {
+      setEmailBody(
+        getTrancheApprovedEmailBody({
+          granteeName,
+          projectTitle,
+          sponsorName,
+          approvedAmount: value,
+          token,
+          salutation,
+        }),
+      );
+    }
   };
 
   const approveTranche = async () => {
     if (approvedAmount === undefined || approvedAmount === 0 || !trancheId)
       return;
 
+    const customEmailBody = emailBody.trim();
+    const emailValidation = validateCustomEmailBody(customEmailBody);
+    if (enableCustomEmail && isCustomEmailOpen && !emailValidation.isValid) {
+      setEmailError(emailValidation.error);
+      return;
+    }
+
     setLoading(true);
     try {
-      await onApproveTranche(trancheId, approvedAmount);
+      await onApproveTranche(
+        trancheId,
+        approvedAmount,
+        enableCustomEmail && isCustomEmailOpen
+          ? emailValidation.sanitized
+          : undefined,
+      );
       approveOnClose();
     } catch (e) {
       console.error(e);
@@ -149,9 +211,30 @@ export const ApproveTrancheModal = ({
 
   useEffect(() => {
     setApprovedAmount(ask);
+    setEmailBody(
+      getTrancheApprovedEmailBody({
+        granteeName,
+        projectTitle,
+        sponsorName,
+        approvedAmount: ask,
+        token,
+        salutation,
+      }),
+    );
+    setHasEditedEmail(false);
+    setIsCustomEmailOpen(false);
+    setEmailError(null);
     setWarningMessage(null);
     setLoading(false);
-  }, [trancheId, ask]);
+  }, [
+    trancheId,
+    ask,
+    granteeName,
+    projectTitle,
+    sponsorName,
+    salutation,
+    token,
+  ]);
 
   return (
     <Dialog open={approveIsOpen} onOpenChange={approveOnClose}>
@@ -208,34 +291,111 @@ export const ApproveTrancheModal = ({
             </p>
           )}
 
+          {enableCustomEmail && isCustomEmailOpen && (
+            <div className="mb-6">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <p className="font-medium text-slate-600">Email Body</p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="h-auto px-2 py-1 text-xs font-semibold text-slate-500"
+                  onClick={() => {
+                    setEmailBody(defaultEmailBody);
+                    setHasEditedEmail(false);
+                  }}
+                  disabled={loading || emailBody === defaultEmailBody}
+                >
+                  Reset
+                </Button>
+              </div>
+              <RichEditor
+                id="approve-tranche-email-body"
+                height="h-[190px]"
+                value={emailBody}
+                onChange={(value) => {
+                  setEmailBody(value);
+                  setHasEditedEmail(true);
+                  setEmailError(validateCustomEmailBody(value).error);
+                }}
+                error={!!emailError}
+                placeholder="Write the email body"
+              />
+              {emailError && (
+                <p className="mt-2 text-sm text-red-500">{emailError}</p>
+              )}
+            </div>
+          )}
+
           <div className="flex gap-3">
             <div className="w-1/2" />
             <Button variant="ghost" onClick={approveOnClose} disabled={loading}>
               Close
             </Button>
-            <Button
-              className="flex-1 rounded-lg border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
-              disabled={
-                loading ||
-                approvedAmount === 0 ||
-                (warningMessage?.includes('exceeds') ?? false)
-              }
-              onClick={approveTranche}
-            >
-              {loading ? (
-                <>
-                  <span className="loading loading-spinner mr-2" />
-                  <span>Approving</span>
-                </>
-              ) : (
-                <>
-                  <div className="mr-2 rounded-full bg-emerald-600 p-0.5">
-                    <Check className="size-2.5 text-white" />
-                  </div>
-                  <span>Approve Tranche</span>
-                </>
+            <div className="flex flex-1">
+              <Button
+                className="flex-1 rounded-l-lg rounded-r-none border border-emerald-500 bg-emerald-50 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
+                disabled={
+                  loading ||
+                  approvedAmount === 0 ||
+                  (warningMessage?.includes('exceeds') ?? false) ||
+                  (enableCustomEmail &&
+                    isCustomEmailOpen &&
+                    (!getCustomEmailPlainText(emailBody) || !!emailError))
+                }
+                onClick={approveTranche}
+              >
+                {loading ? (
+                  <>
+                    <span className="loading loading-spinner mr-2" />
+                    <span>
+                      {isCustomEmailOpen
+                        ? 'Approving with Custom Email'
+                        : 'Approving'}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <div className="mr-2 rounded-full bg-emerald-600 p-0.5">
+                      <Check className="size-2.5 text-white" />
+                    </div>
+                    <span>
+                      {isCustomEmailOpen
+                        ? 'Approve with Custom Email'
+                        : 'Approve Tranche'}
+                    </span>
+                  </>
+                )}
+              </Button>
+              {enableCustomEmail && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      className="rounded-l-none rounded-r-lg border border-l-0 border-emerald-500 bg-emerald-50 px-2 text-emerald-600 hover:bg-emerald-100 hover:text-emerald-600"
+                      disabled={loading}
+                      aria-label="Approve tranche options"
+                    >
+                      <ChevronDown className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="z-70 w-56">
+                    {isCustomEmailOpen ? (
+                      <DropdownMenuItem
+                        onClick={() => setIsCustomEmailOpen(false)}
+                      >
+                        Use default email
+                      </DropdownMenuItem>
+                    ) : (
+                      <DropdownMenuItem
+                        onClick={() => setIsCustomEmailOpen(true)}
+                      >
+                        Approve with custom email
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
               )}
-            </Button>
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/src/features/sponsor-dashboard/components/Traches/ApproveTrancheModal.tsx
+++ b/src/features/sponsor-dashboard/components/Traches/ApproveTrancheModal.tsx
@@ -284,6 +284,7 @@ export const ApproveTrancheModal = ({
               id="approve-tranche-custom-note"
               value={customNote}
               previewHtml={previewEmailBody}
+              emailType="approval"
               error={emailError}
               onChange={(value) => {
                 const sanitizedNote = sanitizeCustomEmailBody(value);

--- a/src/features/sponsor-dashboard/components/Traches/RejectTrancheModal.tsx
+++ b/src/features/sponsor-dashboard/components/Traches/RejectTrancheModal.tsx
@@ -128,6 +128,7 @@ export const RejectTrancheModal = ({
               id="reject-tranche-custom-note"
               value={customNote}
               previewHtml={previewEmailBody}
+              emailType="rejection"
               error={emailError}
               onChange={(value) => {
                 const sanitizedNote = sanitizeCustomEmailBody(value);

--- a/src/features/sponsor-dashboard/components/Traches/RejectTrancheModal.tsx
+++ b/src/features/sponsor-dashboard/components/Traches/RejectTrancheModal.tsx
@@ -1,7 +1,6 @@
 import { ChevronDown, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
-import { RichEditor } from '@/components/shared/RichEditor';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import {
@@ -12,12 +11,15 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
+import { cn } from '@/utils/cn';
 
 import {
   getCustomEmailPlainText,
-  validateCustomEmailBody,
+  sanitizeCustomEmailBody,
+  validateCustomEmailNote,
 } from '../../utils/customEmailSanitizer';
 import { getTrancheRejectedEmailBody } from '../../utils/grantEmailCopy';
+import { CustomNoteEditor } from '../GrantApplications/Modals/CustomNoteEditor';
 
 interface RejectTrancheProps {
   rejectIsOpen: boolean;
@@ -30,7 +32,7 @@ interface RejectTrancheProps {
   salutation: string | null | undefined;
   token: string;
   enableCustomEmail: boolean;
-  onRejectTranche: (trancheId: string, emailBody?: string) => void;
+  onRejectTranche: (trancheId: string, customNote?: string) => void;
 }
 
 export const RejectTrancheModal = ({
@@ -47,24 +49,27 @@ export const RejectTrancheModal = ({
   onRejectTranche,
 }: RejectTrancheProps) => {
   const [loading, setLoading] = useState<boolean>(false);
-  const [emailBody, setEmailBody] = useState('');
+  const [customNote, setCustomNote] = useState('');
   const [isCustomEmailOpen, setIsCustomEmailOpen] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
 
-  const defaultEmailBody = getTrancheRejectedEmailBody({
+  const previewEmailBody = getTrancheRejectedEmailBody({
     granteeName,
     projectTitle,
     sponsorName,
     salutation,
+    reviewerNote: sanitizeCustomEmailBody(customNote),
   });
 
   const rejectTranche = async () => {
     if (!trancheId) return;
 
-    const customEmailBody = emailBody.trim();
-    const emailValidation = validateCustomEmailBody(customEmailBody);
-    if (enableCustomEmail && isCustomEmailOpen && !emailValidation.isValid) {
-      setEmailError(emailValidation.error);
+    const noteValidation = validateCustomEmailNote({
+      noteHtml: customNote.trim(),
+      fullEmailHtml: previewEmailBody,
+    });
+    if (enableCustomEmail && isCustomEmailOpen && !noteValidation.isValid) {
+      setEmailError(noteValidation.error);
       return;
     }
 
@@ -73,7 +78,7 @@ export const RejectTrancheModal = ({
       await onRejectTranche(
         trancheId,
         enableCustomEmail && isCustomEmailOpen
-          ? emailValidation.sanitized
+          ? noteValidation.sanitized
           : undefined,
       );
     } catch (e) {
@@ -85,11 +90,11 @@ export const RejectTrancheModal = ({
   };
 
   useEffect(() => {
-    setEmailBody(defaultEmailBody);
+    setCustomNote('');
     setIsCustomEmailOpen(false);
     setEmailError(null);
     setLoading(false);
-  }, [trancheId, defaultEmailBody]);
+  }, [trancheId]);
 
   return (
     <Dialog open={rejectIsOpen} onOpenChange={rejectOnClose}>
@@ -119,34 +124,28 @@ export const RejectTrancheModal = ({
           </div>
 
           {enableCustomEmail && isCustomEmailOpen && (
-            <div className="mb-6">
-              <div className="mb-2 flex items-center justify-between gap-3">
-                <p className="font-medium text-slate-600">Email Body</p>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="h-auto px-2 py-1 text-xs font-semibold text-slate-500"
-                  onClick={() => setEmailBody(defaultEmailBody)}
-                  disabled={loading || emailBody === defaultEmailBody}
-                >
-                  Reset
-                </Button>
-              </div>
-              <RichEditor
-                id="reject-tranche-email-body"
-                height="h-[190px]"
-                value={emailBody}
-                onChange={(value) => {
-                  setEmailBody(value);
-                  setEmailError(validateCustomEmailBody(value).error);
-                }}
-                error={!!emailError}
-                placeholder="Write the email body"
-              />
-              {emailError && (
-                <p className="mt-2 text-sm text-red-500">{emailError}</p>
-              )}
-            </div>
+            <CustomNoteEditor
+              id="reject-tranche-custom-note"
+              value={customNote}
+              previewHtml={previewEmailBody}
+              error={emailError}
+              onChange={(value) => {
+                const sanitizedNote = sanitizeCustomEmailBody(value);
+                setCustomNote(value);
+                setEmailError(
+                  validateCustomEmailNote({
+                    noteHtml: value,
+                    fullEmailHtml: getTrancheRejectedEmailBody({
+                      granteeName,
+                      projectTitle,
+                      sponsorName,
+                      salutation,
+                      reviewerNote: sanitizedNote,
+                    }),
+                  }).error,
+                );
+              }}
+            />
           )}
 
           <div className="flex gap-3">
@@ -156,12 +155,17 @@ export const RejectTrancheModal = ({
             </Button>
             <div className="flex flex-1">
               <Button
-                className="flex-1 rounded-l-lg rounded-r-none border border-red-500 bg-red-50 text-red-600 hover:bg-red-100"
+                className={cn(
+                  'flex-1 border border-red-500 bg-red-50 text-red-600 hover:bg-red-100',
+                  enableCustomEmail
+                    ? 'rounded-l-lg rounded-r-none'
+                    : 'rounded-lg',
+                )}
                 disabled={
                   loading ||
                   (enableCustomEmail &&
                     isCustomEmailOpen &&
-                    (!getCustomEmailPlainText(emailBody) || !!emailError))
+                    (!getCustomEmailPlainText(customNote) || !!emailError))
                 }
                 onClick={rejectTranche}
               >
@@ -170,7 +174,7 @@ export const RejectTrancheModal = ({
                     <span className="loading loading-spinner mr-2" />
                     <span>
                       {isCustomEmailOpen
-                        ? 'Rejecting with Custom Email'
+                        ? 'Rejecting with Custom Note'
                         : 'Rejecting'}
                     </span>
                   </>
@@ -181,7 +185,7 @@ export const RejectTrancheModal = ({
                     </div>
                     <span>
                       {isCustomEmailOpen
-                        ? 'Reject with Custom Email'
+                        ? 'Reject with Custom Note'
                         : 'Reject Tranche'}
                     </span>
                   </>
@@ -210,7 +214,7 @@ export const RejectTrancheModal = ({
                       <DropdownMenuItem
                         onClick={() => setIsCustomEmailOpen(true)}
                       >
-                        Reject with custom email
+                        Reject with custom note
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>

--- a/src/features/sponsor-dashboard/components/Traches/RejectTrancheModal.tsx
+++ b/src/features/sponsor-dashboard/components/Traches/RejectTrancheModal.tsx
@@ -13,13 +13,14 @@ import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
 import { cn } from '@/utils/cn';
 
+import { useCustomNoteCloseGuard } from '@/features/sponsor-dashboard/components/GrantApplications/hooks/useCustomNoteCloseGuard';
+import { CustomNoteEditor } from '@/features/sponsor-dashboard/components/GrantApplications/Modals/CustomNoteEditor';
 import {
   getCustomEmailPlainText,
   sanitizeCustomEmailBody,
   validateCustomEmailNote,
-} from '../../utils/customEmailSanitizer';
-import { getTrancheRejectedEmailBody } from '../../utils/grantEmailCopy';
-import { CustomNoteEditor } from '../GrantApplications/Modals/CustomNoteEditor';
+} from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
+import { getTrancheRejectedEmailBody } from '@/features/sponsor-dashboard/utils/grantEmailCopy';
 
 interface RejectTrancheProps {
   rejectIsOpen: boolean;
@@ -61,6 +62,20 @@ export const RejectTrancheModal = ({
     reviewerNote: sanitizeCustomEmailBody(customNote),
   });
 
+  const closeAndDiscardCustomNote = () => {
+    setCustomNote('');
+    setIsCustomEmailOpen(false);
+    setEmailError(null);
+    rejectOnClose();
+  };
+
+  const { closeWithoutGuard, discardChangesDialog, requestClose } =
+    useCustomNoteCloseGuard({
+      customNote,
+      isEnabled: enableCustomEmail && isCustomEmailOpen,
+      onDiscard: closeAndDiscardCustomNote,
+    });
+
   const rejectTranche = async () => {
     if (!trancheId) return;
 
@@ -85,7 +100,7 @@ export const RejectTrancheModal = ({
       console.error(e);
     } finally {
       setLoading(false);
-      rejectOnClose();
+      closeWithoutGuard();
     }
   };
 
@@ -97,134 +112,142 @@ export const RejectTrancheModal = ({
   }, [trancheId]);
 
   return (
-    <Dialog open={rejectIsOpen} onOpenChange={rejectOnClose}>
-      <DialogContent className="m-0 p-0" hideCloseIcon>
-        <DialogTitle className="text-md -mb-1 px-6 pt-4 font-semibold text-slate-900">
-          Reject Tranche Payment
-        </DialogTitle>
-        <Separator />
-        <div className="px-6 pb-6 text-[0.95rem]">
-          <p className="mb-4 text-slate-500">
-            You are about to reject {granteeName}&apos;s tranche payment. They
-            will be notified via email.
-          </p>
+    <>
+      <Dialog
+        open={rejectIsOpen}
+        onOpenChange={(open) => {
+          if (!open) requestClose();
+        }}
+      >
+        <DialogContent className="m-0 p-0" hideCloseIcon>
+          <DialogTitle className="text-md -mb-1 px-6 pt-4 font-semibold text-slate-900">
+            Reject Tranche Payment
+          </DialogTitle>
+          <Separator />
+          <div className="px-6 pb-6 text-[0.95rem]">
+            <p className="mb-4 text-slate-500">
+              You are about to reject {granteeName}&apos;s tranche payment. They
+              will be notified via email.
+            </p>
 
-          <div className="mb-6 flex items-center justify-between">
-            <p className="text-slate-500">Tranche Payment</p>
-            <div className="flex items-center">
-              <TokenIcon
-                className="h-5 w-5 rounded-full"
-                alt={`${token} icon`}
-                symbol={token}
+            <div className="mb-6 flex items-center justify-between">
+              <p className="text-slate-500">Tranche Payment</p>
+              <div className="flex items-center">
+                <TokenIcon
+                  className="h-5 w-5 rounded-full"
+                  alt={`${token} icon`}
+                  symbol={token}
+                />
+                <p className="ml-1 font-semibold text-slate-600">
+                  {ask} <span className="text-slate-400">{token}</span>
+                </p>
+              </div>
+            </div>
+
+            {enableCustomEmail && isCustomEmailOpen && (
+              <CustomNoteEditor
+                id="reject-tranche-custom-note"
+                value={customNote}
+                previewHtml={previewEmailBody}
+                emailType="rejection"
+                error={emailError}
+                onChange={(value) => {
+                  const sanitizedNote = sanitizeCustomEmailBody(value);
+                  setCustomNote(value);
+                  setEmailError(
+                    validateCustomEmailNote({
+                      noteHtml: value,
+                      fullEmailHtml: getTrancheRejectedEmailBody({
+                        granteeName,
+                        projectTitle,
+                        sponsorName,
+                        salutation,
+                        reviewerNote: sanitizedNote,
+                      }),
+                    }).error,
+                  );
+                }}
               />
-              <p className="ml-1 font-semibold text-slate-600">
-                {ask} <span className="text-slate-400">{token}</span>
-              </p>
-            </div>
-          </div>
+            )}
 
-          {enableCustomEmail && isCustomEmailOpen && (
-            <CustomNoteEditor
-              id="reject-tranche-custom-note"
-              value={customNote}
-              previewHtml={previewEmailBody}
-              emailType="rejection"
-              error={emailError}
-              onChange={(value) => {
-                const sanitizedNote = sanitizeCustomEmailBody(value);
-                setCustomNote(value);
-                setEmailError(
-                  validateCustomEmailNote({
-                    noteHtml: value,
-                    fullEmailHtml: getTrancheRejectedEmailBody({
-                      granteeName,
-                      projectTitle,
-                      sponsorName,
-                      salutation,
-                      reviewerNote: sanitizedNote,
-                    }),
-                  }).error,
-                );
-              }}
-            />
-          )}
-
-          <div className="flex gap-3">
-            <div className="w-1/2" />
-            <Button variant="ghost" onClick={rejectOnClose} disabled={loading}>
-              Close
-            </Button>
-            <div className="flex flex-1">
-              <Button
-                className={cn(
-                  'flex-1 border border-red-500 bg-red-50 text-red-600 hover:bg-red-100',
-                  enableCustomEmail
-                    ? 'rounded-l-lg rounded-r-none'
-                    : 'rounded-lg',
-                )}
-                disabled={
-                  loading ||
-                  (enableCustomEmail &&
-                    isCustomEmailOpen &&
-                    (!getCustomEmailPlainText(customNote) || !!emailError))
-                }
-                onClick={rejectTranche}
-              >
-                {loading ? (
-                  <>
-                    <span className="loading loading-spinner mr-2" />
-                    <span>
-                      {isCustomEmailOpen
-                        ? 'Rejecting with Custom Note'
-                        : 'Rejecting'}
-                    </span>
-                  </>
-                ) : (
-                  <>
-                    <div className="rounded-full bg-red-600 p-0.5">
-                      <X className="size-2 text-white" />
-                    </div>
-                    <span>
-                      {isCustomEmailOpen
-                        ? 'Reject with Custom Note'
-                        : 'Reject Tranche'}
-                    </span>
-                  </>
-                )}
+            <div className="flex gap-3">
+              <div className="w-1/2" />
+              <Button variant="ghost" onClick={requestClose} disabled={loading}>
+                Close
               </Button>
-              {enableCustomEmail && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      type="button"
-                      className="rounded-l-none rounded-r-lg border border-l-0 border-red-500 bg-red-50 px-2 text-red-600 hover:bg-red-100"
-                      disabled={loading}
-                      aria-label="Reject tranche options"
-                    >
-                      <ChevronDown className="size-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="z-70 w-56">
-                    {isCustomEmailOpen ? (
-                      <DropdownMenuItem
-                        onClick={() => setIsCustomEmailOpen(false)}
+              <div className="flex flex-1">
+                <Button
+                  className={cn(
+                    'flex-1 border border-red-500 bg-red-50 text-red-600 hover:bg-red-100',
+                    enableCustomEmail
+                      ? 'rounded-l-lg rounded-r-none'
+                      : 'rounded-lg',
+                  )}
+                  disabled={
+                    loading ||
+                    (enableCustomEmail &&
+                      isCustomEmailOpen &&
+                      (!getCustomEmailPlainText(customNote) || !!emailError))
+                  }
+                  onClick={rejectTranche}
+                >
+                  {loading ? (
+                    <>
+                      <span className="loading loading-spinner mr-2" />
+                      <span>
+                        {isCustomEmailOpen
+                          ? 'Rejecting with Custom Note'
+                          : 'Rejecting'}
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <div className="rounded-full bg-red-600 p-0.5">
+                        <X className="size-2 text-white" />
+                      </div>
+                      <span>
+                        {isCustomEmailOpen
+                          ? 'Reject with Custom Note'
+                          : 'Reject Tranche'}
+                      </span>
+                    </>
+                  )}
+                </Button>
+                {enableCustomEmail && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        className="rounded-l-none rounded-r-lg border border-l-0 border-red-500 bg-red-50 px-2 text-red-600 hover:bg-red-100"
+                        disabled={loading}
+                        aria-label="Reject tranche options"
                       >
-                        Use default email
-                      </DropdownMenuItem>
-                    ) : (
-                      <DropdownMenuItem
-                        onClick={() => setIsCustomEmailOpen(true)}
-                      >
-                        Reject with custom note
-                      </DropdownMenuItem>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
+                        <ChevronDown className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="z-70 w-56">
+                      {isCustomEmailOpen ? (
+                        <DropdownMenuItem
+                          onClick={() => setIsCustomEmailOpen(false)}
+                        >
+                          Use default email
+                        </DropdownMenuItem>
+                      ) : (
+                        <DropdownMenuItem
+                          onClick={() => setIsCustomEmailOpen(true)}
+                        >
+                          Reject with custom note
+                        </DropdownMenuItem>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+      {discardChangesDialog}
+    </>
   );
 };

--- a/src/features/sponsor-dashboard/components/Traches/RejectTrancheModal.tsx
+++ b/src/features/sponsor-dashboard/components/Traches/RejectTrancheModal.tsx
@@ -1,10 +1,23 @@
-import { X } from 'lucide-react';
-import { useState } from 'react';
+import { ChevronDown, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
+import { RichEditor } from '@/components/shared/RichEditor';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
 import { TokenIcon } from '@/components/ui/token-icon';
+
+import {
+  getCustomEmailPlainText,
+  validateCustomEmailBody,
+} from '../../utils/customEmailSanitizer';
+import { getTrancheRejectedEmailBody } from '../../utils/grantEmailCopy';
 
 interface RejectTrancheProps {
   rejectIsOpen: boolean;
@@ -12,8 +25,12 @@ interface RejectTrancheProps {
   trancheId: string | undefined;
   ask: number | undefined;
   granteeName: string | null | undefined;
+  projectTitle: string | null | undefined;
+  sponsorName: string | null | undefined;
+  salutation: string | null | undefined;
   token: string;
-  onRejectTranche: (trancheId: string) => void;
+  enableCustomEmail: boolean;
+  onRejectTranche: (trancheId: string, emailBody?: string) => void;
 }
 
 export const RejectTrancheModal = ({
@@ -22,17 +39,43 @@ export const RejectTrancheModal = ({
   rejectOnClose,
   ask,
   granteeName,
+  projectTitle,
+  sponsorName,
+  salutation,
   token,
+  enableCustomEmail,
   onRejectTranche,
 }: RejectTrancheProps) => {
   const [loading, setLoading] = useState<boolean>(false);
+  const [emailBody, setEmailBody] = useState('');
+  const [isCustomEmailOpen, setIsCustomEmailOpen] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  const defaultEmailBody = getTrancheRejectedEmailBody({
+    granteeName,
+    projectTitle,
+    sponsorName,
+    salutation,
+  });
 
   const rejectTranche = async () => {
     if (!trancheId) return;
 
+    const customEmailBody = emailBody.trim();
+    const emailValidation = validateCustomEmailBody(customEmailBody);
+    if (enableCustomEmail && isCustomEmailOpen && !emailValidation.isValid) {
+      setEmailError(emailValidation.error);
+      return;
+    }
+
     setLoading(true);
     try {
-      await onRejectTranche(trancheId);
+      await onRejectTranche(
+        trancheId,
+        enableCustomEmail && isCustomEmailOpen
+          ? emailValidation.sanitized
+          : undefined,
+      );
     } catch (e) {
       console.error(e);
     } finally {
@@ -40,6 +83,13 @@ export const RejectTrancheModal = ({
       rejectOnClose();
     }
   };
+
+  useEffect(() => {
+    setEmailBody(defaultEmailBody);
+    setIsCustomEmailOpen(false);
+    setEmailError(null);
+    setLoading(false);
+  }, [trancheId, defaultEmailBody]);
 
   return (
     <Dialog open={rejectIsOpen} onOpenChange={rejectOnClose}>
@@ -68,30 +118,105 @@ export const RejectTrancheModal = ({
             </div>
           </div>
 
+          {enableCustomEmail && isCustomEmailOpen && (
+            <div className="mb-6">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <p className="font-medium text-slate-600">Email Body</p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="h-auto px-2 py-1 text-xs font-semibold text-slate-500"
+                  onClick={() => setEmailBody(defaultEmailBody)}
+                  disabled={loading || emailBody === defaultEmailBody}
+                >
+                  Reset
+                </Button>
+              </div>
+              <RichEditor
+                id="reject-tranche-email-body"
+                height="h-[190px]"
+                value={emailBody}
+                onChange={(value) => {
+                  setEmailBody(value);
+                  setEmailError(validateCustomEmailBody(value).error);
+                }}
+                error={!!emailError}
+                placeholder="Write the email body"
+              />
+              {emailError && (
+                <p className="mt-2 text-sm text-red-500">{emailError}</p>
+              )}
+            </div>
+          )}
+
           <div className="flex gap-3">
             <div className="w-1/2" />
             <Button variant="ghost" onClick={rejectOnClose} disabled={loading}>
               Close
             </Button>
-            <Button
-              className="flex-1 rounded-lg border border-red-500 bg-red-50 text-red-600 hover:bg-red-100"
-              disabled={loading}
-              onClick={rejectTranche}
-            >
-              {loading ? (
-                <>
-                  <span className="loading loading-spinner mr-2" />
-                  <span>Rejecting</span>
-                </>
-              ) : (
-                <>
-                  <div className="rounded-full bg-red-600 p-0.5">
-                    <X className="size-2 text-white" />
-                  </div>
-                  <span>Reject Tranche</span>
-                </>
+            <div className="flex flex-1">
+              <Button
+                className="flex-1 rounded-l-lg rounded-r-none border border-red-500 bg-red-50 text-red-600 hover:bg-red-100"
+                disabled={
+                  loading ||
+                  (enableCustomEmail &&
+                    isCustomEmailOpen &&
+                    (!getCustomEmailPlainText(emailBody) || !!emailError))
+                }
+                onClick={rejectTranche}
+              >
+                {loading ? (
+                  <>
+                    <span className="loading loading-spinner mr-2" />
+                    <span>
+                      {isCustomEmailOpen
+                        ? 'Rejecting with Custom Email'
+                        : 'Rejecting'}
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <div className="rounded-full bg-red-600 p-0.5">
+                      <X className="size-2 text-white" />
+                    </div>
+                    <span>
+                      {isCustomEmailOpen
+                        ? 'Reject with Custom Email'
+                        : 'Reject Tranche'}
+                    </span>
+                  </>
+                )}
+              </Button>
+              {enableCustomEmail && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      className="rounded-l-none rounded-r-lg border border-l-0 border-red-500 bg-red-50 px-2 text-red-600 hover:bg-red-100"
+                      disabled={loading}
+                      aria-label="Reject tranche options"
+                    >
+                      <ChevronDown className="size-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="z-70 w-56">
+                    {isCustomEmailOpen ? (
+                      <DropdownMenuItem
+                        onClick={() => setIsCustomEmailOpen(false)}
+                      >
+                        Use default email
+                      </DropdownMenuItem>
+                    ) : (
+                      <DropdownMenuItem
+                        onClick={() => setIsCustomEmailOpen(true)}
+                      >
+                        Reject with custom email
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
               )}
-            </Button>
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/src/features/sponsor-dashboard/components/TranchesTab.tsx
+++ b/src/features/sponsor-dashboard/components/TranchesTab.tsx
@@ -143,13 +143,21 @@ export const TranchesTab = ({ slug }: Props) => {
   };
 
   const rejectGrantMutation = useMutation({
-    mutationFn: async (trancheId: string) => {
+    mutationFn: async ({
+      trancheId,
+      emailBody,
+    }: {
+      trancheId: string;
+      emailBody?: string;
+    }) => {
+      const customEmailBody = emailBody?.trim();
       await api.post('/api/sponsor-dashboard/grants/update-tranche-status', {
         id: trancheId,
         status: 'Rejected',
+        ...(customEmailBody ? { emailBody: customEmailBody } : {}),
       });
     },
-    onMutate: async (trancheId) => {
+    onMutate: async ({ trancheId }) => {
       const previousTranches = queryClient.getQueryData<TranchesReturn>([
         'sponsor-tranches',
         grant?.slug,
@@ -195,14 +203,18 @@ export const TranchesTab = ({ slug }: Props) => {
     mutationFn: async ({
       trancheId,
       approvedAmount,
+      emailBody,
     }: {
       trancheId: string;
       approvedAmount: number;
+      emailBody?: string;
     }) => {
+      const customEmailBody = emailBody?.trim();
       await api.post('/api/sponsor-dashboard/grants/update-tranche-status', {
         id: trancheId,
         status: 'Approved',
         approvedAmount,
+        ...(customEmailBody ? { emailBody: customEmailBody } : {}),
       });
     },
     onMutate: async ({ trancheId, approvedAmount }) => {
@@ -248,12 +260,16 @@ export const TranchesTab = ({ slug }: Props) => {
     },
   });
 
-  const handleApproveTranche = (trancheId: string, approvedAmount: number) => {
-    approveGrantMutation.mutate({ trancheId, approvedAmount });
+  const handleApproveTranche = (
+    trancheId: string,
+    approvedAmount: number,
+    emailBody?: string,
+  ) => {
+    approveGrantMutation.mutate({ trancheId, approvedAmount, emailBody });
   };
 
-  const handleRejectTranche = (trancheId: string) => {
-    rejectGrantMutation.mutate(trancheId);
+  const handleRejectTranche = (trancheId: string, emailBody?: string) => {
+    rejectGrantMutation.mutate({ trancheId, emailBody });
   };
   return (
     <>
@@ -311,7 +327,11 @@ export const TranchesTab = ({ slug }: Props) => {
         rejectOnClose={rejectedOnClose}
         ask={selectedTranche?.ask}
         granteeName={selectedTranche?.GrantApplication?.user?.firstName}
+        projectTitle={selectedTranche?.GrantApplication?.projectTitle}
+        sponsorName={grant?.sponsor?.name}
+        salutation={grant?.emailSalutation}
         token={grant?.token || 'USDC'}
+        enableCustomEmail={grant?.isNative === true}
         onRejectTranche={handleRejectTranche}
       />
 
@@ -321,7 +341,11 @@ export const TranchesTab = ({ slug }: Props) => {
         approveOnClose={approveOnClose}
         ask={selectedTranche?.ask}
         granteeName={selectedTranche?.GrantApplication?.user?.firstName}
+        projectTitle={selectedTranche?.GrantApplication?.projectTitle}
+        sponsorName={grant?.sponsor?.name}
+        salutation={grant?.emailSalutation}
         token={grant?.token || 'USDC'}
+        enableCustomEmail={grant?.isNative === true}
         onApproveTranche={handleApproveTranche}
         grantApprovedAmount={
           selectedTranche?.GrantApplication?.approvedAmount || 0

--- a/src/features/sponsor-dashboard/components/TranchesTab.tsx
+++ b/src/features/sponsor-dashboard/components/TranchesTab.tsx
@@ -271,6 +271,9 @@ export const TranchesTab = ({ slug }: Props) => {
   const handleRejectTranche = (trancheId: string, customNote?: string) => {
     rejectGrantMutation.mutate({ trancheId, customNote });
   };
+
+  const enableCustomEmail = grant?.isNative === true || grant?.isST === true;
+
   return (
     <>
       <div className="flex w-full items-start bg-white">
@@ -331,7 +334,7 @@ export const TranchesTab = ({ slug }: Props) => {
         sponsorName={grant?.sponsor?.name}
         salutation={grant?.emailSalutation}
         token={grant?.token || 'USDC'}
-        enableCustomEmail={grant?.isNative === true}
+        enableCustomEmail={enableCustomEmail}
         onRejectTranche={handleRejectTranche}
       />
 
@@ -345,7 +348,7 @@ export const TranchesTab = ({ slug }: Props) => {
         sponsorName={grant?.sponsor?.name}
         salutation={grant?.emailSalutation}
         token={grant?.token || 'USDC'}
-        enableCustomEmail={grant?.isNative === true}
+        enableCustomEmail={enableCustomEmail}
         onApproveTranche={handleApproveTranche}
         grantApprovedAmount={
           selectedTranche?.GrantApplication?.approvedAmount || 0

--- a/src/features/sponsor-dashboard/components/TranchesTab.tsx
+++ b/src/features/sponsor-dashboard/components/TranchesTab.tsx
@@ -145,16 +145,16 @@ export const TranchesTab = ({ slug }: Props) => {
   const rejectGrantMutation = useMutation({
     mutationFn: async ({
       trancheId,
-      emailBody,
+      customNote,
     }: {
       trancheId: string;
-      emailBody?: string;
+      customNote?: string;
     }) => {
-      const customEmailBody = emailBody?.trim();
+      const reviewerNote = customNote?.trim();
       await api.post('/api/sponsor-dashboard/grants/update-tranche-status', {
         id: trancheId,
         status: 'Rejected',
-        ...(customEmailBody ? { emailBody: customEmailBody } : {}),
+        ...(reviewerNote ? { customNote: reviewerNote } : {}),
       });
     },
     onMutate: async ({ trancheId }) => {
@@ -203,18 +203,18 @@ export const TranchesTab = ({ slug }: Props) => {
     mutationFn: async ({
       trancheId,
       approvedAmount,
-      emailBody,
+      customNote,
     }: {
       trancheId: string;
       approvedAmount: number;
-      emailBody?: string;
+      customNote?: string;
     }) => {
-      const customEmailBody = emailBody?.trim();
+      const reviewerNote = customNote?.trim();
       await api.post('/api/sponsor-dashboard/grants/update-tranche-status', {
         id: trancheId,
         status: 'Approved',
         approvedAmount,
-        ...(customEmailBody ? { emailBody: customEmailBody } : {}),
+        ...(reviewerNote ? { customNote: reviewerNote } : {}),
       });
     },
     onMutate: async ({ trancheId, approvedAmount }) => {
@@ -263,13 +263,13 @@ export const TranchesTab = ({ slug }: Props) => {
   const handleApproveTranche = (
     trancheId: string,
     approvedAmount: number,
-    emailBody?: string,
+    customNote?: string,
   ) => {
-    approveGrantMutation.mutate({ trancheId, approvedAmount, emailBody });
+    approveGrantMutation.mutate({ trancheId, approvedAmount, customNote });
   };
 
-  const handleRejectTranche = (trancheId: string, emailBody?: string) => {
-    rejectGrantMutation.mutate({ trancheId, emailBody });
+  const handleRejectTranche = (trancheId: string, customNote?: string) => {
+    rejectGrantMutation.mutate({ trancheId, customNote });
   };
   return (
     <>

--- a/src/features/sponsor-dashboard/mutations/useRejectGrantApplications.ts
+++ b/src/features/sponsor-dashboard/mutations/useRejectGrantApplications.ts
@@ -9,6 +9,23 @@ import { selectedGrantApplicationAtom } from '../atoms';
 import { type GrantApplicationsReturn } from '../queries/applications';
 import { type GrantApplicationWithUser } from '../types';
 
+type RejectGrantApplicationsInput =
+  | string[]
+  | {
+      applicationIds: string[];
+      emailBody?: string;
+    };
+
+const parseRejectGrantApplicationsInput = (
+  input: RejectGrantApplicationsInput,
+) => {
+  if (Array.isArray(input)) {
+    return { applicationIds: input };
+  }
+
+  return input;
+};
+
 export const useRejectGrantApplications = (slug: string) => {
   const queryClient = useQueryClient();
   const [selectedApplication, setSelectedApplication] = useAtom(
@@ -54,7 +71,10 @@ export const useRejectGrantApplications = (slug: string) => {
   };
 
   return useMutation({
-    mutationFn: async (applicationIds: string[]) => {
+    mutationFn: async (input: RejectGrantApplicationsInput) => {
+      const { applicationIds, emailBody } =
+        parseRejectGrantApplicationsInput(input);
+      const customEmailBody = emailBody?.trim();
       const batchSize = 10;
       for (let i = 0; i < applicationIds.length; i += batchSize) {
         const batch = applicationIds.slice(i, i + batchSize);
@@ -63,12 +83,15 @@ export const useRejectGrantApplications = (slug: string) => {
           {
             data: batch.map((id) => ({ id })),
             applicationStatus: 'Rejected',
+            ...(customEmailBody ? { emailBody: customEmailBody } : {}),
           },
         );
       }
       return applicationIds;
     },
-    onMutate: async (applicationIds) => {
+    onMutate: async (input) => {
+      const { applicationIds } = parseRejectGrantApplicationsInput(input);
+
       await queryClient.cancelQueries({
         queryKey: ['sponsor-applications', slug],
       });
@@ -120,7 +143,9 @@ export const useRejectGrantApplications = (slug: string) => {
 
       return { previousApplications };
     },
-    onError: (_, applicationIds, context) => {
+    onError: (_, input, context) => {
+      const { applicationIds } = parseRejectGrantApplicationsInput(input);
+
       if (context?.previousApplications) {
         queryClient.setQueryData<GrantApplicationsReturn>(
           ['sponsor-applications', slug],

--- a/src/features/sponsor-dashboard/mutations/useRejectGrantApplications.ts
+++ b/src/features/sponsor-dashboard/mutations/useRejectGrantApplications.ts
@@ -13,7 +13,7 @@ type RejectGrantApplicationsInput =
   | string[]
   | {
       applicationIds: string[];
-      emailBody?: string;
+      customNote?: string;
     };
 
 const parseRejectGrantApplicationsInput = (
@@ -72,9 +72,9 @@ export const useRejectGrantApplications = (slug: string) => {
 
   return useMutation({
     mutationFn: async (input: RejectGrantApplicationsInput) => {
-      const { applicationIds, emailBody } =
+      const { applicationIds, customNote } =
         parseRejectGrantApplicationsInput(input);
-      const customEmailBody = emailBody?.trim();
+      const reviewerNote = customNote?.trim();
       const batchSize = 10;
       for (let i = 0; i < applicationIds.length; i += batchSize) {
         const batch = applicationIds.slice(i, i + batchSize);
@@ -83,7 +83,7 @@ export const useRejectGrantApplications = (slug: string) => {
           {
             data: batch.map((id) => ({ id })),
             applicationStatus: 'Rejected',
-            ...(customEmailBody ? { emailBody: customEmailBody } : {}),
+            ...(reviewerNote ? { customNote: reviewerNote } : {}),
           },
         );
       }

--- a/src/features/sponsor-dashboard/utils/customEmailSanitizer.ts
+++ b/src/features/sponsor-dashboard/utils/customEmailSanitizer.ts
@@ -1,0 +1,48 @@
+import { domPurify } from '@/lib/domPurify';
+
+const EMAIL_ALLOWED_TAGS = ['a', 'br', 'em', 'li', 'ol', 'p', 'strong', 'ul'];
+
+const EMAIL_ALLOWED_ATTR = ['href', 'rel', 'target'];
+
+const normalizeHtml = (html: string) => html.trim().replace(/\s+/g, ' ');
+
+export const getCustomEmailPlainText = (html: string) =>
+  html
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .trim();
+
+export const sanitizeCustomEmailBody = (html: string) =>
+  domPurify(html, {
+    ALLOWED_TAGS: EMAIL_ALLOWED_TAGS,
+    ALLOWED_ATTR: EMAIL_ALLOWED_ATTR,
+  }).trim();
+
+export const validateCustomEmailBody = (html: string) => {
+  const sanitized = sanitizeCustomEmailBody(html);
+
+  if (!getCustomEmailPlainText(sanitized)) {
+    return {
+      isValid: false,
+      sanitized,
+      error: 'Email body cannot be empty.',
+    };
+  }
+
+  if (normalizeHtml(sanitized) !== normalizeHtml(html)) {
+    return {
+      isValid: false,
+      sanitized,
+      error:
+        'Email body contains unsupported or unsafe HTML. Please remove scripts, embeds, or unsupported formatting.',
+    };
+  }
+
+  return {
+    isValid: true,
+    sanitized,
+    error: null,
+  };
+};

--- a/src/features/sponsor-dashboard/utils/customEmailSanitizer.ts
+++ b/src/features/sponsor-dashboard/utils/customEmailSanitizer.ts
@@ -1,9 +1,19 @@
 import { domPurify } from '@/lib/domPurify';
 
-const EMAIL_ALLOWED_TAGS = ['a', 'br', 'em', 'li', 'ol', 'p', 'strong', 'ul'];
+const EMAIL_ALLOWED_TAGS = [
+  'a',
+  'br',
+  'em',
+  'li',
+  'ol',
+  'p',
+  'strong',
+  'u',
+  'ul',
+];
 
 const EMAIL_ALLOWED_ATTR = ['href', 'rel', 'target'];
-export const CUSTOM_EMAIL_MAX_CHARS = 5000;
+export const CUSTOM_EMAIL_MAX_CHARS = 4000;
 
 const normalizeHtml = (html: string) => html.trim().replace(/\s+/g, ' ');
 

--- a/src/features/sponsor-dashboard/utils/customEmailSanitizer.ts
+++ b/src/features/sponsor-dashboard/utils/customEmailSanitizer.ts
@@ -3,6 +3,7 @@ import { domPurify } from '@/lib/domPurify';
 const EMAIL_ALLOWED_TAGS = ['a', 'br', 'em', 'li', 'ol', 'p', 'strong', 'ul'];
 
 const EMAIL_ALLOWED_ATTR = ['href', 'rel', 'target'];
+export const CUSTOM_EMAIL_MAX_CHARS = 5000;
 
 const normalizeHtml = (html: string) => html.trim().replace(/\s+/g, ' ');
 
@@ -37,6 +38,48 @@ export const validateCustomEmailBody = (html: string) => {
       sanitized,
       error:
         'Email body contains unsupported or unsafe HTML. Please remove scripts, embeds, or unsupported formatting.',
+    };
+  }
+
+  return {
+    isValid: true,
+    sanitized,
+    error: null,
+  };
+};
+
+export const validateCustomEmailNote = ({
+  noteHtml,
+  fullEmailHtml,
+}: {
+  noteHtml: string;
+  fullEmailHtml: string;
+}) => {
+  const sanitized = sanitizeCustomEmailBody(noteHtml);
+  const fullEmailPlainText = getCustomEmailPlainText(fullEmailHtml);
+
+  if (!getCustomEmailPlainText(sanitized)) {
+    return {
+      isValid: false,
+      sanitized,
+      error: 'Custom note cannot be empty.',
+    };
+  }
+
+  if (normalizeHtml(sanitized) !== normalizeHtml(noteHtml)) {
+    return {
+      isValid: false,
+      sanitized,
+      error:
+        'Custom note contains unsupported or unsafe HTML. Please remove scripts, embeds, or unsupported formatting.',
+    };
+  }
+
+  if (fullEmailPlainText.length > CUSTOM_EMAIL_MAX_CHARS) {
+    return {
+      isValid: false,
+      sanitized,
+      error: `Email must be ${CUSTOM_EMAIL_MAX_CHARS.toLocaleString()} characters or fewer including the note.`,
     };
   }
 

--- a/src/features/sponsor-dashboard/utils/grantEmailCopy.ts
+++ b/src/features/sponsor-dashboard/utils/grantEmailCopy.ts
@@ -1,0 +1,112 @@
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+export const getGrantApprovedEmailBody = ({
+  granteeName,
+  grantTitle,
+  projectTitle,
+  approvedAmount,
+  token,
+  salutation,
+}: {
+  granteeName?: string | null;
+  grantTitle?: string;
+  projectTitle?: string | null;
+  approvedAmount?: number;
+  token: string;
+  salutation?: string | null;
+}) => {
+  const greetingName = escapeHtml(granteeName?.trim() || 'there');
+  const title = escapeHtml(grantTitle?.trim() || 'the grant');
+  const applicationTitle = escapeHtml(projectTitle?.trim() || 'your project');
+  const tokenText = escapeHtml(token);
+  const amountText = approvedAmount
+    ? ` for ${approvedAmount} ${tokenText}`
+    : '';
+  const signoff = escapeHtml(salutation?.trim() || 'Best, Superteam Earn');
+
+  return `<p>Hi ${greetingName},</p><p></p>
+<p>Your application to <strong>${title}</strong> for <strong>${applicationTitle}</strong> has been approved${amountText}. Congratulations!</p>
+<p>Here are the next steps:</p>
+<ul><li>Once you receive your first tranche and make significant progress on your project, share an update to claim your next tranche from the grant listing page.</li></ul>
+<p><strong>Note:</strong> Payments for this grant will be made in USDG. If your wallet is not compatible with USDG, please reach out to us immediately. Once payments are sent for processing (on Monday noon UTC), we won't be able to update your wallet address.</p><p></p>
+<p>${signoff}</p>`;
+};
+
+export const getGrantRejectedEmailBody = ({
+  granteeName,
+  grantTitle,
+  projectTitle,
+  salutation,
+}: {
+  granteeName?: string | null;
+  grantTitle?: string;
+  projectTitle?: string | null;
+  salutation?: string | null;
+}) => {
+  const greetingName = escapeHtml(granteeName?.trim() || 'there');
+  const title = escapeHtml(grantTitle?.trim() || 'the grant');
+  const applicationTitle = escapeHtml(projectTitle?.trim() || 'your project');
+  const signoff = escapeHtml(salutation?.trim() || 'Best, Superteam Earn');
+
+  return `<p>Hey ${greetingName},</p><p></p>
+<p>Unfortunately, your grant application for <strong>${applicationTitle}</strong> under <strong>${title}</strong> has been rejected. Please note that it is not possible for us or the sponsor to share individual feedback on your grant application.</p><p></p>
+<p>We hope you continue adding to your proof of work by submitting to bounties and projects, and winning some along the way. All the best!</p><p></p>
+<p>${signoff}</p>`;
+};
+
+export const getTrancheApprovedEmailBody = ({
+  granteeName,
+  projectTitle,
+  sponsorName,
+  approvedAmount,
+  token,
+  salutation,
+}: {
+  granteeName?: string | null;
+  projectTitle?: string | null;
+  sponsorName?: string | null;
+  approvedAmount?: number;
+  token: string;
+  salutation?: string | null;
+}) => {
+  const greetingName = escapeHtml(granteeName?.trim() || 'there');
+  const title = escapeHtml(projectTitle?.trim() || 'your project');
+  const sponsor = escapeHtml(sponsorName?.trim() || 'the sponsor');
+  const tokenText = escapeHtml(token);
+  const amountText = approvedAmount
+    ? ` for ${approvedAmount} ${tokenText}`
+    : '';
+  const signoff = escapeHtml(salutation?.trim() || 'Best, Superteam Earn');
+
+  return `<p>Hi ${greetingName},</p><p></p>
+<p>Your tranche request for <strong>${title}</strong> has been accepted by ${sponsor}${amountText}. Congratulations! You should receive your payment in a few days.</p><p></p>
+<p><strong>Note:</strong> Payments for this grant will be made in USDG. If your wallet is not compatible with USDG, please reach out to us immediately. Once payments are sent for processing (on Monday noon UTC), we won't be able to update your wallet address.</p><p></p>
+<p>${signoff}</p>`;
+};
+
+export const getTrancheRejectedEmailBody = ({
+  granteeName,
+  projectTitle,
+  sponsorName,
+  salutation,
+}: {
+  granteeName?: string | null;
+  projectTitle?: string | null;
+  sponsorName?: string | null;
+  salutation?: string | null;
+}) => {
+  const greetingName = escapeHtml(granteeName?.trim() || 'there');
+  const title = escapeHtml(projectTitle?.trim() || 'your project');
+  const sponsor = escapeHtml(sponsorName?.trim() || 'the sponsor');
+  const signoff = escapeHtml(salutation?.trim() || 'Best, Superteam Earn');
+
+  return `<p>Hi ${greetingName},</p><p></p>
+<p>Unfortunately, your tranche request for <strong>${title}</strong> has been rejected by ${sponsor}. Please get in touch with the sponsor directly to discuss further.</p><p></p>
+<p>${signoff}</p>`;
+};

--- a/src/features/sponsor-dashboard/utils/grantEmailCopy.ts
+++ b/src/features/sponsor-dashboard/utils/grantEmailCopy.ts
@@ -6,6 +6,16 @@ const escapeHtml = (value: string) =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 
+const reviewerNoteBlock = (reviewerNote?: string) =>
+  reviewerNote
+    ? `<p>Additionally, here's a note from the grant reviewer:</p>${reviewerNote}`
+    : '';
+
+const rejectionNoteBlock = (reviewerNote?: string) =>
+  reviewerNote
+    ? `<p>Here's a note from the grant reviewer:</p>${reviewerNote}`
+    : '';
+
 export const getGrantApprovedEmailBody = ({
   granteeName,
   grantTitle,
@@ -13,6 +23,7 @@ export const getGrantApprovedEmailBody = ({
   approvedAmount,
   token,
   salutation,
+  reviewerNote,
 }: {
   granteeName?: string | null;
   grantTitle?: string;
@@ -20,6 +31,7 @@ export const getGrantApprovedEmailBody = ({
   approvedAmount?: number;
   token: string;
   salutation?: string | null;
+  reviewerNote?: string;
 }) => {
   const greetingName = escapeHtml(granteeName?.trim() || 'there');
   const title = escapeHtml(grantTitle?.trim() || 'the grant');
@@ -30,11 +42,12 @@ export const getGrantApprovedEmailBody = ({
     : '';
   const signoff = escapeHtml(salutation?.trim() || 'Best, Superteam Earn');
 
-  return `<p>Hi ${greetingName},</p><p></p>
+  return `<p>Hi ${greetingName},</p>
 <p>Your application to <strong>${title}</strong> for <strong>${applicationTitle}</strong> has been approved${amountText}. Congratulations!</p>
 <p>Here are the next steps:</p>
 <ul><li>Once you receive your first tranche and make significant progress on your project, share an update to claim your next tranche from the grant listing page.</li></ul>
-<p><strong>Note:</strong> Payments for this grant will be made in USDG. If your wallet is not compatible with USDG, please reach out to us immediately. Once payments are sent for processing (on Monday noon UTC), we won't be able to update your wallet address.</p><p></p>
+${reviewerNoteBlock(reviewerNote)}
+<p><strong>Note:</strong> Payments for this grant will be made in USDG. If your wallet is not compatible with USDG, please reach out to us immediately. Once payments are sent for processing (on Monday noon UTC), we won't be able to update your wallet address.</p>
 <p>${signoff}</p>`;
 };
 
@@ -43,20 +56,23 @@ export const getGrantRejectedEmailBody = ({
   grantTitle,
   projectTitle,
   salutation,
+  reviewerNote,
 }: {
   granteeName?: string | null;
   grantTitle?: string;
   projectTitle?: string | null;
   salutation?: string | null;
+  reviewerNote?: string;
 }) => {
   const greetingName = escapeHtml(granteeName?.trim() || 'there');
   const title = escapeHtml(grantTitle?.trim() || 'the grant');
   const applicationTitle = escapeHtml(projectTitle?.trim() || 'your project');
   const signoff = escapeHtml(salutation?.trim() || 'Best, Superteam Earn');
 
-  return `<p>Hey ${greetingName},</p><p></p>
-<p>Unfortunately, your grant application for <strong>${applicationTitle}</strong> under <strong>${title}</strong> has been rejected. Please note that it is not possible for us or the sponsor to share individual feedback on your grant application.</p><p></p>
-<p>We hope you continue adding to your proof of work by submitting to bounties and projects, and winning some along the way. All the best!</p><p></p>
+  return `<p>Hey ${greetingName},</p>
+<p>Unfortunately, your grant application for <strong>${applicationTitle}</strong> under <strong>${title}</strong> has been rejected.</p>
+${reviewerNote ? rejectionNoteBlock(reviewerNote) : '<p>Please note that it is not possible for us or the sponsor to share individual feedback on your grant application.</p>'}
+<p>We hope you continue adding to your proof of work by submitting to bounties and projects, and winning some along the way. All the best!</p>
 <p>${signoff}</p>`;
 };
 
@@ -67,6 +83,7 @@ export const getTrancheApprovedEmailBody = ({
   approvedAmount,
   token,
   salutation,
+  reviewerNote,
 }: {
   granteeName?: string | null;
   projectTitle?: string | null;
@@ -74,6 +91,7 @@ export const getTrancheApprovedEmailBody = ({
   approvedAmount?: number;
   token: string;
   salutation?: string | null;
+  reviewerNote?: string;
 }) => {
   const greetingName = escapeHtml(granteeName?.trim() || 'there');
   const title = escapeHtml(projectTitle?.trim() || 'your project');
@@ -84,9 +102,10 @@ export const getTrancheApprovedEmailBody = ({
     : '';
   const signoff = escapeHtml(salutation?.trim() || 'Best, Superteam Earn');
 
-  return `<p>Hi ${greetingName},</p><p></p>
-<p>Your tranche request for <strong>${title}</strong> has been accepted by ${sponsor}${amountText}. Congratulations! You should receive your payment in a few days.</p><p></p>
-<p><strong>Note:</strong> Payments for this grant will be made in USDG. If your wallet is not compatible with USDG, please reach out to us immediately. Once payments are sent for processing (on Monday noon UTC), we won't be able to update your wallet address.</p><p></p>
+  return `<p>Hi ${greetingName},</p>
+<p>Your tranche request for <strong>${title}</strong> has been accepted by ${sponsor}${amountText}. Congratulations! You should receive your payment in a few days.</p>
+${reviewerNoteBlock(reviewerNote)}
+<p><strong>Note:</strong> Payments for this grant will be made in USDG. If your wallet is not compatible with USDG, please reach out to us immediately. Once payments are sent for processing (on Monday noon UTC), we won't be able to update your wallet address.</p>
 <p>${signoff}</p>`;
 };
 
@@ -95,18 +114,21 @@ export const getTrancheRejectedEmailBody = ({
   projectTitle,
   sponsorName,
   salutation,
+  reviewerNote,
 }: {
   granteeName?: string | null;
   projectTitle?: string | null;
   sponsorName?: string | null;
   salutation?: string | null;
+  reviewerNote?: string;
 }) => {
   const greetingName = escapeHtml(granteeName?.trim() || 'there');
   const title = escapeHtml(projectTitle?.trim() || 'your project');
   const sponsor = escapeHtml(sponsorName?.trim() || 'the sponsor');
   const signoff = escapeHtml(salutation?.trim() || 'Best, Superteam Earn');
 
-  return `<p>Hi ${greetingName},</p><p></p>
-<p>Unfortunately, your tranche request for <strong>${title}</strong> has been rejected by ${sponsor}. Please get in touch with the sponsor directly to discuss further.</p><p></p>
+  return `<p>Hi ${greetingName},</p>
+<p>Unfortunately, your tranche request for <strong>${title}</strong> has been rejected by ${sponsor}.</p>
+${reviewerNote ? rejectionNoteBlock(reviewerNote) : '<p>Please get in touch with the sponsor directly to discuss further.</p>'}
 <p>${signoff}</p>`;
 };

--- a/src/pages/api/sponsor-dashboard/grants/update-application-status.ts
+++ b/src/pages/api/sponsor-dashboard/grants/update-application-status.ts
@@ -18,7 +18,11 @@ import { queueEmail } from '@/features/emails/utils/queueEmail';
 import { convertGrantApplicationToAirtable } from '@/features/grants/utils/convertGrantApplicationToAirtable';
 import { createTranche } from '@/features/grants/utils/createTranche';
 import { COINDCX_GRANT_ID } from '@/features/grants/utils/stGrant';
-import { validateCustomEmailBody } from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
+import { validateCustomEmailNote } from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
+import {
+  getGrantApprovedEmailBody,
+  getGrantRejectedEmailBody,
+} from '@/features/sponsor-dashboard/utils/grantEmailCopy';
 import { fetchTokenUSDValue } from '@/features/wallet/utils/fetchTokenUSDValue';
 
 const MAX_RECORDS = 10;
@@ -34,7 +38,7 @@ const UpdateGrantApplicationSchema = z.object({
     .min(1, 'Data array cannot be empty')
     .max(MAX_RECORDS, `Only max ${MAX_RECORDS} records allowed in data`),
   applicationStatus: z.string(),
-  emailBody: z.string().trim().min(1).max(5000).optional(),
+  customNote: z.string().trim().min(1).max(5000).optional(),
 });
 
 const checkAndUpdateKYCStatus = async (
@@ -112,18 +116,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     });
   }
 
-  const { data, applicationStatus, emailBody } = validationResult.data;
-  const emailValidation = emailBody ? validateCustomEmailBody(emailBody) : null;
-
-  if (emailValidation && !emailValidation.isValid) {
-    logger.warn('Invalid custom email body:', emailValidation.error);
-    return res.status(400).json({
-      error: 'Invalid custom email body',
-      details: emailValidation.error,
-    });
-  }
-
-  const sanitizedEmailBody = emailValidation?.sanitized;
+  const { data, applicationStatus, customNote } = validationResult.data;
 
   try {
     const currentApplications = await prisma.grantApplication.findMany({
@@ -134,6 +127,11 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       },
       include: {
         grant: true,
+        user: {
+          select: {
+            firstName: true,
+          },
+        },
       },
     });
 
@@ -172,13 +170,49 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       return res.status(authError.status).json({ error: authError.message });
     }
 
+    const isApproved = applicationStatus === 'Approved';
+    let sanitizedCustomNote: string | undefined;
+    if (customNote) {
+      for (const [index, application] of currentApplications.entries()) {
+        const approvedAmount = data[index]?.approvedAmount ?? undefined;
+        const fullEmailHtml = isApproved
+          ? getGrantApprovedEmailBody({
+              granteeName: application.user?.firstName,
+              grantTitle: application.grant.title,
+              projectTitle: application.projectTitle,
+              approvedAmount: approvedAmount ?? undefined,
+              token: application.grant.token || 'USDC',
+              salutation: application.grant.emailSalutation,
+              reviewerNote: customNote,
+            })
+          : getGrantRejectedEmailBody({
+              granteeName: application.user?.firstName,
+              grantTitle: application.grant.title,
+              projectTitle: application.projectTitle,
+              salutation: application.grant.emailSalutation,
+              reviewerNote: customNote,
+            });
+        const noteValidation = validateCustomEmailNote({
+          noteHtml: customNote,
+          fullEmailHtml,
+        });
+        if (!noteValidation.isValid) {
+          logger.warn('Invalid custom note:', noteValidation.error);
+          return res.status(400).json({
+            error: 'Invalid custom note',
+            details: noteValidation.error,
+          });
+        }
+        sanitizedCustomNote = noteValidation.sanitized;
+      }
+    }
+
     const commonUpdateField = {
       applicationStatus,
       decidedAt: new Date().toISOString(),
       decidedBy: userId,
     };
 
-    const isApproved = applicationStatus === 'Approved';
     const updatedData: {
       applicationStatus: string;
       decidedAt: string;
@@ -298,9 +332,9 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
             id: r.id,
             userId: r.userId,
             triggeredBy: userId,
-            otherInfo: sanitizedEmailBody
+            otherInfo: sanitizedCustomNote
               ? {
-                  customEmailBody: sanitizedEmailBody,
+                  customEmailNote: sanitizedCustomNote,
                 }
               : undefined,
           }),

--- a/src/pages/api/sponsor-dashboard/grants/update-application-status.ts
+++ b/src/pages/api/sponsor-dashboard/grants/update-application-status.ts
@@ -18,6 +18,7 @@ import { queueEmail } from '@/features/emails/utils/queueEmail';
 import { convertGrantApplicationToAirtable } from '@/features/grants/utils/convertGrantApplicationToAirtable';
 import { createTranche } from '@/features/grants/utils/createTranche';
 import { COINDCX_GRANT_ID } from '@/features/grants/utils/stGrant';
+import { validateCustomEmailBody } from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
 import { fetchTokenUSDValue } from '@/features/wallet/utils/fetchTokenUSDValue';
 
 const MAX_RECORDS = 10;
@@ -33,6 +34,7 @@ const UpdateGrantApplicationSchema = z.object({
     .min(1, 'Data array cannot be empty')
     .max(MAX_RECORDS, `Only max ${MAX_RECORDS} records allowed in data`),
   applicationStatus: z.string(),
+  emailBody: z.string().trim().min(1).max(5000).optional(),
 });
 
 const checkAndUpdateKYCStatus = async (
@@ -110,7 +112,18 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     });
   }
 
-  const { data, applicationStatus } = validationResult.data;
+  const { data, applicationStatus, emailBody } = validationResult.data;
+  const emailValidation = emailBody ? validateCustomEmailBody(emailBody) : null;
+
+  if (emailValidation && !emailValidation.isValid) {
+    logger.warn('Invalid custom email body:', emailValidation.error);
+    return res.status(400).json({
+      error: 'Invalid custom email body',
+      details: emailValidation.error,
+    });
+  }
+
+  const sanitizedEmailBody = emailValidation?.sanitized;
 
   try {
     const currentApplications = await prisma.grantApplication.findMany({
@@ -285,6 +298,11 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
             id: r.id,
             userId: r.userId,
             triggeredBy: userId,
+            otherInfo: sanitizedEmailBody
+              ? {
+                  customEmailBody: sanitizedEmailBody,
+                }
+              : undefined,
           }),
         ),
       );


### PR DESCRIPTION
## What does this PR do?
- Adds dropdown on approve and reject with option for custom email.
- Custom email supports rich text editing and has sanity validation on frontend and backend to not allow cross site scripts in the input.
- Default email templates are added as a way to edit and add feedback over the same.
- Similar changes are made to Tranche requests.
- Merge to staging first to check the functionality since this is a mid size change

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to include personalized custom notes when approving or rejecting grants and tranches
  * Introduced email preview functionality to preview how custom notes appear in approval and rejection communications
  * Implemented character limit validation for custom notes to ensure emails remain appropriately sized
  * Added UI toggles allowing users to switch between standard and customized email modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->