### PR TITLE
Re: Add back frontier to just nav

### DIFF
--- a/src/features/hackathon/constants/hackathons.ts
+++ b/src/features/hackathon/constants/hackathons.ts
@@ -2,4 +2,10 @@ export const HACKATHONS: {
   label: string;
   slug: string;
   logo: string;
-}[] = [];
+}[] = [
+  {
+    label: 'Frontier',
+    slug: 'frontier',
+    logo: '/hackathon/frontier/logo.webp',
+  },
+];

--- a/src/features/home/components/SideBar.tsx
+++ b/src/features/home/components/SideBar.tsx
@@ -24,7 +24,6 @@ import { userStatsQuery } from '../queries/user-stats';
 import { HowItWorks } from './HowItWorks';
 import { RecentActivity } from './RecentActivity';
 import { RecentEarners } from './RecentEarners';
-import { SidebarBanner } from './SidebarBanner';
 import { SponsorBanner } from './SponsorBanner';
 import { SponsorFeatures } from './SponsorFeatures';
 import { SponsorResources } from './SponsorResources';
@@ -86,7 +85,7 @@ interface FeedSidebarContentProps {
 const FeedSidebarContent = ({ recentEarners }: FeedSidebarContentProps) => (
   <>
     <VibeCard />
-    <SidebarBanner />
+    {/* <SidebarBanner /> */}
     <LiveListings>
       <SectionHeader title="LIVE LISTINGS" href="/earn" />
     </LiveListings>
@@ -135,7 +134,7 @@ const NonSponsorSidebarContent = ({
         TVE={totals?.totalInUSD}
       />
     </div>
-    <SidebarBanner />
+    {/* <SidebarBanner /> */}
     <HowItWorks />
     {currentPath !== '/earn/bookmarks' && !!bookmarks?.length && (
       <YourBookmarks>


### PR DESCRIPTION
## What does this PR do?
- Adds back frontiner to mobile and desktop nav

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Frontier hackathon is now available on the platform, providing users with access to a new hackathon event along with corresponding branding and event information.

* **UI Changes**
  * Removed the sidebar banner from the home feed, streamlining the interface for a cleaner user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperteamDAO/earn/pull/1391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->