### PR TITLE
Reject grant applications without cooldown

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -287,6 +287,7 @@ model GrantApplication {
   approvedAmount      Float                  @default(0)
   approvedAmountInUSD Float                  @default(0)
   decidedAt           DateTime?
+  isCooldownSkipped   Boolean                @default(false)
   totalPaid           Float                  @default(0)
   isShipped           Boolean                @default(false)
   paymentDetails      Json?

--- a/src/app/api/grant-application/create/route.ts
+++ b/src/app/api/grant-application/create/route.ts
@@ -197,6 +197,7 @@ export async function POST(request: NextRequest) {
         grantId,
         userId,
         applicationStatus: 'Rejected',
+        isCooldownSkipped: false,
         decidedAt: { gte: dayjs().subtract(30, 'day').toDate() },
       },
       orderBy: { decidedAt: 'desc' },

--- a/src/features/grants/hooks/useApplicationState.ts
+++ b/src/features/grants/hooks/useApplicationState.ts
@@ -24,7 +24,8 @@ export const useApplicationState = (
 
     if (application.applicationStatus === 'Rejected') {
       setApplicationState(
-        isGrantApplicationInCooldown(application.decidedAt)
+        !application.isCooldownSkipped &&
+          isGrantApplicationInCooldown(application.decidedAt)
           ? 'COOLDOWN'
           : 'ALLOW NEW',
       );

--- a/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
+++ b/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
@@ -357,10 +357,15 @@ export const ApplicationsTab = ({ slug }: Props) => {
     }
   };
 
-  const handleRejectGrant = (applicationId: string, customNote?: string) => {
+  const handleRejectGrant = (
+    applicationId: string,
+    customNote?: string,
+    skipCooldown?: boolean,
+  ) => {
     rejectGrantApplications.mutate({
       applicationIds: [applicationId],
       customNote,
+      skipCooldown,
     });
   };
 

--- a/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/Modals/RejectModal.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Separator } from '@/components/ui/separator';
+import { Switch } from '@/components/ui/switch';
 import { TokenIcon } from '@/components/ui/token-icon';
 import { cn } from '@/utils/cn';
 
@@ -34,7 +35,11 @@ interface RejectModalProps {
   salutation: string | null | undefined;
   token: string;
   enableCustomEmail: boolean;
-  onRejectGrant: (applicationId: string, customNote?: string) => void;
+  onRejectGrant: (
+    applicationId: string,
+    customNote?: string,
+    skipCooldown?: boolean,
+  ) => void;
 }
 
 export const RejectGrantApplicationModal = ({
@@ -53,6 +58,7 @@ export const RejectGrantApplicationModal = ({
   const [loading, setLoading] = useState<boolean>(false);
   const [customNote, setCustomNote] = useState('');
   const [isCustomEmailOpen, setIsCustomEmailOpen] = useState(false);
+  const [skipCooldown, setSkipCooldown] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
 
   const previewEmailBody = getGrantRejectedEmailBody({
@@ -66,6 +72,7 @@ export const RejectGrantApplicationModal = ({
   const closeAndDiscardCustomNote = () => {
     setCustomNote('');
     setIsCustomEmailOpen(false);
+    setSkipCooldown(false);
     setEmailError(null);
     rejectOnClose();
   };
@@ -97,6 +104,7 @@ export const RejectGrantApplicationModal = ({
         enableCustomEmail && isCustomEmailOpen
           ? noteValidation.sanitized
           : undefined,
+        skipCooldown,
       );
     } catch (e) {
       console.error(e);
@@ -109,9 +117,18 @@ export const RejectGrantApplicationModal = ({
   useEffect(() => {
     setCustomNote('');
     setIsCustomEmailOpen(false);
+    setSkipCooldown(false);
     setEmailError(null);
     setLoading(false);
   }, [applicationId]);
+
+  const rejectButtonText = isCustomEmailOpen
+    ? 'Reject with Custom Note'
+    : 'Reject Grant';
+
+  const rejectingText = isCustomEmailOpen
+    ? 'Rejecting with Custom Note'
+    : 'Rejecting';
 
   return (
     <>
@@ -144,6 +161,22 @@ export const RejectGrantApplicationModal = ({
                   {ask} <span className="text-slate-400">{token}</span>
                 </p>
               </div>
+            </div>
+
+            <div className="mb-6 flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium text-slate-500">
+                  Apply 30-day cooldown
+                </p>
+                <p className="mt-0.5 text-xs text-slate-400">
+                  Turn off to let them reapply immediately.
+                </p>
+              </div>
+              <Switch
+                checked={!skipCooldown}
+                disabled={loading}
+                onCheckedChange={(checked) => setSkipCooldown(!checked)}
+              />
             </div>
 
             {enableCustomEmail && isCustomEmailOpen && (
@@ -196,22 +229,14 @@ export const RejectGrantApplicationModal = ({
                   {loading ? (
                     <>
                       <span className="loading loading-spinner mr-2" />
-                      <span>
-                        {isCustomEmailOpen
-                          ? 'Rejecting with Custom Note'
-                          : 'Rejecting'}
-                      </span>
+                      <span>{rejectingText}</span>
                     </>
                   ) : (
                     <>
                       <div className="rounded-full bg-red-600 p-0.5">
                         <X className="size-2 text-white" />
                       </div>
-                      <span>
-                        {isCustomEmailOpen
-                          ? 'Reject with Custom Note'
-                          : 'Reject Grant'}
-                      </span>
+                      <span>{rejectButtonText}</span>
                     </>
                   )}
                 </Button>

--- a/src/features/sponsor-dashboard/mutations/useRejectGrantApplications.ts
+++ b/src/features/sponsor-dashboard/mutations/useRejectGrantApplications.ts
@@ -14,6 +14,7 @@ type RejectGrantApplicationsInput =
   | {
       applicationIds: string[];
       customNote?: string;
+      skipCooldown?: boolean;
     };
 
 const parseRejectGrantApplicationsInput = (
@@ -72,7 +73,7 @@ export const useRejectGrantApplications = (slug: string) => {
 
   return useMutation({
     mutationFn: async (input: RejectGrantApplicationsInput) => {
-      const { applicationIds, customNote } =
+      const { applicationIds, customNote, skipCooldown } =
         parseRejectGrantApplicationsInput(input);
       const reviewerNote = customNote?.trim();
       const batchSize = 10;
@@ -84,13 +85,15 @@ export const useRejectGrantApplications = (slug: string) => {
             data: batch.map((id) => ({ id })),
             applicationStatus: 'Rejected',
             ...(reviewerNote ? { customNote: reviewerNote } : {}),
+            ...(skipCooldown ? { skipCooldown } : {}),
           },
         );
       }
       return applicationIds;
     },
     onMutate: async (input) => {
-      const { applicationIds } = parseRejectGrantApplicationsInput(input);
+      const { applicationIds, skipCooldown } =
+        parseRejectGrantApplicationsInput(input);
 
       await queryClient.cancelQueries({
         queryKey: ['sponsor-applications', slug],
@@ -112,6 +115,7 @@ export const useRejectGrantApplications = (slug: string) => {
               ? {
                   ...application,
                   applicationStatus: GrantApplicationStatus.Rejected,
+                  isCooldownSkipped: !!skipCooldown,
                   label:
                     application.label === 'Unreviewed' ||
                     application.label === 'Pending'

--- a/src/pages/api/sponsor-dashboard/grants/update-application-status.ts
+++ b/src/pages/api/sponsor-dashboard/grants/update-application-status.ts
@@ -39,6 +39,7 @@ const UpdateGrantApplicationSchema = z.object({
     .max(MAX_RECORDS, `Only max ${MAX_RECORDS} records allowed in data`),
   applicationStatus: z.string(),
   customNote: z.string().trim().min(1).max(5000).optional(),
+  skipCooldown: z.boolean().optional(),
 });
 
 const checkAndUpdateKYCStatus = async (
@@ -116,7 +117,8 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     });
   }
 
-  const { data, applicationStatus, customNote } = validationResult.data;
+  const { data, applicationStatus, customNote, skipCooldown } =
+    validationResult.data;
 
   try {
     const currentApplications = await prisma.grantApplication.findMany({
@@ -211,6 +213,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       applicationStatus,
       decidedAt: new Date().toISOString(),
       decidedBy: userId,
+      isCooldownSkipped: applicationStatus === 'Rejected' && !!skipCooldown,
     };
 
     const updatedData: {
@@ -221,6 +224,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       approvedAmountInUSD?: number;
       totalTranches?: number;
       label?: SubmissionLabels;
+      isCooldownSkipped?: boolean;
     }[] = [];
 
     await Promise.all(


### PR DESCRIPTION
## What does this PR do?
- Adds a field to reject grant applications without the mandatory cooldown for the applicant

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to skip the 30-day cooldown period when rejecting grant applications. A new toggle has been added to the rejection confirmation dialog, allowing administrators to choose whether the standard cooldown applies to rejected applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->