### PR TITLE
feat: change review badges to dropdowns on sponsor dashboard sidebar …

### DIFF
--- a/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
+++ b/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
@@ -401,6 +401,7 @@ export const ApplicationsTab = ({ slug }: Props) => {
                   (application) => application.applicationStatus === 'Pending',
                 ).length === 0
               }
+              grantSlug={slug}
             />
           </div>
 

--- a/src/features/sponsor-dashboard/components/GrantApplications/ApplicationDetails.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/ApplicationDetails.tsx
@@ -159,7 +159,12 @@ export const ApplicationDetails = ({
                   </Link>
                 </div>
                 <div className="self-start">
-                  {isPending && <SelectLabel grantSlug={grant?.slug!} />}
+                  {isPending && (
+                    <SelectLabel
+                      grantSlug={grant?.slug!}
+                      application={undefined}
+                    />
+                  )}
                 </div>
               </div>
               <div className="ph-no-capture flex w-full items-center justify-end gap-2">

--- a/src/features/sponsor-dashboard/components/GrantApplications/ApplicationList.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/ApplicationList.tsx
@@ -21,6 +21,7 @@ import { labelMenuOptionsGrants } from '../../constants';
 import { type GrantApplicationWithUser } from '../../types';
 import { colorMap } from '../../utils/statusColorMap';
 import { MultiSelectFilter } from './MultiSelectFilter';
+import { SelectLabel } from './SelectLabel';
 
 interface Props {
   applications: GrantApplicationWithUser[] | undefined;
@@ -34,6 +35,7 @@ interface Props {
     filters: Set<GrantApplicationStatus | SubmissionLabels>,
   ) => void;
   isToggleDisabled: boolean;
+  grantSlug: string | undefined;
 }
 
 export const ApplicationList = ({
@@ -46,6 +48,7 @@ export const ApplicationList = ({
   selectedFilters,
   onFilterChange,
   isToggleDisabled,
+  grantSlug,
 }: Props) => {
   const debouncedSetSearchTextRef = useRef<
     ReturnType<typeof debounce> | undefined
@@ -189,8 +192,7 @@ export const ApplicationList = ({
                   >
                     {applicationLabelUi || applicationLabel}
                   </StatusPill>
-                ) : applicationStatus !== 'Pending' ||
-                  applicationLabel === 'Unreviewed' ? (
+                ) : applicationStatus !== 'Pending' ? (
                   <StatusPill
                     className="ml-auto w-fit text-[0.625rem]"
                     color={statusColor}
@@ -199,6 +201,11 @@ export const ApplicationList = ({
                   >
                     {applicationStatus}
                   </StatusPill>
+                ) : grantSlug ? (
+                  <SelectLabel
+                    grantSlug={grantSlug}
+                    application={application}
+                  />
                 ) : (
                   <StatusPill
                     className="ml-auto w-fit text-[0.625rem]"

--- a/src/features/sponsor-dashboard/components/GrantApplications/SelectLabel.tsx
+++ b/src/features/sponsor-dashboard/components/GrantApplications/SelectLabel.tsx
@@ -14,20 +14,33 @@ import { api } from '@/lib/api';
 import { type SubmissionLabels } from '@/prisma/enums';
 import { cn } from '@/utils/cn';
 
-import { isStateUpdatingAtom, selectedGrantApplicationAtom } from '../../atoms';
+import {
+  applicationsAtom,
+  isStateUpdatingAtom,
+  selectedGrantApplicationAtom,
+} from '../../atoms';
 import { labelMenuOptionsGrants } from '../../constants';
 import { type GrantApplicationsReturn } from '../../queries/applications';
+import { type GrantApplicationWithUser } from '../../types';
 import { colorMap } from '../../utils/statusColorMap';
 
 interface Props {
   grantSlug: string;
+  application: GrantApplicationWithUser | undefined;
 }
 
-export const SelectLabel = ({ grantSlug }: Props) => {
+export const SelectLabel = ({
+  grantSlug,
+  application: propApplication,
+}: Props) => {
   const queryClient = useQueryClient();
-  const [selectedApplication, setSelectedApplication] = useAtom(
+  const [selectedApplicationAtomValue, setSelectedApplication] = useAtom(
     selectedGrantApplicationAtom,
   );
+
+  const targetApplication = propApplication || selectedApplicationAtomValue;
+
+  const setApplications = useSetAtom(applicationsAtom);
   const setLabelsUpdating = useSetAtom(isStateUpdatingAtom);
 
   const selectLabel = async (
@@ -39,9 +52,9 @@ export const SelectLabel = ({ grantSlug }: Props) => {
   };
 
   let bg, color, border;
-  if (selectedApplication) {
+  if (targetApplication) {
     ({ bg, color, border } =
-      colorMap[selectedApplication?.label as SubmissionLabels]);
+      colorMap[targetApplication?.label as SubmissionLabels]);
   }
 
   const { mutate: updateLabel } = useMutation({
@@ -81,6 +94,16 @@ export const SelectLabel = ({ grantSlug }: Props) => {
           ? { ...prev, label: variables.label }
           : prev,
       );
+
+      setApplications((prev) =>
+        prev
+          ? prev.map((app) =>
+              app.id === variables.id
+                ? { ...app, label: variables.label }
+                : app,
+            )
+          : prev,
+      );
     },
     onMutate: () => {
       setLabelsUpdating(true);
@@ -102,61 +125,63 @@ export const SelectLabel = ({ grantSlug }: Props) => {
 
   const filterTriggerLabel = useMemo(() => {
     const applicationLabel = labelMenuOptionsGrants.find(
-      (s) => s.value === selectedApplication?.label,
+      (s) => s.value === targetApplication?.label,
     );
     if (applicationLabel) return applicationLabel.label;
-    else return selectedApplication?.label;
-  }, [selectedApplication?.label]);
+    else return targetApplication?.label;
+  }, [targetApplication?.label]);
 
   const labelMenuOptionsGrantsPerAppl = useMemo(() => {
-    if (selectedApplication?.applicationStatus !== 'Pending') {
+    if (targetApplication?.applicationStatus !== 'Pending') {
       return labelMenuOptionsGrants.filter((s) => s.value !== 'Pending');
     }
     return labelMenuOptionsGrants;
-  }, [selectedApplication]);
+  }, [targetApplication]);
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild className="min-w-[110px]">
-        <button
-          className={cn(
-            'flex w-full items-center justify-between rounded-lg border border-slate-200 bg-transparent px-2 py-1 text-xs font-medium text-slate-500 capitalize transition-all duration-300 ease-in-out hover:border-slate-200 data-[state=open]:rounded-b-none data-[state=open]:border-slate-200',
-            color,
-            bg,
-            border,
-          )}
-        >
-          {filterTriggerLabel || 'Select Option'}
-          <ChevronDown className="ml-2 size-3" />
-        </button>
-      </DropdownMenuTrigger>
-
-      <DropdownMenuContent
-        sideOffset={-1}
-        className="w-full min-w-[110px] rounded-t-none px-0 pt-1.5"
-      >
-        {labelMenuOptionsGrantsPerAppl.map((option) => (
-          <DropdownMenuItem
-            key={option.value}
-            className="cursor-pointer px-2 py-1 text-center text-[0.7rem]"
-            onClick={() =>
-              selectLabel(
-                option.value as SubmissionLabels,
-                selectedApplication?.id,
-              )
-            }
+    <div onClick={(e) => e.stopPropagation()}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild className="min-w-[110px]">
+          <button
+            className={cn(
+              'flex w-full items-center justify-between rounded-lg border border-slate-200 bg-transparent px-2 py-1 text-xs font-medium text-slate-500 capitalize transition-all duration-300 ease-in-out hover:border-slate-200 data-[state=open]:rounded-b-none data-[state=open]:border-slate-200',
+              color,
+              bg,
+              border,
+            )}
           >
-            <StatusPill
-              color={colorMap[option.value as SubmissionLabels].color}
-              backgroundColor={colorMap[option.value as SubmissionLabels].bg}
-              borderColor={colorMap[option.value as SubmissionLabels].border}
-              className="w-fit text-[10px]"
+            {filterTriggerLabel || 'Select Option'}
+            <ChevronDown className="ml-2 size-3" />
+          </button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent
+          sideOffset={-1}
+          className="w-full min-w-[110px] rounded-t-none px-0 pt-1.5"
+        >
+          {labelMenuOptionsGrantsPerAppl.map((option) => (
+            <DropdownMenuItem
+              key={option.value}
+              className="cursor-pointer px-2 py-1 text-center text-[0.7rem]"
+              onClick={() =>
+                selectLabel(
+                  option.value as SubmissionLabels,
+                  targetApplication?.id,
+                )
+              }
             >
-              {option.label}
-            </StatusPill>
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+              <StatusPill
+                color={colorMap[option.value as SubmissionLabels].color}
+                backgroundColor={colorMap[option.value as SubmissionLabels].bg}
+                borderColor={colorMap[option.value as SubmissionLabels].border}
+                className="w-fit text-[10px]"
+              >
+                {option.label}
+              </StatusPill>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 };

--- a/src/features/sponsor-dashboard/components/Submissions/SelectLabel.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/SelectLabel.tsx
@@ -21,13 +21,21 @@ import { colorMap } from '../../utils/statusColorMap';
 interface Props {
   listingSlug: string;
   type: BountyType | 'grant' | undefined;
+  submission: SubmissionWithUser | undefined;
 }
 
-export const SelectLabel = ({ listingSlug, type }: Props) => {
+export const SelectLabel = ({
+  listingSlug,
+  type,
+  submission: propSubmission,
+}: Props) => {
   const queryClient = useQueryClient();
-  const [selectedSubmission, setSelectedSubmission] = useAtom(
+  const [selectedSubmissionAtomValue, setSelectedSubmission] = useAtom(
     selectedSubmissionAtom,
   );
+
+  const targetSubmission = propSubmission || selectedSubmissionAtomValue;
+
   const setLabelsUpdating = useSetAtom(isStateUpdatingAtom);
 
   const selectLabel = async (
@@ -39,9 +47,9 @@ export const SelectLabel = ({ listingSlug, type }: Props) => {
   };
 
   let bg, color, border;
-  if (selectedSubmission) {
+  if (targetSubmission) {
     ({ bg, color, border } =
-      colorMap[selectedSubmission?.label as SubmissionLabels]);
+      colorMap[targetSubmission?.label as SubmissionLabels]);
   }
 
   const { mutate: updateLabel } = useMutation({
@@ -85,51 +93,57 @@ export const SelectLabel = ({ listingSlug, type }: Props) => {
   });
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild className="min-w-[110px]">
-        <button
-          className={cn(
-            'flex w-full items-center justify-between rounded-lg border border-slate-200 bg-transparent px-2 py-1 text-xs font-medium text-slate-500 capitalize transition-all duration-300 ease-in-out hover:border-slate-200 data-[state=open]:rounded-b-none data-[state=open]:border-slate-200',
-            color,
-            bg,
-            border,
-          )}
-        >
-          {labelMenuOptions(type).find(
-            (option) => option.value === selectedSubmission?.label,
-          )?.label || 'Select Option'}
-          <ChevronDown className="ml-2 size-3" />
-        </button>
-      </DropdownMenuTrigger>
+    <div onClick={(e) => e.stopPropagation()}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild className="min-w-[110px]">
+          <button
+            className={cn(
+              'flex w-full items-center justify-between rounded-lg border border-slate-200 bg-transparent px-2 py-1 text-xs font-medium text-slate-500 capitalize transition-all duration-300 ease-in-out hover:border-slate-200 data-[state=open]:rounded-b-none data-[state=open]:border-slate-200',
+              color,
+              bg,
+              border,
+            )}
+          >
+            {labelMenuOptions(type).find(
+              (option) => option.value === targetSubmission?.label,
+            )?.label || 'Select Option'}
+            <ChevronDown className="ml-2 size-3" />
+          </button>
+        </DropdownMenuTrigger>
 
-      <DropdownMenuContent
-        sideOffset={-1}
-        className="w-full min-w-[110px] rounded-t-none px-0 pt-1.5"
-      >
-        {labelMenuOptions(type)
-          .filter((option) => !option.hidden)
-          .map((option) => (
-            <DropdownMenuItem
-              key={option.value}
-              className="cursor-pointer px-1.5 py-1 text-center text-[0.7rem]"
-              onClick={() =>
-                selectLabel(
-                  option.value as SubmissionLabels,
-                  selectedSubmission?.id,
-                )
-              }
-            >
-              <StatusPill
-                color={colorMap[option.value as SubmissionLabels].color}
-                backgroundColor={colorMap[option.value as SubmissionLabels].bg}
-                borderColor={colorMap[option.value as SubmissionLabels].border}
-                className="w-fit text-[10px]"
+        <DropdownMenuContent
+          sideOffset={-1}
+          className="w-full min-w-[110px] rounded-t-none px-0 pt-1.5"
+        >
+          {labelMenuOptions(type)
+            .filter((option) => !option.hidden)
+            .map((option) => (
+              <DropdownMenuItem
+                key={option.value}
+                className="cursor-pointer px-1.5 py-1 text-center text-[0.7rem]"
+                onClick={() =>
+                  selectLabel(
+                    option.value as SubmissionLabels,
+                    targetSubmission?.id,
+                  )
+                }
               >
-                {option.label}
-              </StatusPill>
-            </DropdownMenuItem>
-          ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+                <StatusPill
+                  color={colorMap[option.value as SubmissionLabels].color}
+                  backgroundColor={
+                    colorMap[option.value as SubmissionLabels].bg
+                  }
+                  borderColor={
+                    colorMap[option.value as SubmissionLabels].border
+                  }
+                  className="w-fit text-[10px]"
+                >
+                  {option.label}
+                </StatusPill>
+              </DropdownMenuItem>
+            ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 };

--- a/src/features/sponsor-dashboard/components/Submissions/SubmissionList.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/SubmissionList.tsx
@@ -7,7 +7,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { StatusPill } from '@/components/ui/status-pill';
 import type { SubmissionWithUser } from '@/interface/submission';
-import { type SubmissionLabels } from '@/prisma/enums';
+import { type BountyType, type SubmissionLabels } from '@/prisma/enums';
 import { cn } from '@/utils/cn';
 import { dayjs } from '@/utils/dayjs';
 import { getRankLabels } from '@/utils/rank';
@@ -23,6 +23,7 @@ import { selectedSubmissionAtom } from '../../atoms';
 import { labelMenuOptions } from '../../constants';
 import { colorMap } from '../../utils/statusColorMap';
 import { MultiSelectFilter } from './MultiSelectFilter';
+import { SelectLabel } from './SelectLabel';
 
 interface Props {
   listing?: Listing;
@@ -38,6 +39,7 @@ interface Props {
   toggleAllSubmissions?: () => void;
   isAllToggled?: boolean;
   isMultiSelectDisabled: boolean;
+  isHackathonPage: boolean | undefined;
 }
 
 export const SubmissionList = ({
@@ -52,6 +54,7 @@ export const SubmissionList = ({
   toggleAllSubmissions,
   isAllToggled,
   isMultiSelectDisabled,
+  isHackathonPage,
 }: Props) => {
   const [selectedSubmission, setSelectedSubmission] = useAtom(
     selectedSubmissionAtom,
@@ -215,14 +218,29 @@ export const SubmissionList = ({
                 </div>
               </div>
 
-              <StatusPill
-                className="w-fit px-2 py-0.5 text-[10px]"
-                color={color}
-                backgroundColor={bg}
-                borderColor={border}
-              >
-                {getSubmissionLabel(submission)}
-              </StatusPill>
+              <div className="ml-auto flex w-min flex-col justify-end gap-1 align-bottom">
+                {!isHackathonPage &&
+                submission?.status === 'Pending' &&
+                !listing?.isWinnersAnnounced &&
+                !submission.isWinner &&
+                submission?.label !== 'Spam' &&
+                listing?.slug ? (
+                  <SelectLabel
+                    type={listing?.type as BountyType | 'grant' | undefined}
+                    listingSlug={listing.slug}
+                    submission={submission}
+                  />
+                ) : (
+                  <StatusPill
+                    className="ml-auto w-fit px-2 py-0.5 text-[10px]"
+                    color={color}
+                    backgroundColor={bg}
+                    borderColor={border}
+                  >
+                    {getSubmissionLabel(submission)}
+                  </StatusPill>
+                )}
+              </div>
             </div>
           );
         })}

--- a/src/features/sponsor-dashboard/components/Submissions/SubmissionPanel.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/SubmissionPanel.tsx
@@ -92,6 +92,7 @@ export const SubmissionPanel = ({
                       <SelectLabel
                         type={bounty?.type}
                         listingSlug={bounty?.slug!}
+                        submission={undefined}
                       />
                     )}
                 </div>

--- a/src/pages/earn/dashboard/hackathon/[listing]/submissions.tsx
+++ b/src/pages/earn/dashboard/hackathon/[listing]/submissions.tsx
@@ -255,6 +255,7 @@ export default function BountySubmissions({ listing }: Props) {
                 <div className="grid min-h-[600px] w-full grid-cols-[23rem_1fr] bg-white">
                   <div className="h-full w-full">
                     <SubmissionList
+                      isHackathonPage={true}
                       listing={bounty}
                       selectedFilters={selectedFilters}
                       onFilterChange={setSelectedFilters}

--- a/src/pages/earn/dashboard/listings/[slug]/submissions.tsx
+++ b/src/pages/earn/dashboard/listings/[slug]/submissions.tsx
@@ -480,6 +480,7 @@ export default function BountySubmissions({ slug }: Props) {
             <TabsContent value="submissions" className="w-full px-0">
               <div className="grid h-160 w-full grid-cols-[23rem_1fr] bg-white">
                 <SubmissionList
+                  isHackathonPage={false}
                   listing={bounty}
                   selectedFilters={selectedFilters}
                   onFilterChange={setSelectedFilters}


### PR DESCRIPTION
feat: modify review badges to dropdown input in the submission sidebar (fixes #1420)

## What does this PR do?
This PR updates the submission sidebar in the Sponsor Dashboard. The static review badges ("Unreviewed", "Shortlisted", etc.) have been replaced with a Dropdown input similar to the one found in the main submission details panel. Sponsors can now click the badge directly from the sidebar to change the review label. The click propagation is handled correctly so that interacting with the dropdown does not inadvertently open or close the submission details.

## Where should the reviewer start?
The reviewer should start by looking at `src/features/sponsor-dashboard/components/Submissions/SelectLabel.tsx` where the `DropdownMenu` was integrated to replace the static pill. Next, see `src/features/sponsor-dashboard/components/Submissions/SubmissionList.tsx` for how the new interactive label is conditionally rendered (hidden for hackathons/spams/winners).

## How should this be manually tested?
1. Go to the Sponsor Dashboard and navigate to Submissions or Grant Applications.
2. In the left sidebar listing the submissions, observe that the status badge is now an interactive dropdown.
3. Click on the badge to change the status (e.g., from Unreviewed to Shortlisted).
4. Verify that the label updates successfully, and that clicking the dropdown doesn't unintentionally open the submission details modal.

## Any background context you want to provide?
This change improves the sponsor's UX by allowing quick triage directly from the sidebar list, removing the need to open every single submission just to change its status. 

## What are the relevant issues?
Fixes #1420

## Screenshots (if appropriate)
(Feel free to add a quick screenshot or GIF showing the working dropdown in the sidebar here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pending applications and submissions can now show a label-selection control across grant and non-hackathon submission views.
  * Label selection is now driven by the specific item being displayed (application or submission), with grant-aware behavior for application lists.
* **Bug Fixes**
  * Improved status/pill rendering for pending vs non-pending states, including correct handling of spam.
  * Prevented label-menu interactions from triggering surrounding click/selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->