### PR TITLE
Added payment replay checks for txn verification

### DIFF
--- a/src/features/sponsor-dashboard/utils/paymentReplayCheck.ts
+++ b/src/features/sponsor-dashboard/utils/paymentReplayCheck.ts
@@ -1,0 +1,93 @@
+import { prisma } from '@/prisma';
+import { Prisma } from '@/prisma/client';
+
+type PrismaLike = Pick<typeof prisma, '$queryRaw'>;
+
+type PaymentReplayRow = {
+  txId: string;
+};
+
+const MAX_TX_IDS_PER_REPLAY_CHECK = 25;
+
+export function normalizePaymentTxId(txId: string) {
+  const trimmedTxId = txId.trim();
+
+  try {
+    const url = new URL(trimmedTxId);
+    const match = url.pathname.match(/\/tx\/([A-Za-z0-9]+)/);
+    return match?.[1] ?? trimmedTxId;
+  } catch {
+    const match = trimmedTxId.match(/\/tx\/([A-Za-z0-9]+)/);
+    return match?.[1] ?? trimmedTxId;
+  }
+}
+
+function escapeJsonSearchPattern(value: string) {
+  return value.replace(/[\\%_]/g, '\\$&');
+}
+
+function paymentTxSearchPatterns(txId: string) {
+  const escapedTxId = escapeJsonSearchPattern(txId);
+
+  return [
+    escapedTxId,
+    `%/tx/${escapedTxId}`,
+    `%/tx/${escapedTxId}?%`,
+    `%/tx/${escapedTxId}#%`,
+    `%/tx/${escapedTxId}/%`,
+  ];
+}
+
+function buildJsonSearchExistsQuery(
+  tableName: 'GrantApplication' | 'Submission',
+) {
+  return (txId: string) => {
+    const searchPredicates = paymentTxSearchPatterns(txId).map(
+      (pattern) =>
+        Prisma.sql`JSON_SEARCH(JSON_EXTRACT(paymentDetails, '$[*].txId'), 'one', ${pattern}) IS NOT NULL`,
+    );
+
+    return Prisma.sql`
+      EXISTS (
+        SELECT 1
+        FROM ${Prisma.raw(`\`${tableName}\``)}
+        WHERE paymentDetails IS NOT NULL
+          AND (${Prisma.join(searchPredicates, ' OR ')})
+        LIMIT 1
+      )
+    `;
+  };
+}
+
+export async function findUsedPaymentTxIds(
+  txIds: string[],
+  client: PrismaLike = prisma,
+) {
+  const uniqueTxIds = [
+    ...new Set(txIds.filter(Boolean).map(normalizePaymentTxId)),
+  ];
+  if (uniqueTxIds.length === 0) return [];
+
+  if (uniqueTxIds.length > MAX_TX_IDS_PER_REPLAY_CHECK) {
+    throw new Error(
+      `Cannot check more than ${MAX_TX_IDS_PER_REPLAY_CHECK} transaction IDs at once`,
+    );
+  }
+
+  const submissionHasPaymentTxId = buildJsonSearchExistsQuery('Submission');
+  const grantHasPaymentTxId = buildJsonSearchExistsQuery('GrantApplication');
+
+  const replayChecks = uniqueTxIds.map(
+    (txId) => Prisma.sql`
+      SELECT ${txId} AS txId
+      WHERE ${submissionHasPaymentTxId(txId)}
+         OR ${grantHasPaymentTxId(txId)}
+    `,
+  );
+
+  const rows = await client.$queryRaw<PaymentReplayRow[]>(
+    Prisma.sql`${Prisma.join(replayChecks, ' UNION ALL ')}`,
+  );
+
+  return [...new Set(rows.map((row) => row.txId))];
+}

--- a/src/pages/api/sponsor-dashboard/grants/add-tranche.ts
+++ b/src/pages/api/sponsor-dashboard/grants/add-tranche.ts
@@ -2,26 +2,39 @@ import type { NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
+import { getTokenBySymbol } from '@/server/tokenList';
 import { safeStringify } from '@/utils/safeStringify';
 
 import { type NextApiRequestWithSponsor } from '@/features/auth/types';
 import { checkGrantSponsorAuth } from '@/features/auth/utils/checkGrantSponsorAuth';
 import { withSponsorAuth } from '@/features/auth/utils/withSponsorAuth';
 import { queueEmail } from '@/features/emails/utils/queueEmail';
+import {
+  findUsedPaymentTxIds,
+  normalizePaymentTxId,
+} from '@/features/sponsor-dashboard/utils/paymentReplayCheck';
+import { validatePayment } from '@/features/sponsor-dashboard/utils/paymentRPCValidation';
+import { fetchTokenUSDValue } from '@/features/wallet/utils/fetchTokenUSDValue';
 
 async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   const { id, trancheAmount, txId = '' } = req.body;
-  const parsedTrancheAmount = parseInt(trancheAmount, 10);
+  const parsedTrancheAmount = Number(trancheAmount);
 
   const userId = req.userId;
   const userSponsorId = req.userSponsorId;
 
   logger.debug(`Request body: ${safeStringify(req.body)}`);
 
-  if (!id || !trancheAmount) {
-    logger.warn('Missing required body parameters: id or trancheAmount');
+  if (!id || trancheAmount === undefined || trancheAmount === null || !txId) {
+    logger.warn('Missing required body parameters: id, trancheAmount, or txId');
     return res.status(400).json({
-      error: 'Missing required body parameters: id or trancheAmount',
+      error: 'Missing required body parameters: id, trancheAmount, or txId',
+    });
+  }
+
+  if (!Number.isFinite(parsedTrancheAmount) || parsedTrancheAmount <= 0) {
+    return res.status(400).json({
+      error: 'trancheAmount must be a positive finite number',
     });
   }
 
@@ -44,6 +57,53 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
 
     if (error) {
       return res.status(error.status).json({ error: error.message });
+    }
+
+    const remainingAmount =
+      currentApplication.approvedAmount - currentApplication.totalPaid;
+    if (parsedTrancheAmount > remainingAmount) {
+      return res.status(400).json({
+        error: `Tranche amount exceeds remaining approved amount (${remainingAmount})`,
+      });
+    }
+
+    const normalizedTxId = normalizePaymentTxId(txId);
+    const alreadyUsedTxIds = await findUsedPaymentTxIds([normalizedTxId]);
+    if (alreadyUsedTxIds.length > 0) {
+      return res.status(400).json({
+        error: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
+      });
+    }
+
+    const dbToken = await getTokenBySymbol(currentApplication.grant.token);
+    if (!dbToken) {
+      return res.status(400).json({
+        error: "Token doesn't exist for this grant",
+      });
+    }
+
+    let tokenPriceUSD: number | undefined;
+    try {
+      tokenPriceUSD = await fetchTokenUSDValue(dbToken.mintAddress);
+    } catch (err) {
+      logger.warn(
+        `Failed to fetch token price for ${dbToken.tokenSymbol}, falling back to fixed tolerance`,
+      );
+    }
+
+    const validationResult = await validatePayment({
+      txId: normalizedTxId,
+      recipientPublicKey: currentApplication.walletAddress,
+      expectedAmount: parsedTrancheAmount,
+      tokenMint: dbToken,
+      tokenPriceUSD,
+    });
+
+    if (!validationResult.isValid) {
+      return res.status(400).json({
+        error: validationResult.error,
+        message: `Transaction validation failed: ${validationResult.error}`,
+      });
     }
 
     let updatedPaymentDetails = currentApplication.paymentDetails || [];

--- a/src/pages/api/sponsor-dashboard/listings/verify-external-payment.ts
+++ b/src/pages/api/sponsor-dashboard/listings/verify-external-payment.ts
@@ -13,6 +13,10 @@ import {
   type VerifyPaymentsFormData,
 } from '@/features/sponsor-dashboard/types';
 import {
+  findUsedPaymentTxIds,
+  normalizePaymentTxId,
+} from '@/features/sponsor-dashboard/utils/paymentReplayCheck';
+import {
   validatePayment,
   type ValidationResult,
 } from '@/features/sponsor-dashboard/utils/paymentRPCValidation';
@@ -89,7 +93,10 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
 
     const validationResults: ValidatePaymentResult[] = [];
 
-    const txIds = paymentLinks.map((link) => link.txId).filter(Boolean);
+    const txIds = paymentLinks
+      .map((link) => link.txId)
+      .filter(Boolean)
+      .map(normalizePaymentTxId);
     const duplicateTxIds = txIds.filter(
       (txId, index) => txIds.indexOf(txId) !== index,
     );
@@ -103,32 +110,12 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     // transaction replay attacks where a txId from a paid submission is reused
     // for a different winner.
     if (txIds.length === 0) {
-      return res.status(400).json({ error: 'No valid transaction IDs provided' });
+      return res
+        .status(400)
+        .json({ error: 'No valid transaction IDs provided' });
     }
 
-    const submissionsUsingTxIds: Array<{
-      id: string;
-      paymentDetails: unknown;
-    }> = await prisma.submission.findMany({
-      where: {
-        OR: txIds.map((txId) => ({
-          paymentDetails: { string_contains: txId },
-        })),
-      },
-      select: { id: true, paymentDetails: true },
-    });
-
-    const alreadyUsedTxIds = [
-      ...new Set(
-        submissionsUsingTxIds
-          .flatMap((sub): (string | undefined)[] =>
-            (
-              (sub.paymentDetails as Array<{ txId?: string }> | null) ?? []
-            ).map((p) => p.txId),
-          )
-          .filter((txId): txId is string => !!txId && txIds.includes(txId)),
-      ),
-    ];
+    const alreadyUsedTxIds = await findUsedPaymentTxIds(txIds);
 
     if (alreadyUsedTxIds.length > 0) {
       return res.status(400).json({

--- a/src/pages/api/sponsor-dashboard/submission/add-payment.ts
+++ b/src/pages/api/sponsor-dashboard/submission/add-payment.ts
@@ -9,6 +9,10 @@ import { type NextApiRequestWithSponsor } from '@/features/auth/types';
 import { checkListingSponsorAuth } from '@/features/auth/utils/checkListingSponsorAuth';
 import { withSponsorAuth } from '@/features/auth/utils/withSponsorAuth';
 import { queueEmail } from '@/features/emails/utils/queueEmail';
+import {
+  findUsedPaymentTxIds,
+  normalizePaymentTxId,
+} from '@/features/sponsor-dashboard/utils/paymentReplayCheck';
 import { validatePayment } from '@/features/sponsor-dashboard/utils/paymentRPCValidation';
 import { fetchTokenUSDValue } from '@/features/wallet/utils/fetchTokenUSDValue';
 
@@ -71,6 +75,28 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     }
 
     const { listing, user, winnerPosition } = currentSubmission;
+    const txIds = paymentDetails
+      .map((payment: { txId?: string }) => payment.txId)
+      .filter((txId: string | undefined): txId is string => !!txId)
+      .map(normalizePaymentTxId);
+    const duplicateTxIds = txIds.filter(
+      (txId, index) => txIds.indexOf(txId) !== index,
+    );
+    if (duplicateTxIds.length > 0) {
+      const uniqueDuplicateTxIds = [...new Set(duplicateTxIds)];
+      return res.status(400).json({
+        error: `Duplicate transaction IDs found: ${uniqueDuplicateTxIds.join(', ')}`,
+        message: `Duplicate transaction IDs found: ${uniqueDuplicateTxIds.join(', ')}`,
+      });
+    }
+
+    const alreadyUsedTxIds = await findUsedPaymentTxIds(txIds);
+    if (alreadyUsedTxIds.length > 0) {
+      return res.status(400).json({
+        error: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
+        message: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
+      });
+    }
 
     const isProject = listing.type === 'project';
     if (!isProject) {


### PR DESCRIPTION
## What does this PR do?
- introduces a utility func replayCheck that checks if a txn id has being used before or not, efficiently.
- add-payment and verify-external-payment both use this to verify txn id properly
- also added the check to add-tranche and fortified the amount checks.

i have added the function stress test results since it checks from the JSON fields directly without introducing schema changes.
```
10k nested payments:
old=63.41ms, heap=12.79 MB
new=115.53ms, heap=4.89 MB

100k nested payments:
old=633.35ms, heap=18.45 MB
new=1167.70ms, heap=7.72 MB

500k nested payments:
old=5110.87ms, heap=70.45 MB
new=6521.86ms, heap=18.79 MB
```
## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)