### PR TITLE
[codex] add avalanche earn landing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,13 @@
 # Windows (with password): mysql://root:YOUR_PASSWORD@localhost:3306/earn_db
 DATABASE_URL='mysql://root@localhost:3306/earn_db'
 
+# Supabase project target for the Avalanche migration.
+# Run: supabase link --project-ref elqxthqtpwztnrixeyun
+SUPABASE_PROJECT_REF='elqxthqtpwztnrixeyun'
+NEXT_PUBLIC_SUPABASE_URL='https://elqxthqtpwztnrixeyun.supabase.co'
+# After prisma/schema.prisma is converted from MySQL to PostgreSQL, set
+# DATABASE_URL to the Supabase Postgres connection string from the dashboard.
+
 # For PlanetScale (production):
 # The app auto-detects PlanetScale URLs (contains '.psdb.cloud')
 # DATABASE_URL='mysql://user:pass@aws.connect.psdb.cloud/database?sslaccept=strict'

--- a/AVALANCHE_MIGRATION.md
+++ b/AVALANCHE_MIGRATION.md
@@ -1,0 +1,47 @@
+# Avalanche Earn Migration Notes
+
+## Current status
+
+- `/earn` is now a standalone Avalanche Earn landing page.
+- Supabase CLI config exists under `supabase/`.
+- The intended Supabase project ref is `elqxthqtpwztnrixeyun`.
+- The existing application database layer is still Prisma with a MySQL schema.
+
+## Supabase link
+
+Use the CLI from the project root:
+
+```bash
+supabase login
+supabase link --project-ref elqxthqtpwztnrixeyun
+```
+
+If prompted, enter the remote database password from the Supabase dashboard.
+The project URL is:
+
+```text
+https://elqxthqtpwztnrixeyun.supabase.co
+```
+
+## Remaining Avalanche port work
+
+The upstream codebase is Solana-first. A production Avalanche migration needs a
+separate wallet and payout pass across:
+
+- `src/components/providers.tsx`
+- `src/context/SolanaWallet.tsx`
+- `src/app/api/wallet/create-signed-transaction/route.ts`
+- `src/features/wallet/components/withdraw/WithdrawFundsFlow.tsx`
+- `src/features/wallet/utils/getConnection.ts`
+- `src/features/wallet/utils/fetchUserTokens.ts`
+- `src/app/api/wallet/price/route.ts`
+- `src/features/sponsor-dashboard/components/Submissions/PayoutButton.tsx`
+- `src/server/tokenList.ts`
+- `src/constants/tokenList.ts`
+- `prisma/schema.prisma`
+- `next.config.ts`
+- `.env.example`
+
+The Prisma schema currently uses `provider = "mysql"`, `relationMode =
+"prisma"`, and MySQL-specific column annotations such as `@db.LongText`. Those
+must be converted before `DATABASE_URL` can point at Supabase Postgres.

--- a/next.config.ts
+++ b/next.config.ts
@@ -27,7 +27,7 @@ const baseCsp = `
   style-src 'self' 'unsafe-inline' https://unpkg.com https://fonts.googleapis.com https://us.posthog.com;
   img-src 'self' blob: data: https://res.cloudinary.com https://*.googleusercontent.com https://googletagmanager.com https://dl.airtable.com https://*.airtableusercontent.com;
   connect-src 'self' blob:  https://auth.privy.io https://*.rpc.privy.systems https://api.mainnet-beta.solana.com https://api.devnet.solana.com https://api.testnet.solana.com https://us.i.posthog.com https://app.posthog.com https://internal-j.posthog.com https://us.posthog.com https://*.helius-rpc.com wss://mainnet.helius-rpc.com https://ipapi.co wss://earn-vibe-production.up.railway.app https://verify.walletconnect.com https://verify.walletconnect.org https://res.cloudinary.com https://api.cloudinary.com https://www.google-analytics.com https://privy.earn.superteam.fun;
-  media-src 'self' blob: data: https://res.cloudinary.com;
+  media-src 'self' blob: data: https://res.cloudinary.com https://d8j0ntlcm91z4.cloudfront.net;
   font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;
   object-src 'none';
   base-uri 'self';

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "Superteam Earn",
-  "short_name": "Earn",
-  "start_url": "/",
+  "name": "Avalanche Earn",
+  "short_name": "Avax Earn",
+  "start_url": "/earn",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",
@@ -14,8 +14,8 @@
       "type": "image/png"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "theme_color": "#070707",
+  "background_color": "#070707",
   "display": "standalone",
   "orientation": "portrait"
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -26,6 +26,10 @@ const TopLoader = dynamic(
   { ssr: false },
 );
 
+type StandaloneComponent = AppProps['Component'] & {
+  standalonePage?: boolean;
+};
+
 function isSTRoute(pathname: string): boolean {
   return ST_ROUTES.includes(pathname);
 }
@@ -33,6 +37,7 @@ function isSTRoute(pathname: string): boolean {
 function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const isST = isSTRoute(router.pathname);
+  const PageComponent = Component as StandaloneComponent;
 
   useEffect(() => {
     if (!isST || typeof window === 'undefined') {
@@ -86,6 +91,14 @@ function App({ Component, pageProps }: AppProps) {
       document.body.style.backgroundColor = '';
     };
   }, [isST]);
+
+  if (PageComponent.standalonePage) {
+    return (
+      <div className={fontVariables}>
+        <Component {...pageProps} key={router.asPath} />
+      </div>
+    );
+  }
 
   if (isST) {
     return (

--- a/src/pages/earn/index.tsx
+++ b/src/pages/earn/index.tsx
@@ -1,12 +1,7 @@
-import { Menu, Search, User, X } from 'lucide-react';
+import { Menu, X } from 'lucide-react';
 import Head from 'next/head';
 import Link from 'next/link';
-import {
-  type CSSProperties,
-  type ReactElement,
-  type ReactNode,
-  useState,
-} from 'react';
+import { type CSSProperties, type ReactElement, useState } from 'react';
 
 import { Meta } from '@/layouts/Meta';
 import { cn } from '@/utils/cn';
@@ -38,34 +33,6 @@ function getEarnCanonical() {
   } catch {
     return undefined;
   }
-}
-
-function NavIconButton({
-  href,
-  label,
-  children,
-  delay,
-  className,
-}: {
-  readonly href: string;
-  readonly label: string;
-  readonly children: ReactNode;
-  readonly delay: number;
-  readonly className?: string;
-}) {
-  return (
-    <Link
-      href={href}
-      aria-label={label}
-      className={cn(
-        'avalanche-liquid-glass avalanche-animate-blur-fade-up inline-flex h-10 w-10 items-center justify-center rounded-full text-zinc-50 transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98]',
-        className,
-      )}
-      style={revealStyle(delay)}
-    >
-      {children}
-    </Link>
-  );
 }
 
 type StandalonePage = {
@@ -124,17 +91,6 @@ const AvalancheEarnLanding: StandalonePage = function AvalancheEarnLanding() {
             </div>
 
             <div className="flex items-center gap-3">
-              <Link
-                href="/earn/search"
-                className="avalanche-liquid-glass avalanche-animate-blur-fade-up hidden items-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-zinc-50 no-underline transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:inline-flex md:px-6"
-                style={revealStyle(350)}
-              >
-                <span>Search</span>
-                <Search size={18} aria-hidden="true" />
-              </Link>
-              <NavIconButton href="/earn/signin" label="Sign in" delay={400}>
-                <User size={18} aria-hidden="true" />
-              </NavIconButton>
               <button
                 type="button"
                 aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
@@ -194,22 +150,6 @@ const AvalancheEarnLanding: StandalonePage = function AvalancheEarnLanding() {
                   {item.label}
                 </Link>
               ))}
-            </div>
-            <div className="mt-4 grid grid-cols-2 gap-3 border-t border-zinc-800 pt-4 sm:hidden">
-              <Link
-                href="/earn/search"
-                className="avalanche-liquid-glass inline-flex min-h-11 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-zinc-50 no-underline focus-visible:ring-2 focus-visible:ring-zinc-50/70"
-              >
-                <span>Search</span>
-                <Search size={18} aria-hidden="true" />
-              </Link>
-              <Link
-                href="/earn/signin"
-                className="avalanche-liquid-glass inline-flex min-h-11 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-zinc-50 no-underline focus-visible:ring-2 focus-visible:ring-zinc-50/70"
-              >
-                <span>Profile</span>
-                <User size={18} aria-hidden="true" />
-              </Link>
             </div>
           </div>
 

--- a/src/pages/earn/index.tsx
+++ b/src/pages/earn/index.tsx
@@ -1,15 +1,4 @@
-import {
-  Calendar,
-  ChevronLeft,
-  ChevronRight,
-  Menu,
-  Play,
-  Search,
-  Star,
-  Timer,
-  User,
-  X,
-} from 'lucide-react';
+import { Menu, Search, User, X } from 'lucide-react';
 import Head from 'next/head';
 import Link from 'next/link';
 import {
@@ -31,13 +20,6 @@ const navItems = [
   { label: 'Grants', href: '/earn/grants' },
   { label: 'Talent', href: '/earn/new/talent' },
   { label: 'Sponsors', href: '/earn/sponsor' },
-];
-
-const metadataItems = [
-  { icon: Star, label: 'Avalanche Ecosystem' },
-  { icon: Timer, label: 'Bounties, Projects & Grants' },
-  { icon: Calendar, label: 'Paid in USDC / AVAX' },
-  { icon: ChevronRight, label: 'Remote-first' },
 ];
 
 function revealStyle(delay: number): CSSProperties {
@@ -93,6 +75,7 @@ type StandalonePage = {
 
 const AvalancheEarnLanding: StandalonePage = function AvalancheEarnLanding() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [hasJoinedWaitlist, setHasJoinedWaitlist] = useState(false);
   const canonical = getEarnCanonical();
 
   return (
@@ -230,85 +213,57 @@ const AvalancheEarnLanding: StandalonePage = function AvalancheEarnLanding() {
             </div>
           </div>
 
-          <section className="relative z-10 flex flex-1 flex-col justify-end px-4 pb-8 sm:px-6 md:px-12 md:pb-16">
-            <div className="flex flex-col items-start gap-8 lg:flex-row lg:items-end lg:justify-between">
-              <div className="max-w-5xl flex-1">
-                <div
-                  className="avalanche-animate-blur-fade-up mb-6 flex flex-wrap items-center gap-3 text-xs font-medium text-zinc-50/80 sm:gap-6 sm:text-sm md:mb-8"
-                  style={revealStyle(300)}
-                >
-                  {metadataItems.map(({ icon: Icon, label }) => (
-                    <span
-                      key={label}
-                      className="inline-flex items-center gap-2"
-                    >
-                      <Icon
-                        size={16}
-                        aria-hidden="true"
-                        className={cn(
-                          label === 'Avalanche Ecosystem' && 'fill-zinc-50',
-                        )}
-                      />
-                      {label}
-                    </span>
-                  ))}
-                </div>
-
+          <section className="relative z-10 flex flex-1 flex-col items-center justify-center px-4 pb-8 text-center sm:px-6 md:px-12 md:pb-16">
+            <div className="w-full max-w-5xl">
+              <div className="mx-auto max-w-4xl">
                 <h1
-                  className="avalanche-animate-blur-fade-up mb-4 max-w-4xl text-4xl leading-[1.02] font-normal tracking-[-0.04em] text-zinc-50 sm:text-5xl md:mb-6 md:text-6xl lg:text-7xl"
+                  className="avalanche-animate-blur-fade-up mb-6 text-5xl leading-[1.02] font-normal tracking-[-0.04em] text-zinc-50 sm:text-6xl md:text-7xl lg:text-8xl"
                   style={revealStyle(400)}
                 >
-                  Build What&apos;s Next on Avalanche
+                  Join the Waitlist
                 </h1>
 
                 <p
-                  className="avalanche-animate-blur-fade-up mb-6 max-w-2xl text-base leading-relaxed text-zinc-300 sm:text-lg md:mb-12 md:text-xl"
+                  className="avalanche-animate-blur-fade-up mx-auto mb-10 max-w-3xl text-xl leading-relaxed font-semibold text-zinc-300 sm:text-2xl md:text-3xl"
                   style={revealStyle(500)}
                 >
-                  Discover bounties, grants, and high-impact project work from
-                  teams building across the Avalanche ecosystem.
+                  Get early access to Avalanche Earn, the marketplace for
+                  bounties, grants, and project work launching soon.
                 </p>
 
-                <div className="flex flex-wrap items-center gap-3 sm:gap-4">
-                  <Link
-                    href="/earn/new/talent"
-                    className="avalanche-animate-blur-fade-up inline-flex min-h-11 items-center gap-2 rounded-full bg-zinc-50 px-6 py-2.5 text-sm font-semibold text-zinc-950 no-underline transition-[background-color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:px-8 sm:py-3"
-                    style={revealStyle(600)}
-                  >
-                    <Play
-                      size={18}
-                      aria-hidden="true"
-                      className="fill-zinc-950"
-                    />
-                    <span>Start Earning</span>
-                  </Link>
-                  <Link
-                    href="/earn/new/sponsor"
-                    className="avalanche-liquid-glass avalanche-animate-blur-fade-up inline-flex min-h-11 items-center rounded-full px-6 py-2.5 text-sm font-semibold text-zinc-50 no-underline transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:px-8 sm:py-3"
-                    style={revealStyle(700)}
-                  >
-                    Post an Opportunity
-                  </Link>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-3 lg:justify-end">
-                <Link
-                  href="/earn/new/talent"
-                  className="avalanche-liquid-glass avalanche-animate-blur-fade-up inline-flex min-h-11 items-center gap-2 rounded-full px-4 py-2.5 text-sm font-medium text-zinc-50 no-underline transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:px-6 sm:py-3"
-                  style={revealStyle(800)}
+                <form
+                  className="avalanche-animate-blur-fade-up mx-auto flex w-full max-w-3xl flex-col gap-4 sm:flex-row"
+                  style={revealStyle(650)}
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    setHasJoinedWaitlist(true);
+                  }}
                 >
-                  <ChevronLeft size={18} aria-hidden="true" />
-                  <span>For Talent</span>
-                </Link>
-                <Link
-                  href="/earn/new/sponsor"
-                  className="avalanche-liquid-glass avalanche-animate-blur-fade-up inline-flex min-h-11 items-center gap-2 rounded-full px-4 py-2.5 text-sm font-medium text-zinc-50 no-underline transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:px-6 sm:py-3"
-                  style={revealStyle(900)}
+                  <label htmlFor="waitlist-email" className="sr-only">
+                    Email address
+                  </label>
+                  <input
+                    id="waitlist-email"
+                    name="email"
+                    type="email"
+                    autoComplete="email"
+                    required
+                    placeholder="you@company.com"
+                    className="min-h-16 flex-1 rounded-[1.75rem] border border-zinc-500/60 bg-zinc-950/55 px-6 text-lg font-semibold text-zinc-50 shadow-[inset_0_1px_1px_rgba(255,255,255,0.08)] backdrop-blur-md transition-[border-color,background-color] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] placeholder:text-zinc-500 focus-visible:border-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:outline-none sm:min-h-20 sm:rounded-[2rem] sm:px-8 sm:text-2xl"
+                  />
+                  <button
+                    type="submit"
+                    className="min-h-16 rounded-[1.75rem] bg-[#e84142] px-8 text-lg font-bold text-zinc-50 transition-[background-color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-[#ff3536] focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:min-h-20 sm:rounded-[2rem] sm:px-12 sm:text-2xl"
+                  >
+                    Get Notified
+                  </button>
+                </form>
+                <p
+                  aria-live="polite"
+                  className="mt-4 min-h-6 text-sm font-medium text-zinc-300"
                 >
-                  <span>For Teams</span>
-                  <ChevronRight size={18} aria-hidden="true" />
-                </Link>
+                  {hasJoinedWaitlist ? 'Thanks, we will be in touch soon.' : ''}
+                </p>
               </div>
             </div>
           </section>

--- a/src/pages/earn/index.tsx
+++ b/src/pages/earn/index.tsx
@@ -1,154 +1,323 @@
-import { usePrivy } from '@privy-io/react-auth';
-import { useQuery } from '@tanstack/react-query';
-import { type GetServerSideProps } from 'next';
-import dynamic from 'next/dynamic';
-
-import { JsonLd } from '@/components/shared/JsonLd';
-import { useBreakpoint } from '@/hooks/use-breakpoint';
-import { Default } from '@/layouts/Default';
-import { Meta } from '@/layouts/Meta';
-import { prisma } from '@/prisma';
-import { useUser } from '@/store/user';
-import { cn } from '@/utils/cn';
 import {
-  generateOrganizationSchema,
-  generateWebSiteSchema,
-} from '@/utils/json-ld';
+  Calendar,
+  ChevronLeft,
+  ChevronRight,
+  Menu,
+  Play,
+  Search,
+  Star,
+  Timer,
+  User,
+  X,
+} from 'lucide-react';
+import Head from 'next/head';
+import Link from 'next/link';
+import {
+  type CSSProperties,
+  type ReactElement,
+  type ReactNode,
+  useState,
+} from 'react';
 
-import { ProListingsAnnouncement } from '@/features/announcements/components/ProListingsAnnouncement';
-import { BannerCarousel } from '@/features/home/components/Banner';
-import { SponsorStageBanner } from '@/features/home/components/SponsorStage/SponsorStageBanner';
-import { UserStatsBanner } from '@/features/home/components/UserStatsBanner';
-import { userCountQuery } from '@/features/home/queries/user-count';
-import { ListingsSection } from '@/features/listings/components/ListingsSection';
+import { Meta } from '@/layouts/Meta';
+import { cn } from '@/utils/cn';
 
-const GrantsSection = dynamic(() =>
-  import('@/features/grants/components/GrantsSection').then(
-    (mod) => mod.GrantsSection,
-  ),
-);
+const VIDEO_URL =
+  'https://d8j0ntlcm91z4.cloudfront.net/user_38xzZboKViGWJOttwIXH07lWA1P/hf_20260406_094145_4a271a6c-3869-4f1c-8aa7-aeb0cb227994.mp4';
 
-const HomeSideBar = dynamic(() =>
-  import('@/features/home/components/SideBar').then((mod) => mod.HomeSideBar),
-);
+const navItems = [
+  { label: 'Bounties', href: '/earn/bounties' },
+  { label: 'Projects', href: '/earn/projects' },
+  { label: 'Grants', href: '/earn/grants' },
+  { label: 'Talent', href: '/earn/new/talent' },
+  { label: 'Sponsors', href: '/earn/sponsor' },
+];
 
-const HomepagePop = dynamic(
-  () =>
-    import('@/features/conversion-popups/components/HomepagePop').then(
-      (mod) => mod.HomepagePop,
-    ),
-  { ssr: false },
-);
+const metadataItems = [
+  { icon: Star, label: 'Avalanche Ecosystem' },
+  { icon: Timer, label: 'Bounties, Projects & Grants' },
+  { icon: Calendar, label: 'Paid in USDC / AVAX' },
+  { icon: ChevronRight, label: 'Remote-first' },
+];
 
-interface HomePageProps {
-  readonly potentialSession: boolean;
-  readonly totalUsers: number;
-  readonly totalSponsors: number;
+function revealStyle(delay: number): CSSProperties {
+  return { animationDelay: `${delay}ms` };
 }
 
-export default function HomePage({
-  potentialSession,
-  totalUsers,
-  totalSponsors,
-}: HomePageProps) {
-  const { authenticated } = usePrivy();
-  useQuery({ ...userCountQuery, initialData: { totalUsers } });
-  const { user } = useUser();
-  const isLg = useBreakpoint('lg');
+function getEarnCanonical() {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
 
-  const organizationSchema = generateOrganizationSchema();
-  const websiteSchema = generateWebSiteSchema();
+  if (!siteUrl) {
+    return undefined;
+  }
 
+  try {
+    return new URL('/earn/', siteUrl).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function NavIconButton({
+  href,
+  label,
+  children,
+  delay,
+  className,
+}: {
+  readonly href: string;
+  readonly label: string;
+  readonly children: ReactNode;
+  readonly delay: number;
+  readonly className?: string;
+}) {
   return (
-    <Default
-      className="bg-white"
-      topBanner={
-        <div className="w-full border-b border-slate-200 bg-slate-50">
-          <div className="mx-auto flex max-w-7xl items-center justify-center px-4 py-2 text-center text-xs font-medium text-slate-700 sm:text-sm">
-            <a
-              href="/earn/agents"
-              className="text-brand-purple hover:text-brand-purple-dark font-mono text-[8px] tracking-[0.2em] uppercase no-underline sm:text-xs"
-            >
-              If you&apos;re an AI agent, browse agent-eligible listings to earn
-              your first crypto.
-            </a>
-          </div>
-        </div>
-      }
-      meta={
-        <>
-          <Meta
-            title="Superteam Earn | Crypto Bounties, Web3 Jobs & Solana Opportunities | Work to Earn in Crypto"
-            description="Find crypto bounties, web3 jobs, and Solana opportunities. Earn crypto by completing bounties in design, development, and content. The leading platform for remote crypto work."
-            canonical="https://superteam.fun/earn/"
-          />
-          <JsonLd data={[organizationSchema, websiteSchema]} />
-        </>
-      }
+    <Link
+      href={href}
+      aria-label={label}
+      className={cn(
+        'avalanche-liquid-glass avalanche-animate-blur-fade-up inline-flex h-10 w-10 items-center justify-center rounded-full text-zinc-50 transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98]',
+        className,
+      )}
+      style={revealStyle(delay)}
     >
-      <div className={cn('mx-auto w-full px-2 lg:px-6')}>
-        <div className="mx-auto w-full max-w-7xl p-0">
-          <div className="flex items-start justify-between">
-            <div className="w-full lg:border-r lg:border-slate-100">
-              <div className="w-full lg:pr-6">
-                <div className="pt-3">
-                  {potentialSession || authenticated ? (
-                    <>
-                      {!!user?.currentSponsorId && isLg ? (
-                        <div className="mt-3">
-                          <SponsorStageBanner />
-                        </div>
-                      ) : (
-                        <UserStatsBanner />
-                      )}
-                    </>
-                  ) : (
-                    <BannerCarousel
-                      totalUsers={totalUsers}
-                      totalSponsors={totalSponsors}
-                    />
-                  )}
-                </div>
-                <div className="w-full">
-                  <ListingsSection
-                    type="home"
-                    potentialSession={potentialSession}
-                  />
-                  {/* <HackathonSection type="home" /> */}
-                  <GrantsSection type="home" />
-                </div>
-              </div>
-            </div>
-            {isLg && (
-              <div className="flex">
-                <HomeSideBar type="landing" />
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-      <HomepagePop />
-      <ProListingsAnnouncement />
-    </Default>
+      {children}
+    </Link>
   );
 }
 
-export const getServerSideProps: GetServerSideProps<HomePageProps> = async ({
-  req,
-}) => {
-  const cookies = req.headers.cookie || '';
-
-  const cookieExists = /(^|;)\s*user-id-hint=/.test(cookies);
-
-  const [userCount, sponsorCount] = await Promise.all([
-    prisma.user.count(),
-    prisma.sponsors.count(),
-  ]);
-
-  const totalUsers = Math.ceil((userCount - 289) / 10) * 10;
-  const totalSponsors = Math.ceil(sponsorCount / 10) * 10;
-
-  return {
-    props: { potentialSession: cookieExists, totalUsers, totalSponsors },
-  };
+type StandalonePage = {
+  (): ReactElement;
+  standalonePage?: boolean;
 };
+
+const AvalancheEarnLanding: StandalonePage = function AvalancheEarnLanding() {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const canonical = getEarnCanonical();
+
+  return (
+    <>
+      <Meta
+        title="Avalanche Earn | Bounties, Grants & Projects on Avalanche"
+        description="Find Avalanche bounties, grants, and project work. Build for leading Avalanche teams, earn in crypto, and apply with one profile."
+        canonical={canonical}
+      />
+      <Head>
+        <link rel="preconnect" href="https://d8j0ntlcm91z4.cloudfront.net" />
+      </Head>
+      <main className="relative flex min-h-[100dvh] overflow-hidden bg-[#070707] font-sans text-zinc-50">
+        <video
+          className="fixed inset-0 z-0 h-full w-full object-cover"
+          src={VIDEO_URL}
+          autoPlay
+          loop
+          muted
+          playsInline
+          aria-hidden="true"
+        />
+        <div className="avalanche-bottom-blur pointer-events-none fixed inset-0 z-[1]" />
+
+        <div className="relative z-10 flex min-h-[100dvh] w-full flex-col">
+          <nav className="relative z-50 flex items-center justify-between px-4 py-4 sm:px-6 md:px-12 md:py-6">
+            <Link
+              href="/earn"
+              className="avalanche-animate-blur-fade-up flex h-8 items-center text-sm font-semibold tracking-[0.18em] text-zinc-50 uppercase no-underline transition-colors duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 md:h-10"
+              style={revealStyle(0)}
+            >
+              Avalanche Earn
+            </Link>
+
+            <div className="hidden items-center gap-7 lg:flex">
+              {navItems.map((item, index) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="avalanche-animate-blur-fade-up text-sm font-medium text-zinc-50/80 no-underline transition-colors duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-50 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+                  style={revealStyle(100 + index * 50)}
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Link
+                href="/earn/search"
+                className="avalanche-liquid-glass avalanche-animate-blur-fade-up hidden items-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-zinc-50 no-underline transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:inline-flex md:px-6"
+                style={revealStyle(350)}
+              >
+                <span>Search</span>
+                <Search size={18} aria-hidden="true" />
+              </Link>
+              <NavIconButton href="/earn/signin" label="Sign in" delay={400}>
+                <User size={18} aria-hidden="true" />
+              </NavIconButton>
+              <button
+                type="button"
+                aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
+                aria-controls="avalanche-mobile-menu"
+                aria-expanded={isMenuOpen}
+                onClick={() => setIsMenuOpen((current) => !current)}
+                className="avalanche-liquid-glass avalanche-animate-blur-fade-up relative inline-flex h-10 w-10 items-center justify-center rounded-full text-zinc-50 transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] lg:hidden"
+                style={revealStyle(350)}
+              >
+                <Menu
+                  size={20}
+                  aria-hidden="true"
+                  className={cn(
+                    'absolute transition-[opacity,transform] duration-500 ease-[cubic-bezier(0.16,1,0.3,1)]',
+                    isMenuOpen
+                      ? 'scale-50 rotate-180 opacity-0'
+                      : 'scale-100 rotate-0 opacity-100',
+                  )}
+                />
+                <X
+                  size={20}
+                  aria-hidden="true"
+                  className={cn(
+                    'absolute transition-[opacity,transform] duration-500 ease-[cubic-bezier(0.16,1,0.3,1)]',
+                    isMenuOpen
+                      ? 'scale-100 rotate-0 opacity-100'
+                      : 'scale-50 -rotate-180 opacity-0',
+                  )}
+                />
+              </button>
+            </div>
+          </nav>
+
+          <div
+            id="avalanche-mobile-menu"
+            className={cn(
+              'absolute top-[72px] right-0 left-0 z-40 border-y border-zinc-800 bg-zinc-950/95 px-4 py-4 shadow-2xl backdrop-blur-lg transition-[opacity,transform] duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] lg:hidden',
+              isMenuOpen
+                ? 'translate-y-0 opacity-100'
+                : 'pointer-events-none -translate-y-4 opacity-0',
+            )}
+          >
+            <div className="flex flex-col gap-1">
+              {navItems.map((item, index) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={() => setIsMenuOpen(false)}
+                  className={cn(
+                    'rounded-lg px-3 py-3 text-sm font-medium text-zinc-100 no-underline transition-[background-color,color,transform,opacity] duration-500 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-zinc-800/50 hover:text-zinc-50 focus-visible:ring-2 focus-visible:ring-zinc-50/70',
+                    isMenuOpen
+                      ? 'translate-x-0 opacity-100'
+                      : '-translate-x-4 opacity-0',
+                  )}
+                  style={revealStyle(index * 50)}
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+            <div className="mt-4 grid grid-cols-2 gap-3 border-t border-zinc-800 pt-4 sm:hidden">
+              <Link
+                href="/earn/search"
+                className="avalanche-liquid-glass inline-flex min-h-11 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-zinc-50 no-underline focus-visible:ring-2 focus-visible:ring-zinc-50/70"
+              >
+                <span>Search</span>
+                <Search size={18} aria-hidden="true" />
+              </Link>
+              <Link
+                href="/earn/signin"
+                className="avalanche-liquid-glass inline-flex min-h-11 items-center justify-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-zinc-50 no-underline focus-visible:ring-2 focus-visible:ring-zinc-50/70"
+              >
+                <span>Profile</span>
+                <User size={18} aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
+
+          <section className="relative z-10 flex flex-1 flex-col justify-end px-4 pb-8 sm:px-6 md:px-12 md:pb-16">
+            <div className="flex flex-col items-start gap-8 lg:flex-row lg:items-end lg:justify-between">
+              <div className="max-w-5xl flex-1">
+                <div
+                  className="avalanche-animate-blur-fade-up mb-6 flex flex-wrap items-center gap-3 text-xs font-medium text-zinc-50/80 sm:gap-6 sm:text-sm md:mb-8"
+                  style={revealStyle(300)}
+                >
+                  {metadataItems.map(({ icon: Icon, label }) => (
+                    <span
+                      key={label}
+                      className="inline-flex items-center gap-2"
+                    >
+                      <Icon
+                        size={16}
+                        aria-hidden="true"
+                        className={cn(
+                          label === 'Avalanche Ecosystem' && 'fill-zinc-50',
+                        )}
+                      />
+                      {label}
+                    </span>
+                  ))}
+                </div>
+
+                <h1
+                  className="avalanche-animate-blur-fade-up mb-4 max-w-4xl text-4xl leading-[1.02] font-normal tracking-[-0.04em] text-zinc-50 sm:text-5xl md:mb-6 md:text-6xl lg:text-7xl"
+                  style={revealStyle(400)}
+                >
+                  Build What&apos;s Next on Avalanche
+                </h1>
+
+                <p
+                  className="avalanche-animate-blur-fade-up mb-6 max-w-2xl text-base leading-relaxed text-zinc-300 sm:text-lg md:mb-12 md:text-xl"
+                  style={revealStyle(500)}
+                >
+                  Discover bounties, grants, and high-impact project work from
+                  teams building across the Avalanche ecosystem.
+                </p>
+
+                <div className="flex flex-wrap items-center gap-3 sm:gap-4">
+                  <Link
+                    href="/earn/new/talent"
+                    className="avalanche-animate-blur-fade-up inline-flex min-h-11 items-center gap-2 rounded-full bg-zinc-50 px-6 py-2.5 text-sm font-semibold text-zinc-950 no-underline transition-[background-color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:bg-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:px-8 sm:py-3"
+                    style={revealStyle(600)}
+                  >
+                    <Play
+                      size={18}
+                      aria-hidden="true"
+                      className="fill-zinc-950"
+                    />
+                    <span>Start Earning</span>
+                  </Link>
+                  <Link
+                    href="/earn/new/sponsor"
+                    className="avalanche-liquid-glass avalanche-animate-blur-fade-up inline-flex min-h-11 items-center rounded-full px-6 py-2.5 text-sm font-semibold text-zinc-50 no-underline transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:px-8 sm:py-3"
+                    style={revealStyle(700)}
+                  >
+                    Post an Opportunity
+                  </Link>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3 lg:justify-end">
+                <Link
+                  href="/earn/new/talent"
+                  className="avalanche-liquid-glass avalanche-animate-blur-fade-up inline-flex min-h-11 items-center gap-2 rounded-full px-4 py-2.5 text-sm font-medium text-zinc-50 no-underline transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:px-6 sm:py-3"
+                  style={revealStyle(800)}
+                >
+                  <ChevronLeft size={18} aria-hidden="true" />
+                  <span>For Talent</span>
+                </Link>
+                <Link
+                  href="/earn/new/sponsor"
+                  className="avalanche-liquid-glass avalanche-animate-blur-fade-up inline-flex min-h-11 items-center gap-2 rounded-full px-4 py-2.5 text-sm font-medium text-zinc-50 no-underline transition-[color,transform] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-zinc-50/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 active:scale-[0.98] sm:px-6 sm:py-3"
+                  style={revealStyle(900)}
+                >
+                  <span>For Teams</span>
+                  <ChevronRight size={18} aria-hidden="true" />
+                </Link>
+              </div>
+            </div>
+          </section>
+        </div>
+      </main>
+    </>
+  );
+};
+
+AvalancheEarnLanding.standalonePage = true;
+
+export default AvalancheEarnLanding;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -645,3 +645,74 @@ h3.tiptap-heading + h2.tiptap-heading {
     transition-duration: 0.01ms !important;
   }
 }
+
+.avalanche-bottom-blur {
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  mask-image: linear-gradient(to top, black 0%, transparent 45%);
+  -webkit-mask-image: linear-gradient(to top, black 0%, transparent 45%);
+}
+
+.avalanche-liquid-glass {
+  background: rgba(255, 255, 255, 0.01);
+  background-blend-mode: luminosity;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  border: none;
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.1);
+  overflow: hidden;
+  position: relative;
+}
+
+.avalanche-liquid-glass::before {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.4px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.45) 0%,
+    rgba(255, 255, 255, 0.15) 20%,
+    rgba(255, 255, 255, 0) 40%,
+    rgba(255, 255, 255, 0) 60%,
+    rgba(255, 255, 255, 0.15) 80%,
+    rgba(255, 255, 255, 0.45) 100%
+  );
+  content: '';
+  pointer-events: none;
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+}
+
+@keyframes avalancheBlurFadeUp {
+  from {
+    opacity: 0;
+    filter: blur(20px);
+    transform: translateY(40px);
+  }
+  to {
+    opacity: 1;
+    filter: blur(0);
+    transform: translateY(0);
+  }
+}
+
+.avalanche-animate-blur-fade-up {
+  animation: avalancheBlurFadeUp 1s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .avalanche-animate-blur-fade-up {
+    animation: none !important;
+    filter: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/src/utils/AppConfig.ts
+++ b/src/utils/AppConfig.ts
@@ -1,7 +1,7 @@
 export const AppConfig = {
-  site_name: 'Superteam Earn',
-  title: 'Superteam Earn',
+  site_name: 'Avalanche Earn',
+  title: 'Avalanche Earn',
   description:
-    'Find crypto bounties, web3 jobs, and Solana opportunities. Earn crypto for your skills in development, design, and content.',
+    'Find Avalanche bounties, grants, and project work. Build for leading Avalanche teams, earn in crypto, and apply with one profile.',
   locale: 'en',
 };

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,417 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "avalanche_earn"
+
+[remotes.production]
+project_id = "elqxthqtpwztnrixeyun"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ `{{ .Code }}` }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"


### PR DESCRIPTION
## What changed

- Replaced the `/earn` homepage with a standalone cinematic Avalanche Earn landing page based on the supplied hero prompt.
- Added liquid glass styling, blur-fade-up animation, responsive mobile nav, and CSP media allowance for the provided CloudFront video.
- Added Supabase CLI config targeting project `elqxthqtpwztnrixeyun` and documented the remaining Avalanche migration work.
- Updated default Earn metadata and PWA manifest naming to Avalanche Earn.

## Validation

- `./node_modules/.bin/tsc --noEmit --pretty`
- `./node_modules/.bin/oxlint . --quiet` (0 errors, existing warnings remain)
- Local dev server at `http://localhost:3000/earn`
- Chrome responsive checks at 1280, 768, and 375 px: no horizontal overflow, video present, CTA visible, old movie copy removed.

## Notes

The upstream app is still Solana-first in wallet, payout, token metadata, and Prisma/MySQL database code. Full Avalanche wallet/payment and Supabase Postgres migration require a separate backend pass.