### PR TITLE
[codex] Fix grant member status display

### DIFF
--- a/src/features/sponsor-dashboard/components/GrantApplications/ApplicationDetails.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/ApplicationDetails.tsx
@@ -24,6 +24,7 @@ import {
   isAgenticEngineeringGrant,
   ST_GRANT_COPY,
 } from '@/features/grants/utils/stGrant';
+import { isEligiblePeopleType } from '@/features/membership/utils/peopleEligibility';
 import {
   GitHub,
   Telegram,
@@ -113,7 +114,10 @@ export const ApplicationDetails = ({
   };
 
   const chapter = useMemo(
-    () => selectedApplication?.user.people?.chapter,
+    () =>
+      isEligiblePeopleType(selectedApplication?.user.people?.type)
+        ? selectedApplication?.user.people?.chapter
+        : null,
     [selectedApplication],
   );
   return (

--- a/src/features/sponsor-dashboard/components/GrantApplications/ApplicationList.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/ApplicationList.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/prisma/enums';
 import { cn } from '@/utils/cn';
 
+import { isEligiblePeopleType } from '@/features/membership/utils/peopleEligibility';
 import { EarnAvatar } from '@/features/talent/components/EarnAvatar';
 
 import { selectedGrantApplicationAtom } from '../../atoms';
@@ -123,7 +124,12 @@ export const ApplicationList = ({
             color: labelColor,
             border: labelBorder,
           } = colorMap[applicationLabel];
-          const chapter = application?.user.people?.chapter;
+          const isEligibleMember = isEligiblePeopleType(
+            application?.user.people?.type,
+          );
+          const chapter = isEligibleMember
+            ? application?.user.people?.chapter
+            : null;
           return (
             <div
               key={application?.id}

--- a/src/features/sponsor-dashboard/types.ts
+++ b/src/features/sponsor-dashboard/types.ts
@@ -22,6 +22,7 @@ type UserWithChapter = PrismaUserWithoutKYC & {
   people?: {
     id: string;
     chapterId?: string | null;
+    type?: string | null;
     chapter?: {
       id: string;
       name: string;

--- a/src/pages/api/sponsor-dashboard/grants/[slug]/applications.ts
+++ b/src/pages/api/sponsor-dashboard/grants/[slug]/applications.ts
@@ -160,6 +160,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
               select: {
                 id: true,
                 chapterId: true,
+                type: true,
                 chapter: {
                   select: {
                     id: true,


### PR DESCRIPTION
## Summary

Fixes sponsor dashboard grant application UI that showed users as Superteam members whenever they had a linked `peopleId`/chapter, even if their `people.type` was not an active member type.

## Changes

- Include `people.type` in the grant applications API response.
- Add `people.type` to the sponsor dashboard grant application user type.
- Gate chapter badges and the `SUPERTEAM MEMBER?` value behind `isEligiblePeopleType`, so only `member` and `core` display as active members.

## Impact

Former members with stale linked `peopleId` rows no longer appear as current Superteam members in the grant application list/details UI.

## Validation

- `pnpm lint` (0 errors, 42 existing warnings)
- `pnpm check-types`
- Commit hook typecheck passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Member chapter information in grant application details and listings now properly validates user eligibility before displaying. Chapter data only appears for applicants meeting eligibility criteria.

* **Improvements**
  * Strengthened eligibility validation logic across grant applications to ensure accurate member classification and information visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperteamDAO/earn/pull/1389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->