### PR TITLE
Close Nigeria grants to new applications

### DIFF
--- a/src/app/api/grant-application/update/route.ts
+++ b/src/app/api/grant-application/update/route.ts
@@ -190,7 +190,7 @@ export async function POST(request: NextRequest) {
     const { grant, user } = await validateGrantRequest(
       userId as string,
       grantId,
-      { skipLocationCooldown: true },
+      { skipLocationCooldown: true, skipStatusCheck: true },
     );
 
     if (grant.isST) {

--- a/src/features/grants/components/ApplicationActionButton.tsx
+++ b/src/features/grants/components/ApplicationActionButton.tsx
@@ -41,6 +41,7 @@ export const ApplicationActionButton = ({
 
   const { region, id, link, isNative, isPublished, isPro, isST, sponsorId } =
     grant;
+  const isClosedForNewApplications = grant.status !== 'OPEN';
   const isUserPro = user?.isPro;
   const isUserEligibleST = isUserEligibleForST(user);
 
@@ -97,12 +98,16 @@ export const ApplicationActionButton = ({
     buttonConfig.isDisabled ||
     Boolean(
       !isPublished ||
+      (isClosedForNewApplications && applicationState === 'ALLOW NEW') ||
       (user?.id && user?.isTalentFilled && !isUserEligibleByRegion) ||
       (user?.id && user?.isTalentFilled && isNewApplicationLocationCooldown) ||
       isNotEligibleForPro,
     );
 
   const getButtonText = () => {
+    if (isClosedForNewApplications && applicationState === 'ALLOW NEW') {
+      return 'Closed';
+    }
     if (isNewApplicationLocationCooldown) {
       return 'Ineligible';
     }

--- a/src/features/grants/components/GrantEntry.tsx
+++ b/src/features/grants/components/GrantEntry.tsx
@@ -39,15 +39,19 @@ export const GrantEntry = ({
   token,
   slug,
   logo,
+  status,
 }: {
   title: string;
   rewardAmount?: number;
   token?: string;
   slug: string;
   logo?: string;
+  status?: string;
   minReward?: number;
   maxReward?: number;
 }) => {
+  const isClosed = status !== 'OPEN';
+
   return (
     <Link
       className="mx-auto block w-full cursor-pointer overflow-hidden rounded-lg border shadow-md transition-all duration-300 hover:shadow-lg sm:w-80"
@@ -77,7 +81,7 @@ export const GrantEntry = ({
             variant="outline"
             className="hover:bg-brand-purple w-full border-slate-300 bg-gray-100 text-sm font-medium text-slate-400 hover:text-white"
           >
-            Apply Now
+            {isClosed ? 'Closed' : 'Apply Now'}
           </Button>
         </Link>
       </div>

--- a/src/features/grants/constants/schema.ts
+++ b/src/features/grants/constants/schema.ts
@@ -37,6 +37,7 @@ export const grantsSelect = {
   historicalApplications: true,
   totalPaid: true,
   logo: true,
+  status: true,
   isPro: true,
   isST: true,
   sponsor: {

--- a/src/features/grants/hooks/useApplicationState.ts
+++ b/src/features/grants/hooks/useApplicationState.ts
@@ -33,11 +33,7 @@ export const useApplicationState = (
     }
 
     if (application.applicationStatus === 'Pending') {
-      if (grant.isNative) {
-        setApplicationState('ALLOW EDIT');
-      } else {
-        setApplicationState('APPLIED');
-      }
+      setApplicationState('ALLOW EDIT');
       return;
     }
 

--- a/src/features/grants/utils/validateGrantRequest.ts
+++ b/src/features/grants/utils/validateGrantRequest.ts
@@ -7,7 +7,7 @@ import { userRegionEligibilty } from '@/features/listings/utils/region';
 export async function validateGrantRequest(
   userId: string,
   grantId: string,
-  options?: { skipLocationCooldown?: boolean },
+  options?: { skipLocationCooldown?: boolean; skipStatusCheck?: boolean },
 ) {
   const grant = await prisma.grants.findUnique({
     where: { id: grantId },
@@ -17,6 +17,7 @@ export async function validateGrantRequest(
       slug: true,
       isActive: true,
       isPublished: true,
+      status: true,
       region: true,
       minReward: true,
       maxReward: true,
@@ -40,6 +41,10 @@ export async function validateGrantRequest(
 
   if (grant.isActive === false || grant.isPublished === false) {
     throw new Error('Grant is not active');
+  }
+
+  if (!options?.skipStatusCheck && grant.status !== 'OPEN') {
+    throw new Error('Grant is closed');
   }
 
   const user = await prisma.user.findUnique({

--- a/src/pages/earn/grants/index.tsx
+++ b/src/pages/earn/grants/index.tsx
@@ -79,6 +79,7 @@ function Grants() {
                     maxReward={grant?.maxReward}
                     token={grant?.token}
                     logo={grant?.logo}
+                    status={grant?.status}
                   />
                 </div>
               ))}


### PR DESCRIPTION
## Problem

We need to stop accepting new applications for the Nigeria grants:

- `touching-grass-nigeria`
- `solana-foundation-nigeria-grants`

Changing the DB rows to `CLOSED` already makes the grant header look closed, but it did not fully close the application flow. A user could still see application-oriented CTAs in some places, and direct API submissions were not guarded by grant status.

## Solution

This makes `Grant.status = CLOSED` mean "not accepting new applications" across the grant application path:

- The create application API now rejects closed grants.
- The main grant CTA shows `Closed` and disables only the new-application state.
- Existing pending application edits still work, so we do not freeze users who already applied.
- Existing approved/KYC/tranche flows still work.
- The older grants listing card now shows `Closed` instead of `Apply Now` for closed grants.

The code is intentionally not hardcoded to Nigeria. The rollout stays scoped to Nigeria by updating only those two grant rows to `CLOSED` in the DB.

## Why this approach

Hardcoding Nigeria slugs would solve today's request, but it would make future grant closures require code changes. Since the product already has `OPEN | CLOSED` grant status and the header already treats non-open grants as closed, using that status as the source of truth is the simpler and more maintainable path.

## DB follow-up

After this is deployed, close only the two Nigeria grants:

```sql
UPDATE Grants
SET status = 'CLOSED'
WHERE slug IN (
  'touching-grass-nigeria',
  'solana-foundation-nigeria-grants'
);
```

## Checks

- `pnpm lint` passed
- `git diff --check` passed
- `pnpm check-types` was run and still fails on existing generated/schema mismatches unrelated to this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grants now show whether applications are open or closed, with closed grants displaying “Closed” instead of “Apply Now.”
  * The application action button now reflects grant availability more clearly and prevents starting new applications when a grant is closed.

* **Bug Fixes**
  * Pending applications now consistently stay editable instead of switching to a different state in some cases.
  * Grant application validation now respects closed-status checks, while selected flows can still bypass that check when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->