### PR TITLE
fix: atomically check and consume credits on submission

### DIFF
--- a/src/pages/api/submission/create.ts
+++ b/src/pages/api/submission/create.ts
@@ -7,6 +7,7 @@ import { safeStringify } from '@/utils/safeStringify';
 import { queueAgent } from '@/features/agents/utils/queueAgent';
 import { type NextApiRequestWithUser } from '@/features/auth/types';
 import { withAuth } from '@/features/auth/utils/withAuth';
+import { LockNotAcquiredError, withRedisLock } from '@/lib/with-redis-lock';
 import { consumeCredit } from '@/features/credits/utils/allocateCredits';
 import { canUserSubmit } from '@/features/credits/utils/canUserSubmit';
 import { queueEmail } from '@/features/emails/utils/queueEmail';
@@ -121,27 +122,38 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
       });
     }
 
-    if (!isHackathon && !isPro) {
-      const hasCredits = await canUserSubmit(userId as string);
-      if (!hasCredits) {
-        logger.warn(`User ${userId} has insufficient credits for submission`);
-        return res.status(403).json({
-          error: 'Insufficient credits',
-          message: 'You need at least 1 credit to make a submission.',
-        });
-      }
-    }
-
-    const result = await createSubmission(
-      userId as string,
-      listingId,
-      { link, tweet, otherInfo, eligibilityAnswers, ask, telegram },
-      listing,
-    );
+    let result: Awaited<ReturnType<typeof createSubmission>>;
 
     if (!isHackathon && !isPro) {
-      await consumeCredit(userId, result.id);
-      logger.info(`Consumed 1 credit from user ${userId} for submission`);
+      result = await withRedisLock(
+        `locks:submission:${userId}`,
+        async () => {
+          const hasCredits = await canUserSubmit(userId as string);
+          if (!hasCredits) {
+            logger.warn(
+              `User ${userId} has insufficient credits for submission`,
+            );
+            throw new Error('Insufficient credits');
+          }
+          const submission = await createSubmission(
+            userId as string,
+            listingId,
+            { link, tweet, otherInfo, eligibilityAnswers, ask, telegram },
+            listing,
+          );
+          await consumeCredit(userId, submission.id);
+          logger.info(`Consumed 1 credit from user ${userId} for submission`);
+          return submission;
+        },
+        { ttlSeconds: 30 },
+      );
+    } else {
+      result = await createSubmission(
+        userId as string,
+        listingId,
+        { link, tweet, otherInfo, eligibilityAnswers, ask, telegram },
+        listing,
+      );
     }
 
     await queueEmail({
@@ -169,9 +181,16 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
 
     return res.status(200).json(result);
   } catch (error: any) {
-    const statusCode = error.message.includes('Validation') ? 400 : 403;
     logger.error(`User ${userId} unable to submit: ${safeStringify(error)}`);
 
+    if (error instanceof LockNotAcquiredError) {
+      return res.status(429).json({
+        error: 'Too many requests',
+        message: 'A submission is already in progress. Please try again.',
+      });
+    }
+
+    const statusCode = error.message.includes('Validation') ? 400 : 403;
     return res.status(statusCode).json({
       error: error.message,
       message: `User ${userId} unable to submit: ${error.message}`,


### PR DESCRIPTION
## What does this PR do?
Wraps the credit check, submission creation, and credit consumption in a single Redis lock per user, making the three previously separate operations atomic.

Before this fix, concurrent requests could all pass the credit check before any credit was consumed, allowing unlimited submissions with a single credit.

## Where should the reviewer start?
`src/pages/api/submission/create.ts` - the `withRedisLock` block at line 128.

## How should this be manually tested?
1. As a user with 1 credit, fire multiple concurrent POST requests to `/api/submission/create`
2. Only 1 should succeed with `200` - the rest return `429`
3. Verify only 1 submission in DB and credit balance is 0

## Any background context you want to provide?
`canUserSubmit()` and `consumeCredit()` were two separate DB calls with no lock between them. The fix uses the existing `withRedisLock` utility (already used in the grant tranche flow) with a 30s TTL keyed to `userId`. Hackathon and Pro submissions are unaffected.

## What are the relevant issues?
Internal security.

## Screenshots
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submission handling to prevent concurrent duplicate submissions with appropriate conflict messaging.
  * Enhanced credit availability verification and consumption for standard submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->