### PR TITLE
fix(logger): raise production minLevel to INFO (DEBUG was always on)

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,7 +1,10 @@
 import { Logger } from 'tslog';
 
 const logger = new Logger({
-  minLevel: process.env.IS_LOCAL === 'true' ? 2 : 2,
+  // tslog levels: DEBUG=2, INFO=3. Locally surface DEBUG; in production
+  // start at INFO so debug logs (which include full request bodies) are
+  // not emitted to the log sink.
+  minLevel: process.env.IS_LOCAL === 'true' ? 2 : 3,
   prettyLogTimeZone: 'UTC',
   prettyErrorStackTemplate:
     '  • {{fileName}}\t{{method}}\n\t{{filePathWithLine}}',


### PR DESCRIPTION
### Problem
`src/lib/logger.ts` sets:
    minLevel: process.env.IS_LOCAL === 'true' ? 2 : 2

Both ternary branches are `2` (tslog DEBUG), so the logger stays at DEBUG
in every environment. Several API routes log full request bodies at debug
level (e.g. `pow/create`, `comment/create` call
`logger.debug(\`Request body: ${safeStringify(req.body)}\`)`), so
user-submitted payloads are emitted to the production log sink on every
request. The `IS_LOCAL` check suggests the intent was a higher threshold
in production.

### Fix
Local keeps DEBUG (2); production starts at INFO (3), so debug-level
request-body logs are no longer emitted in prod. One-line change + comment.

### Testing
Type-checks; no behavioural change beyond the log level threshold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced log verbosity in non-local environments, so debug-level details are no longer shown by default.
  * Local development still keeps debug logging enabled for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->