### PR TITLE
Remove global option while editing listings

### DIFF
--- a/src/app/api/sponsor-dashboard/listing/draft/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/draft/route.ts
@@ -18,7 +18,10 @@ import { validateSession } from '@/features/auth/utils/getSponsorSession';
 import type { ListingFormData } from '@/features/listing-builder/types';
 import { getValidSlug } from '@/features/listing-builder/utils/getValidSlug';
 import { validateDraftPermissions } from '@/features/listing-builder/utils/isListingDraftable';
-import { getValidListingRegion } from '@/features/listing-builder/utils/validateListingRegion';
+import {
+  getValidListingRegion,
+  isChapterSponsorEditingRegionToGlobal,
+} from '@/features/listing-builder/utils/validateListingRegion';
 
 async function transformToPrismaData(
   formData: Partial<ListingFormData>,
@@ -148,6 +151,21 @@ export async function POST(request: Request) {
         return result.error;
       }
       listing = result.listing;
+    }
+
+    if (
+      listing &&
+      body.region &&
+      isChapterSponsorEditingRegionToGlobal({
+        currentRegion: listing.region,
+        nextRegion: body.region,
+        hasChapter: !!listing.sponsor.chapter,
+      })
+    ) {
+      return NextResponse.json(
+        { error: 'Chapter sponsors cannot edit a listing region to Global' },
+        { status: 400 },
+      );
     }
 
     const isDraftNotAllowed = validateDraftPermissions(listing);

--- a/src/components/shared/RegionCombobox.tsx
+++ b/src/components/shared/RegionCombobox.tsx
@@ -208,6 +208,7 @@ export function RegionCombobox({
       }),
     [options],
   );
+  const selectedOption = value ? findOptionByValue(value) : undefined;
 
   return (
     <Popover
@@ -245,9 +246,7 @@ export function RegionCombobox({
             </span>
           )}
           <p className="truncate">
-            {value
-              ? findOptionByValue(value)?.label || placeholder
-              : placeholder}
+            {value ? selectedOption?.label || value : placeholder}
           </p>
           <ChevronsUpDown className="ml-auto h-4 w-4 shrink-0 opacity-50" />
         </Button>

--- a/src/features/listing-builder/components/Form/PrePublish/GeoLock.tsx
+++ b/src/features/listing-builder/components/Form/PrePublish/GeoLock.tsx
@@ -32,6 +32,7 @@ export function GeoLock() {
   );
   const fallbackRegion = officialSuperteamRegion || 'Global';
   const isRegionLocked = !!officialSuperteamRegion && !isEditing;
+  const canSelectGlobal = !officialSuperteamRegion || !isEditing;
   const lockTooltip =
     'Contact the global team if you want to add a global listing.';
   const normalizedRegion = region?.trim();
@@ -90,7 +91,7 @@ export function GeoLock() {
                 >
                   <RegionCombobox
                     superteams
-                    global
+                    global={canSelectGlobal}
                     disabled={isRegionLocked}
                     value={field.value}
                     className={cn(
@@ -98,6 +99,7 @@ export function GeoLock() {
                     )}
                     onChange={(e) => {
                       if (isRegionLocked) return;
+                      if (!canSelectGlobal && e === 'Global') return;
                       field.onChange(e);
                       form.clearErrors('region');
                       form.saveDraft();

--- a/src/features/listing-builder/utils/listingValidator.ts
+++ b/src/features/listing-builder/utils/listingValidator.ts
@@ -14,7 +14,10 @@ import {
   createListingRefinements,
 } from '../types/schema';
 import { checkSlug } from './getValidSlug';
-import { getValidListingRegion } from './validateListingRegion';
+import {
+  getValidListingRegion,
+  isChapterSponsorEditingRegionToGlobal,
+} from './validateListingRegion';
 
 interface ListingValidatorParams {
   listing: ListingWithSponsor;
@@ -69,6 +72,19 @@ export const validateListing = async ({
         ctx.addIssue({
           code: 'custom',
           message: 'Invalid region selected',
+          path: ['region'],
+        });
+      } else if (
+        isEditing &&
+        isChapterSponsorEditingRegionToGlobal({
+          currentRegion: listing.region,
+          nextRegion: validRegion,
+          hasChapter: !!sponsor.chapter,
+        })
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Chapter sponsors cannot edit a listing region to Global',
           path: ['region'],
         });
       } else {

--- a/src/features/listing-builder/utils/validateListingRegion.ts
+++ b/src/features/listing-builder/utils/validateListingRegion.ts
@@ -32,3 +32,20 @@ export async function getValidListingRegion(value?: string | null) {
 
   return normalizedAllowedRegions.get(normalizeRegion(canonicalRegion)) || null;
 }
+
+export function isChapterSponsorEditingRegionToGlobal({
+  currentRegion,
+  nextRegion,
+  hasChapter,
+}: {
+  currentRegion?: string | null;
+  nextRegion?: string | null;
+  hasChapter?: boolean;
+}) {
+  if (!hasChapter) return false;
+
+  return (
+    normalizeRegion(canonicalizeRegionValue(nextRegion || '')) === 'global' &&
+    normalizeRegion(canonicalizeRegionValue(currentRegion || '')) !== 'global'
+  );
+}


### PR DESCRIPTION
## What does this PR do?
- Removes the option of changing region to Global for superteam chapters while editing listings

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)