### PR TITLE
feat: migrate likes from JSON schema fields to a dedicated Likes data…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -292,7 +292,6 @@ model GrantApplication {
   isShipped           Boolean                @default(false)
   paymentDetails      Json?
   totalTranches       Int                    @default(0)
-  like                Json?
   likeCount           Int                    @default(0)
   Comments            Comment[]
   decidedBy           String?
@@ -357,7 +356,6 @@ model Submission {
   isArchived         Boolean          @default(false)
   createdAt          DateTime         @default(now())
   updatedAt          DateTime         @updatedAt
-  like               Json?
   likeCount          Int              @default(0)
   isPaid             Boolean          @default(false)
   paymentDetails     Json?
@@ -504,6 +502,7 @@ model User {
   isAgent            Boolean              @default(false)
   agentProfile       Agent?
   claimedAgents      Agent[]              @relation("AgentClaimedBy")
+  likes              Likes[]
 
   @@index([currentSponsorId])
   @@index([hackathonId])
@@ -624,7 +623,6 @@ model PoW {
   createdAt   DateTime  @default(now())
   subSkills   Json?
   updatedAt   DateTime  @updatedAt
-  like        Json?
   likeCount   Int       @default(0)
   user        User      @relation(fields: [userId], references: [id])
   ogImage     String?   @db.Text
@@ -1127,6 +1125,25 @@ enum CreditEventType {
   REFERRAL_FIRST_SUBMISSION_BONUS_INVITEE
   REFERRAL_FIRST_SUBMISSION_BONUS_INVITER
   REFERRAL_INVITEE_WIN_BONUS_INVITER
+}
+
+model Likes {
+  id         String         @id @default(uuid())
+  userId     String
+  targetType LikeTargetType
+  targetId   String
+  createdAt  DateTime       @default(now())
+  user       User           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, targetType, targetId])
+  @@index([targetType, targetId, createdAt])
+  @@index([userId])
+}
+
+enum LikeTargetType {
+  SUBMISSION
+  POW
+  GRANT_APPLICATION
 }
 
 enum TalentRankingSkills {

--- a/src/pages/api/feed/[type]/[id]/get.ts
+++ b/src/pages/api/feed/[type]/[id]/get.ts
@@ -153,7 +153,7 @@ export default async function handler(
             //@ts-expect-error prisma ts error, this exists based on above include
             sponsorSlug: sub.listing.sponsor.slug,
             type: 'submission',
-            like: sub.like,
+            like: [] as { id: string; date: number }[],
             likeCount: sub.likeCount,
             ogImage: getCloudinaryFetchUrl(sub.ogImage),
             commentCount: sub._count.Comments,
@@ -216,7 +216,7 @@ export default async function handler(
             username: pow.user.username,
             type: 'pow',
             link: pow.link,
-            like: pow.like,
+            like: [] as { id: string; date: number }[],
             likeCount: pow.likeCount,
             ogImage: getCloudinaryFetchUrl(pow.ogImage),
             commentCount: pow._count.Comments,
@@ -283,7 +283,7 @@ export default async function handler(
             sponsorSlug: ga.grant.sponsor.slug,
             type: 'grant-application',
             grantApplicationAmount: ga.approvedAmount,
-            like: ga.like,
+            like: [] as { id: string; date: number }[],
             likeCount: ga.likeCount,
             commentCount: ga._count.Comments,
             recentCommenters: ga.Comments,
@@ -292,6 +292,32 @@ export default async function handler(
         break;
       }
     }
+    if (feedPost && feedPost.length > 0) {
+      const targetTypeMapForFeed: Record<string, 'SUBMISSION' | 'POW' | 'GRANT_APPLICATION'> = {
+        submission: 'SUBMISSION',
+        pow: 'POW',
+        grantApplication: 'GRANT_APPLICATION',
+      };
+      const feedType = targetTypeMapForFeed[type]!;
+      const feedIds = feedPost.map((p: any) => p.id).filter(Boolean);
+      const likes = feedIds.length > 0
+        ? await prisma.likes.findMany({
+            where: { targetType: feedType, targetId: { in: feedIds } },
+            select: { targetId: true, userId: true, createdAt: true },
+          })
+        : [];
+      const likesMap = new Map<string, { id: string; date: number }[]>();
+      for (const like of likes) {
+        const arr = likesMap.get(like.targetId) ?? [];
+        arr.push({ id: like.userId, date: like.createdAt.getTime() });
+        likesMap.set(like.targetId, arr);
+      }
+      feedPost = feedPost.map((p: any) => ({
+        ...p,
+        like: likesMap.get(p.id) || [],
+      }));
+    }
+
     if (!feedPost) {
       logger.warn(`No Posts found for type ${type} with ID ${id}`);
       res.status(404).send({

--- a/src/pages/api/feed/[type]/[id]/get.ts
+++ b/src/pages/api/feed/[type]/[id]/get.ts
@@ -296,7 +296,7 @@ export default async function handler(
       const targetTypeMapForFeed: Record<string, 'SUBMISSION' | 'POW' | 'GRANT_APPLICATION'> = {
         submission: 'SUBMISSION',
         pow: 'POW',
-        grantApplication: 'GRANT_APPLICATION',
+        'grant-application': 'GRANT_APPLICATION',
       };
       const feedType = targetTypeMapForFeed[type]!;
       const feedIds = feedPost.map((p: any) => p.id).filter(Boolean);

--- a/src/pages/api/feed/get.ts
+++ b/src/pages/api/feed/get.ts
@@ -375,9 +375,55 @@ export default async function handler(
       grantApplications.unshift(grantApplicationHighlighted);
     }
 
-    logger.info(
-      `Fetched ${submissions.length} submissions, ${pow.length} PoWs and ${grantApplications} grant applications`,
-    );
+    const subIds = submissions.map((s) => s.id);
+    const powIds = pow.map((p) => p.id);
+    const gaIds = grantApplications.map((ga) => ga.id);
+
+    const [subLikes, poWLikes, gaLikes] = await Promise.all([
+      subIds.length > 0
+        ? prisma.likes.findMany({
+            where: {
+              targetType: 'SUBMISSION',
+              targetId: { in: subIds },
+            },
+            select: { targetId: true, userId: true, createdAt: true },
+          })
+        : [],
+      powIds.length > 0
+        ? prisma.likes.findMany({
+            where: {
+              targetType: 'POW',
+              targetId: { in: powIds },
+            },
+            select: { targetId: true, userId: true, createdAt: true },
+          })
+        : [],
+      gaIds.length > 0
+        ? prisma.likes.findMany({
+            where: {
+              targetType: 'GRANT_APPLICATION',
+              targetId: { in: gaIds },
+            },
+            select: { targetId: true, userId: true, createdAt: true },
+          })
+        : [],
+    ]);
+
+    const likesByTargetId = (
+      likes: { targetId: string; userId: string; createdAt: Date }[],
+    ) => {
+      const map = new Map<string, { id: string; date: number }[]>();
+      for (const like of likes) {
+        const arr = map.get(like.targetId) ?? [];
+        arr.push({ id: like.userId, date: like.createdAt.getTime() });
+        map.set(like.targetId, arr);
+      }
+      return map;
+    };
+
+    const subLikesMap = likesByTargetId(subLikes);
+    const poWLikesMap = likesByTargetId(poWLikes);
+    const gaLikesMap = likesByTargetId(gaLikes);
 
     const results = [
       ...submissions.map((sub) => ({
@@ -451,7 +497,7 @@ export default async function handler(
             ? sub.listing.sponsor.slug
             : null,
         type: 'submission',
-        like: sub.like,
+        like: subLikesMap.get(sub.id) || [],
         likeCount: sub.likeCount,
         ogImage: !sub.listing.isPrivate
           ? getCloudinaryFetchUrl(sub.ogImage)
@@ -472,7 +518,7 @@ export default async function handler(
         username: pow.user.username,
         type: 'pow',
         link: pow.link,
-        like: pow.like,
+        like: poWLikesMap.get(pow.id) || [],
         likeCount: pow.likeCount,
         ogImage: getCloudinaryFetchUrl(pow.ogImage),
         commentCount: pow._count.Comments,
@@ -506,7 +552,7 @@ export default async function handler(
             : null,
         type: 'grant-application',
         grantApplicationAmount: ga.approvedAmount,
-        like: ga.like,
+        like: gaLikesMap.get(ga.id) || [],
         likeCount: ga.likeCount,
         commentCount: ga._count.Comments,
         recentCommenters: ga.Comments,

--- a/src/pages/api/listings/submissions/[slug].ts
+++ b/src/pages/api/listings/submissions/[slug].ts
@@ -75,7 +75,6 @@ export async function getSubmissionsData(
       link: true,
       isWinner: true,
       winnerPosition: true,
-      like: true,
       likeCount: true,
       rewardInUSD: true,
       createdAt: true,
@@ -91,9 +90,28 @@ export async function getSubmissionsData(
     },
   });
 
-  submission.sort(sortSubmissions);
+  const subIds = submission.map((s) => s.id);
+  const likes = subIds.length > 0
+    ? await prisma.likes.findMany({
+        where: { targetType: 'SUBMISSION', targetId: { in: subIds } },
+        select: { targetId: true, userId: true, createdAt: true },
+      })
+    : [];
+  const likesMap = new Map<string, { id: string; date: number }[]>();
+  for (const like of likes) {
+    const arr = likesMap.get(like.targetId) ?? [];
+    arr.push({ id: like.userId, date: like.createdAt.getTime() });
+    likesMap.set(like.targetId, arr);
+  }
 
-  return { bounty, submission };
+  const submissionWithLikes = submission.map((s) => ({
+    ...s,
+    like: likesMap.get(s.id) || [],
+  }));
+
+  submissionWithLikes.sort(sortSubmissions);
+
+  return { bounty, submission: submissionWithLikes };
 }
 
 export default async function user(req: NextApiRequest, res: NextApiResponse) {

--- a/src/services/likeService.ts
+++ b/src/services/likeService.ts
@@ -7,22 +7,24 @@ const targetTypeMap: Record<string, keyof typeof LikeTargetType> = {
   grantApplication: 'GRANT_APPLICATION',
 };
 
+type TxPrisma = Omit<typeof prisma, '$connect' | '$disconnect' | '$on' | '$transaction' | '$extends'>;
+
 const modelUpdateMap: Record<
   string,
-  (id: string, delta: number) => Promise<unknown>
+  (id: string, delta: number, tx?: TxPrisma) => Promise<unknown>
 > = {
-  submission: (id: string, delta: number) =>
-    prisma.submission.update({
+  submission: (id: string, delta: number, tx?: TxPrisma) =>
+    (tx ?? prisma).submission.update({
       where: { id },
       data: { likeCount: { increment: delta } },
     }),
-  poW: (id: string, delta: number) =>
-    prisma.poW.update({
+  poW: (id: string, delta: number, tx?: TxPrisma) =>
+    (tx ?? prisma).poW.update({
       where: { id },
       data: { likeCount: { increment: delta } },
     }),
-  grantApplication: (id: string, delta: number) =>
-    prisma.grantApplication.update({
+  grantApplication: (id: string, delta: number, tx?: TxPrisma) =>
+    (tx ?? prisma).grantApplication.update({
       where: { id },
       data: { likeCount: { increment: delta } },
     }),
@@ -32,28 +34,32 @@ export async function updateLike(
   model: 'submission' | 'poW' | 'grantApplication',
   itemId: string,
   userId: string,
-) {
+): Promise<{ likesIncremented: boolean }> {
   const targetType = LikeTargetType[targetTypeMap[model]!];
   const uniqueWhere = {
     userId_targetType_targetId: { userId, targetType, targetId: itemId },
   } as const;
 
   try {
-    await prisma.likes.create({
-      data: { userId, targetType, targetId: itemId },
+    return await prisma.$transaction(async (tx) => {
+      await tx.likes.create({
+        data: { userId, targetType, targetId: itemId },
+      });
+      await modelUpdateMap[model]!(itemId, 1, tx);
+      return { likesIncremented: true };
     });
-    await modelUpdateMap[model]!(itemId, 1);
-    return { likesIncremented: true };
   } catch (err: any) {
     if (err.code === 'P2002') {
-      try {
-        await prisma.likes.delete({ where: uniqueWhere });
-      } catch (deleteErr: any) {
-        if (deleteErr.code !== 'P2025') throw deleteErr;
+      return await prisma.$transaction(async (tx) => {
+        try {
+          await tx.likes.delete({ where: uniqueWhere });
+        } catch (deleteErr: any) {
+          if (deleteErr.code !== 'P2025') throw deleteErr;
+          return { likesIncremented: false };
+        }
+        await modelUpdateMap[model]!(itemId, -1, tx);
         return { likesIncremented: false };
-      }
-      await modelUpdateMap[model]!(itemId, -1);
-      return { likesIncremented: false };
+      });
     }
     throw err;
   }

--- a/src/services/likeService.ts
+++ b/src/services/likeService.ts
@@ -1,100 +1,60 @@
 import { prisma } from '@/prisma';
+import { LikeTargetType } from '@/prisma/enums';
+
+const targetTypeMap: Record<string, keyof typeof LikeTargetType> = {
+  submission: 'SUBMISSION',
+  poW: 'POW',
+  grantApplication: 'GRANT_APPLICATION',
+};
+
+const modelUpdateMap: Record<
+  string,
+  (id: string, delta: number) => Promise<unknown>
+> = {
+  submission: (id: string, delta: number) =>
+    prisma.submission.update({
+      where: { id },
+      data: { likeCount: { increment: delta } },
+    }),
+  poW: (id: string, delta: number) =>
+    prisma.poW.update({
+      where: { id },
+      data: { likeCount: { increment: delta } },
+    }),
+  grantApplication: (id: string, delta: number) =>
+    prisma.grantApplication.update({
+      where: { id },
+      data: { likeCount: { increment: delta } },
+    }),
+};
 
 export async function updateLike(
   model: 'submission' | 'poW' | 'grantApplication',
   itemId: string,
   userId: string,
 ) {
-  let result;
+  const targetType = LikeTargetType[targetTypeMap[model]!];
+  const uniqueWhere = {
+    userId_targetType_targetId: { userId, targetType, targetId: itemId },
+  } as const;
 
-  if (model === 'submission') {
-    result = await prisma.submission.findFirst({
-      where: {
-        id: itemId,
-      },
+  try {
+    await prisma.likes.create({
+      data: { userId, targetType, targetId: itemId },
     });
-  } else if (model === 'poW') {
-    result = await prisma.poW.findFirst({
-      where: {
-        id: itemId,
-      },
-    });
-  } else if (model === 'grantApplication') {
-    result = await prisma.grantApplication.findFirst({
-      where: {
-        id: itemId,
-      },
-    });
-  } else {
-    throw new Error('Invalid model provided');
-  }
-
-  let newLikes = [];
-  const resLikes = result?.like as {
-    id: string;
-    date: number;
-  }[];
-
-  if (resLikes?.length > 0) {
-    const like = resLikes.find((e) => e?.id === userId);
-    if (like) {
-      newLikes = resLikes.filter((e) => e.id !== userId);
-    } else {
-      newLikes = [
-        ...resLikes,
-        {
-          id: userId,
-          date: Date.now(),
-        },
-      ];
+    await modelUpdateMap[model]!(itemId, 1);
+    return { likesIncremented: true };
+  } catch (err: any) {
+    if (err.code === 'P2002') {
+      try {
+        await prisma.likes.delete({ where: uniqueWhere });
+      } catch (deleteErr: any) {
+        if (deleteErr.code !== 'P2025') throw deleteErr;
+        return { likesIncremented: false };
+      }
+      await modelUpdateMap[model]!(itemId, -1);
+      return { likesIncremented: false };
     }
-  } else {
-    newLikes = [
-      {
-        id: userId,
-        date: Date.now(),
-      },
-    ];
+    throw err;
   }
-
-  const likeCount = newLikes.length;
-
-  let updateLike;
-
-  if (model === 'submission') {
-    updateLike = await prisma.submission.update({
-      where: {
-        id: itemId,
-      },
-      data: {
-        like: newLikes,
-        likeCount,
-      },
-    });
-  } else if (model === 'poW') {
-    updateLike = await prisma.poW.update({
-      where: {
-        id: itemId,
-      },
-      data: {
-        like: newLikes,
-        likeCount,
-      },
-    });
-  } else if (model === 'grantApplication') {
-    updateLike = await prisma.grantApplication.update({
-      where: {
-        id: itemId,
-      },
-      data: {
-        like: newLikes,
-        likeCount,
-      },
-    });
-  }
-
-  return {
-    likesIncremented: likeCount > (result?.likeCount || 0),
-    updatedData: updateLike,
-  };
 }


### PR DESCRIPTION
## Summary

Fix a TOCTOU (time-of-check–time-of-use) race condition in the like service where concurrent likes could be silently dropped. Replace the non-atomic JSON read-then-write pattern with a dedicated `Likes` table and an atomic create-or-delete toggle.

## What does this PR do?

- Introduces a normalized `Likes` table with a unique constraint on `(userId, targetType, targetId)` and supporting indexes.
- Replaces the JSON `like` array fields on `Submission`, `PoW`, and `GrantApplication` with relational likes.
- Refactors `updateLike` to use an atomic `create`-or-`delete` toggle driven by the DB unique constraint instead of a JSON read–mutate–write cycle.
- Updates feed and listing APIs to hydrate likes from the `Likes` table in batch.
- Adds a migration script to backfill existing JSON likes into the new `Likes` table.

## Where should the reviewer start?

- Schema and enums: `prisma/schema.prisma`
- Core toggle logic: `src/services/likeService.ts`
- Read side / hydration:  
  - `src/pages/api/feed/get.ts`  
  - `src/pages/api/feed/[type]/[id]/get.ts`  
  - `src/pages/api/listings/submissions/[slug].ts`

## How should this be manually tested?

1. Run DB migrations and backfill:
   - `pnpm prisma migrate deploy`
   - `pnpm tsx scripts/migrate-likes.ts`
2. Verify type safety:
   - `pnpm tsc --noEmit --pretty`
3. Functional checks:
   - Like and unlike a submission/PoW/grant application as a single user; ensure `likeCount` and UI stay in sync.
   - With two different users, like the same item nearly simultaneously (or via a small script / multiple tabs); both likes should be preserved and `likeCount` should equal the number of distinct users.
   - Rapidly toggle like/unlike from multiple tabs as the same user; `likeCount` should never go negative or drift.

## Any background context you want to provide?

Previously, likes were stored as a JSON array (`like Json?`) directly on `Submission`, `PoW`, and `GrantApplication`. `updateLike` would:

- `findFirst` the row
- mutate the JSON array in memory
- `update` the row with the new JSON and `likeCount`

Under concurrent load, both requests could read the same JSON, apply different mutations, and the later write would overwrite the earlier one, silently dropping likes. Prisma doesn’t support compare-and-swap semantics on JSON columns, so this pattern was inherently racy.

The new design delegates concurrency control to the database via a unique index on the `Likes` table.

## What are the relevant issues?

- Fixes #1435 – Like service TOCTOU race condition where concurrent likes were silently dropped.

## Screenshots (if appropriate)

N/A – behaviour change is in persistence and API responses rather than UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced like tracking for submissions, PoWs, and grant applications by storing individual likes separately from content records.
  * Like details (including timestamps) are now consistently populated in feeds and listings.
* **Bug Fixes**
  * Improved like/unlike behavior with stronger duplicate-prevention per user per item.
  * More accurate like counts and safer synchronization when likes are updated or removed, including when related records are deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->