### PR TITLE
Fixed grants section for sponsor page

### DIFF
--- a/src/features/grants/components/GrantsSection.tsx
+++ b/src/features/grants/components/GrantsSection.tsx
@@ -24,6 +24,7 @@ interface GrantSectionProps {
   skill?: string;
   category?: string;
   hideWhenEmpty?: boolean;
+  hideCategoryPills?: boolean;
 }
 
 export const GrantsSection = ({
@@ -33,6 +34,7 @@ export const GrantsSection = ({
   skill,
   category: categoryProp,
   hideWhenEmpty,
+  hideCategoryPills,
 }: GrantSectionProps) => {
   const { activeCategory, handleCategoryChange } = useGrantState();
   const isProContext = type === 'pro';
@@ -118,7 +120,7 @@ export const GrantsSection = ({
         )}
       />
 
-      {type !== 'category' && type !== 'category-all' && (
+      {!hideCategoryPills && type !== 'category' && type !== 'category-all' && (
         <div className="mb-2 flex gap-1 overflow-x-auto pb-1">
           <CategoryPill
             key="all"

--- a/src/features/grants/utils/query-builder.ts
+++ b/src/features/grants/utils/query-builder.ts
@@ -142,8 +142,10 @@ export async function buildGrantsQuery(
   }
 
   if (context === 'sponsor' && sponsor) {
+    const sponsorKey = sponsor.toLowerCase();
+
     where.sponsor = {
-      name: sponsor,
+      slug: sponsorKey,
     };
   }
 

--- a/src/pages/earn/pro.tsx
+++ b/src/pages/earn/pro.tsx
@@ -65,7 +65,7 @@ export default function ProPage({ potentialSession }: HomePageProps) {
                 potentialSession={potentialSession}
                 customEmptySection={customEmptySection}
               />
-              <GrantsSection type="pro" />
+              <GrantsSection hideWhenEmpty type="pro" />
             </div>
           </div>
           <ProSidebar />

--- a/src/pages/earn/s/[slug].tsx
+++ b/src/pages/earn/s/[slug].tsx
@@ -235,7 +235,12 @@ const SponsorPage = ({ sponsor, stats }: Props) => {
             sponsor={sSlug}
             customEmptySection={customEmptySection}
           />
-          <GrantsSection hideWhenEmpty type="sponsor" sponsor={sSlug} />
+          <GrantsSection
+            hideWhenEmpty
+            hideCategoryPills
+            type="sponsor"
+            sponsor={sSlug}
+          />
         </div>
       </div>
     </Default>


### PR DESCRIPTION
## What does this PR do?
- Fixes the issue where grants api was incorrectly fetching by sponsor name instead of slug matching.
- hides category pills for grants section in sponsor page
- added hide grant section when empty to pro page

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option to hide category navigation pills in grants sections for cleaner UI customization.

* **Improvements**
  * Enhanced sponsor-based grant filtering with more reliable matching.
  * Improved empty state handling for Pro grants display.
  * Refined grants section layout on sponsor pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->