### PR TITLE
Removed Frontier Hackthon

### DIFF
--- a/src/features/hackathon/constants/hackathons.ts
+++ b/src/features/hackathon/constants/hackathons.ts
@@ -2,10 +2,4 @@ export const HACKATHONS: {
   label: string;
   slug: string;
   logo: string;
-}[] = [
-  {
-    label: 'Frontier',
-    slug: 'frontier',
-    logo: '/hackathon/frontier/logo.webp',
-  },
-];
+}[] = [];


### PR DESCRIPTION
## What does this PR do?
- Removes frontier hackathon from navigations

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleared hackathon listings from the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperteamDAO/earn/pull/1387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->