### PR TITLE
Hide hackathon on non-superteam dashboards

### DIFF
--- a/src/features/listing-builder/components/ListingBuilder.tsx
+++ b/src/features/listing-builder/components/ListingBuilder.tsx
@@ -31,7 +31,7 @@ export function ListingBuilder({ route, slug }: ListingBuilderLayout) {
   const queryClient = useQueryClient();
 
   const { data: hackathons, isLoading: isHackathonLoading } = useQuery({
-    ...activeHackathonsQuery(),
+    ...activeHackathonsQuery(user?.currentSponsorId),
     enabled: !!user,
   });
 

--- a/src/features/sponsor-dashboard/queries/active-hackathons.ts
+++ b/src/features/sponsor-dashboard/queries/active-hackathons.ts
@@ -8,9 +8,9 @@ const fetchActiveHackathons = async (): Promise<HackathonModel[]> => {
   return data;
 };
 
-export const activeHackathonsQuery = () =>
+export const activeHackathonsQuery = (sponsorId?: string) =>
   queryOptions({
-    queryKey: ['active-hackathons'],
+    queryKey: ['active-hackathons', sponsorId],
     queryFn: () => fetchActiveHackathons(),
     retry: false,
     refetchOnMount: false,

--- a/src/layouts/Sponsor.tsx
+++ b/src/layouts/Sponsor.tsx
@@ -182,7 +182,7 @@ export function SponsorLayout({
   }, [user, authenticated, ready, isUserLoading]);
 
   const { data: hackathons } = useQuery({
-    ...activeHackathonsQuery(),
+    ...activeHackathonsQuery(user?.currentSponsorId),
     enabled: !!user,
   });
 

--- a/src/pages/api/sponsor-dashboard/active-hackathons.ts
+++ b/src/pages/api/sponsor-dashboard/active-hackathons.ts
@@ -6,8 +6,25 @@ import { prisma } from '@/prisma';
 import { type NextApiRequestWithSponsor } from '@/features/auth/types';
 import { withSponsorAuth } from '@/features/auth/utils/withSponsorAuth';
 
-async function handler(_: NextApiRequestWithSponsor, res: NextApiResponse) {
+async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   try {
+    if (req.role !== 'GOD') {
+      const sponsor = await prisma.sponsors.findUnique({
+        where: { id: req.userSponsorId },
+        select: {
+          chapter: {
+            select: {
+              id: true,
+            },
+          },
+        },
+      });
+
+      if (!sponsor?.chapter) {
+        return res.status(200).json([]);
+      }
+    }
+
     const now = new Date();
     const hackathons = await prisma.hackathon.findMany({
       where: {

--- a/src/pages/earn/dashboard/hackathon/index.tsx
+++ b/src/pages/earn/dashboard/hackathon/index.tsx
@@ -51,7 +51,7 @@ export default function Hackathon() {
   const router = useRouter();
   const { user } = useUser();
   const { data: hackathons } = useQuery({
-    ...activeHackathonsQuery(),
+    ...activeHackathonsQuery(user?.currentSponsorId),
     enabled: !!user,
   });
   const [totalBounties, setTotalBounties] = useState(0);

--- a/src/pages/earn/dashboard/listings/index.tsx
+++ b/src/pages/earn/dashboard/listings/index.tsx
@@ -77,7 +77,7 @@ export default function SponsorListings({ tab: queryTab }: { tab: string }) {
   }>({ column: '', direction: null });
   const listingsPerPage = 15;
   const { data: hackathons } = useQuery({
-    ...activeHackathonsQuery(),
+    ...activeHackathonsQuery(user?.currentSponsorId),
     enabled: !!user,
   });
 


### PR DESCRIPTION
## What does this PR do?

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Active hackathon listings are now properly filtered to display only those associated with your current sponsor context.
  * Backend now validates sponsor permissions before returning hackathon data, ensuring secure access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->