### PR TITLE
Fix soft bounce suppression flow

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -692,9 +692,11 @@ model emailLogs {
 
 model ResendLogs {
   id        String   @id @default(uuid())
+  emailId   String?
   email     String
   subject   String
   status    String
+  webhookKey String? @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -702,6 +704,7 @@ model ResendLogs {
   @@index([createdAt(sort: Desc)])
   @@index([status])
   @@index([email, status])
+  @@index([emailId])
 }
 
 model SubscribeBounty {
@@ -762,6 +765,21 @@ model BlockedEmail {
   email     String   @unique
   reason    String?
   createdAt DateTime @default(now())
+}
+
+model EmailBounceLog {
+  id                 String   @id @default(uuid())
+  email              String   @unique
+  bounceType         String?
+  diagnosticCode     String?
+  consecutiveBounces Int      @default(0)
+  lastBounceAt       DateTime?
+  suppressedAt       DateTime?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  @@index([suppressedAt])
+  @@index([lastBounceAt(sort: Desc)])
 }
 
 model CreditLedger {

--- a/src/features/emails/utils/queueEmail.ts
+++ b/src/features/emails/utils/queueEmail.ts
@@ -2,6 +2,7 @@ import { Queue } from 'bullmq';
 import Redis from 'ioredis';
 
 import logger from '@/lib/logger';
+import { prisma } from '@/prisma';
 
 type EmailType =
   | 'addPayment'
@@ -44,6 +45,37 @@ interface EmailNotificationParams {
 const redis = new Redis(process.env.REDIS_URL!, { maxRetriesPerRequest: null });
 const logicQueue = new Queue('logicQueue', { connection: redis });
 
+async function isBlockedRecipient(userId?: string) {
+  if (!userId) {
+    return false;
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { email: true },
+  });
+
+  if (!user?.email) {
+    return false;
+  }
+
+  const normalizedEmail = user.email.toLowerCase();
+  const blockedEmail = await prisma.blockedEmail.findUnique({
+    where: { email: normalizedEmail },
+    select: { reason: true },
+  });
+
+  if (!blockedEmail) {
+    return false;
+  }
+
+  logger.info(
+    `Skipping queued email for blocked recipient: userId=${userId}, email=${normalizedEmail}, reason=${blockedEmail.reason ?? 'unspecified'}`,
+  );
+
+  return true;
+}
+
 export async function queueEmail({
   type,
   id,
@@ -57,6 +89,10 @@ export async function queueEmail({
   );
 
   try {
+    if (await isBlockedRecipient(userId)) {
+      return;
+    }
+
     const job = await logicQueue.add(
       'processLogic',
       {

--- a/src/pages/api/email/webhook/index.ts
+++ b/src/pages/api/email/webhook/index.ts
@@ -1,9 +1,10 @@
-import axios from 'axios';
 import { type IncomingMessage } from 'http';
 import { buffer } from 'micro';
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { type Prisma } from '@/generated/prisma/client';
 import { type WebhookRequiredHeaders } from 'svix';
 
+import logger from '@/lib/logger';
 import { webhook } from '@/lib/webhook';
 import { prisma } from '@/prisma';
 
@@ -24,78 +25,288 @@ type EmailType =
 interface WebhookEvent {
   created_at: string;
   data: {
+    bounce?: {
+      message?: string;
+      subType?: string;
+      type?: 'Permanent' | 'Transient' | 'Undetermined' | string;
+    };
     created_at: string;
     email_id: string;
     from: string;
     subject: string;
+    tags?: Record<string, string>;
     to: string[];
   };
   type: EmailType;
 }
 
-async function deleteEmailSettings(recipientEmail: string) {
-  console.log(
-    `Deleting all EmailSettings for this user with email: ${recipientEmail}`,
+type BounceCategory =
+  | 'content_rejected'
+  | 'dead_domain'
+  | 'full_inbox'
+  | 'hard_bounce'
+  | 'temp_provider';
+
+const SOFT_BOUNCE_REASONS = new Set([
+  'bounced - dead domain',
+  'bounced - inbox full',
+  'bounced - transient',
+]);
+
+const HARD_BOUNCE_REASON = 'bounced - hard';
+
+async function deleteEmailSettings(
+  tx: Prisma.TransactionClient,
+  recipientEmail: string,
+) {
+  logger.info(
+    `Deleting all EmailSettings for users with email ${recipientEmail}`,
   );
 
-  const users = await prisma.user.findMany({
+  const users = await tx.user.findMany({
     where: { email: recipientEmail },
     select: { id: true },
   });
 
   if (users.length > 0) {
     for (const user of users) {
-      await prisma.emailSettings.deleteMany({
+      await tx.emailSettings.deleteMany({
         where: { userId: user.id },
       });
-      console.log(`Deleted EmailSettings for user ID: ${user.id}`);
+      logger.info(`Deleted EmailSettings for user ID ${user.id}`);
     }
   } else {
-    console.log(`No users found with email ${recipientEmail}`);
+    logger.info(`No users found with email ${recipientEmail}`);
   }
 }
 
-async function handleEmailBounce(recipientEmail: string, isValid: boolean) {
-  if (!isValid) {
-    await prisma.blockedEmail.create({
-      data: {
+function normalizeEventDate(value: string) {
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+function truncateDiagnosticCode(message?: string) {
+  if (!message) {
+    return null;
+  }
+
+  return message.slice(0, 191);
+}
+
+function classifyBounce(event: WebhookEvent): {
+  category: BounceCategory;
+  diagnosticCode: string | null;
+  shouldIncrement: boolean;
+  suppressImmediately: boolean;
+} {
+  const bounce = event.data.bounce;
+  const diagnosticCode = truncateDiagnosticCode(bounce?.message);
+  const fingerprint = `${bounce?.subType ?? ''} ${bounce?.message ?? ''}`.toLowerCase();
+
+  if (
+    fingerprint.includes('content rejected') ||
+    fingerprint.includes('detected your message as spam') ||
+    fingerprint.includes('marked as spam')
+  ) {
+    return {
+      category: 'content_rejected',
+      diagnosticCode,
+      shouldIncrement: false,
+      suppressImmediately: false,
+    };
+  }
+
+  if (
+    fingerprint.includes('mailbox full') ||
+    fingerprint.includes('out of storage space') ||
+    fingerprint.includes('inbox is full') ||
+    fingerprint.includes('quota exceeded')
+  ) {
+    return {
+      category: 'full_inbox',
+      diagnosticCode,
+      shouldIncrement: true,
+      suppressImmediately: false,
+    };
+  }
+
+  if (
+    fingerprint.includes('no mx') ||
+    fingerprint.includes('no such domain') ||
+    fingerprint.includes('domain does not exist')
+  ) {
+    return {
+      category: 'dead_domain',
+      diagnosticCode,
+      shouldIncrement: true,
+      suppressImmediately: true,
+    };
+  }
+
+  if (bounce?.type === 'Permanent') {
+    return {
+      category: 'hard_bounce',
+      diagnosticCode,
+      shouldIncrement: false,
+      suppressImmediately: true,
+    };
+  }
+
+  return {
+    category: 'temp_provider',
+    diagnosticCode,
+    shouldIncrement: true,
+    suppressImmediately: false,
+  };
+}
+
+function getSuppressionReason(category: BounceCategory) {
+  switch (category) {
+    case 'dead_domain':
+      return 'bounced - dead domain';
+    case 'full_inbox':
+      return 'bounced - inbox full';
+    case 'hard_bounce':
+      return HARD_BOUNCE_REASON;
+    default:
+      return 'bounced - transient';
+  }
+}
+
+async function upsertBlockedEmail(
+  tx: Prisma.TransactionClient,
+  recipientEmail: string,
+  reason: string,
+) {
+  await tx.blockedEmail.upsert({
+    where: { email: recipientEmail },
+    update: { reason },
+    create: {
+      email: recipientEmail,
+      reason,
+    },
+  });
+}
+
+async function handleBounceEvent(
+  tx: Prisma.TransactionClient,
+  event: WebhookEvent,
+  recipientEmail: string,
+) {
+  const eventDate = normalizeEventDate(event.created_at);
+  const bounce = classifyBounce(event);
+
+  if (bounce.category === 'content_rejected') {
+    await tx.emailBounceLog.upsert({
+      where: { email: recipientEmail },
+      update: {
+        bounceType: bounce.category,
+        diagnosticCode: bounce.diagnosticCode,
+        lastBounceAt: eventDate,
+      },
+      create: {
         email: recipientEmail,
+        bounceType: bounce.category,
+        diagnosticCode: bounce.diagnosticCode,
+        lastBounceAt: eventDate,
       },
     });
+
+    logger.warn(
+      `Content rejection recorded for ${recipientEmail}. Not auto-suppressing recipient.`,
+    );
     return;
   }
 
-  const last6Emails = await prisma.resendLogs.findMany({
-    where: {
-      email: recipientEmail,
-    },
-    orderBy: {
-      createdAt: 'desc',
-    },
-    take: 6,
+  if (bounce.suppressImmediately) {
+    const suppressionReason = getSuppressionReason(bounce.category);
+
+    await tx.emailBounceLog.upsert({
+      where: { email: recipientEmail },
+      update: {
+        bounceType: bounce.category,
+        diagnosticCode: bounce.diagnosticCode,
+        consecutiveBounces: bounce.category === 'hard_bounce' ? 0 : 1,
+        lastBounceAt: eventDate,
+        suppressedAt: eventDate,
+      },
+      create: {
+        email: recipientEmail,
+        bounceType: bounce.category,
+        diagnosticCode: bounce.diagnosticCode,
+        consecutiveBounces: bounce.category === 'hard_bounce' ? 0 : 1,
+        lastBounceAt: eventDate,
+        suppressedAt: eventDate,
+      },
+    });
+
+    await upsertBlockedEmail(tx, recipientEmail, suppressionReason);
+    return;
+  }
+
+  const previousLog = await tx.emailBounceLog.findUnique({
+    where: { email: recipientEmail },
   });
 
-  const bouncedCount = last6Emails.filter(
-    (email) => email.status === 'email.bounced',
-  ).length;
-  const delayedCount = last6Emails.filter(
-    (email) => email.status === 'email.delivery_delayed',
-  ).length;
+  const nextConsecutiveBounces =
+    bounce.shouldIncrement === false
+      ? previousLog?.consecutiveBounces ?? 0
+      : (previousLog?.consecutiveBounces ?? 0) + 1;
 
-  const lastThreeAreBounced = last6Emails
-    .slice(0, 3)
-    .every((email) => email.status === 'email.bounced');
+  const shouldSuppress = nextConsecutiveBounces >= 2;
+  const suppressionReason = getSuppressionReason(bounce.category);
 
-  const highFailureTrend = bouncedCount + delayedCount >= 6;
-  const allDelays = delayedCount === 6;
-  const highBounceRatio = bouncedCount / last6Emails.length > 0.5;
+  await tx.emailBounceLog.upsert({
+    where: { email: recipientEmail },
+    update: {
+      bounceType: bounce.category,
+      diagnosticCode: bounce.diagnosticCode,
+      consecutiveBounces: nextConsecutiveBounces,
+      lastBounceAt: eventDate,
+      suppressedAt: shouldSuppress ? eventDate : null,
+    },
+    create: {
+      email: recipientEmail,
+      bounceType: bounce.category,
+      diagnosticCode: bounce.diagnosticCode,
+      consecutiveBounces: nextConsecutiveBounces,
+      lastBounceAt: eventDate,
+      suppressedAt: shouldSuppress ? eventDate : null,
+    },
+  });
 
-  if (lastThreeAreBounced || highFailureTrend || allDelays || highBounceRatio) {
-    await deleteEmailSettings(recipientEmail);
-  } else {
-    console.log(
-      `History for ${recipientEmail} does not meet unsubscribe criteria. No action taken.`,
-    );
+  if (shouldSuppress) {
+    await upsertBlockedEmail(tx, recipientEmail, suppressionReason);
+  }
+}
+
+async function handleDeliveredEvent(
+  tx: Prisma.TransactionClient,
+  recipientEmail: string,
+) {
+  await tx.emailBounceLog.upsert({
+    where: { email: recipientEmail },
+    update: {
+      consecutiveBounces: 0,
+      suppressedAt: null,
+    },
+    create: {
+      email: recipientEmail,
+      consecutiveBounces: 0,
+    },
+  });
+
+  const blockedEmail = await tx.blockedEmail.findUnique({
+    where: { email: recipientEmail },
+  });
+
+  if (
+    blockedEmail?.reason &&
+    SOFT_BOUNCE_REASONS.has(blockedEmail.reason)
+  ) {
+    await tx.blockedEmail.delete({
+      where: { email: recipientEmail },
+    });
   }
 }
 
@@ -117,30 +328,49 @@ const webhooks = async (req: NextApiRequest, res: NextApiResponse) => {
           return res.status(400).json({ error: 'No recipient email found' });
         }
 
-        // Convert email to lowercase to ensure consistency
         const normalizedEmail = recipientEmail.toLowerCase();
+        const webhookKey = `${event.data.email_id}:${event.type}`;
 
-        if (event.type === 'email.bounced') {
-          const { data } = await axios.post(
-            `https://superteam.fun/api/email/validate`,
-            { email: normalizedEmail },
-          );
-          const isValid = data?.isValid ?? false;
-          await handleEmailBounce(normalizedEmail, isValid);
-        } else if (event.type === 'email.complained') {
-          await deleteEmailSettings(normalizedEmail);
+        try {
+          await prisma.$transaction(async (tx) => {
+            await tx.resendLogs.create({
+              data: {
+                email: normalizedEmail,
+                emailId: event.data.email_id,
+                subject: event.data.subject,
+                status: event.type,
+                webhookKey,
+              },
+            });
+
+            if (
+              event.type === 'email.bounced' ||
+              event.type === 'email.delivery_delayed'
+            ) {
+              await handleBounceEvent(tx, event, normalizedEmail);
+            } else if (event.type === 'email.delivered') {
+              await handleDeliveredEvent(tx, normalizedEmail);
+            } else if (event.type === 'email.complained') {
+              await deleteEmailSettings(tx, normalizedEmail);
+            }
+          });
+        } catch (error: unknown) {
+          if (
+            error &&
+            typeof error === 'object' &&
+            'code' in error &&
+            error.code === 'P2002'
+          ) {
+            logger.info(`Ignoring duplicate webhook ${webhookKey}`);
+            return res.status(200).end();
+          }
+
+          throw error;
         }
-
-        await prisma.resendLogs.create({
-          data: {
-            email: normalizedEmail,
-            subject: event.data.subject,
-            status: event.type,
-          },
-        });
 
         return res.status(200).end();
       } catch (error) {
+        logger.error(error);
         return res.status(400).send(error);
       }
     }

--- a/src/pages/api/sponsor-dashboard/submission/add-payment.ts
+++ b/src/pages/api/sponsor-dashboard/submission/add-payment.ts
@@ -183,6 +183,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     await queueEmail({
       type: 'addPayment',
       id,
+      userId: result.userId,
       triggeredBy: userId,
     });
 


### PR DESCRIPTION
## What this does

This adds proper soft-bounce handling on our side instead of just letting Resend keep retrying and then forgetting about the address.

Right now the issue is basically:
- we get bounce-related events from Resend
- but we were not keeping proper recipient-level state for soft bounces
- so the same bad / unhealthy inbox could keep getting future emails
- that wastes sends and is bad for sender health over time

This change fixes that flow in the app.

## What changed

- added an `EmailBounceLog` table to track bounce state per email
- webhook now handles `email.bounced`, `email.delivery_delayed`, `email.delivered`, and `email.complained` in a more deterministic way
- repeated soft/transient failures now suppress the recipient into `blockedEmail`
- successful delivery resets the soft-bounce counter and clears soft suppression
- explicit dead-domain signals like `no mx` / `no such domain` / `domain does not exist` are handled more aggressively
- queue-time guard added for user-targeted queued mail so blocked recipients do not keep getting enqueued
- `addPayment` now passes `userId` so that targeted path is also covered by the queue-time check
- webhook processing is idempotent via a stored unique webhook key, so duplicate webhook deliveries do not double-count

## Behavior now

- first transient / mailbox-full style failure: track it, do not block yet
- second consecutive failure for the same recipient: suppress
- later successful delivery: reset counter and remove soft-bounce suppression
- content-rejected / spam-style failures are logged but not treated like a dead inbox problem

## Why this was done this way

This keeps the blast radius small.

We did not change the whole email system or wipe user preferences as the main fix.
We kept `blockedEmail` as the actual enforcement gate and made the webhook + queue layer smarter so repeated bad recipients stop getting targeted.

This also avoids overreacting to ambiguous DNS/provider noise. Only explicit dead-domain signals are treated as dead-domain cases.

## Not in this PR

- no 30-day reprobe / reactivation cron yet
- no DMARC / SPF work
- no broader deliverability/content review changes

Those can come later after this is live and we confirm webhook traffic + suppression behavior in prod.

## After merge / rollout checklist

- apply the Prisma schema change
- confirm Resend webhook secret matches deployed env
- make sure Resend app webhook stays subscribed to:
  - `email.bounced`
  - `email.delivery_delayed`
  - `email.delivered`
  - `email.complained`
- delete the broken Zapier webhook
- manually verify a replay / fresh webhook event reaches the app successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic email blocking for recipients with persistent delivery failures to improve sender reputation and reduce bounce rates.
  * Enhanced webhook event processing to prevent duplicate message handling.
  * Added bounce type classification and suppression logic for improved email deliverability.

* **New Features**
  * Introduced comprehensive bounce tracking and logging system to monitor email delivery issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SuperteamDAO/earn/pull/1394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->