### PR TITLE
Add cap to search and list endpoints

### DIFF
--- a/src/pages/api/agents/comments/[id].ts
+++ b/src/pages/api/agents/comments/[id].ts
@@ -1,6 +1,7 @@
 import type { NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { safeStringify } from '@/utils/safeStringify';
 
 import { type NextApiRequestWithAgent } from '@/features/auth/types';
@@ -14,8 +15,26 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
 
   const params = req.query;
   const refId = params.id as string;
-  const skip = params.skip ? parseInt(params.skip as string, 10) : 0;
-  const take = params.take ? parseInt(params.take as string, 10) : 0;
+  const skipResult = parseBoundedIntegerParam(params.skip, {
+    defaultValue: 0,
+    maxValue: 1000,
+    name: 'skip',
+  });
+  const takeResult = parseBoundedIntegerParam(params.take, {
+    defaultValue: 10,
+    maxValue: 50,
+    name: 'take',
+  });
+
+  if (!skipResult.ok) {
+    return res.status(400).json({ error: skipResult.error });
+  }
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+
+  const skip = skipResult.value;
+  const take = takeResult.value;
 
   logger.debug(
     `[AgentComment] Fetching comments for refId=${refId}, skip=${skip}`,

--- a/src/pages/api/agents/listings/live.ts
+++ b/src/pages/api/agents/listings/live.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/prisma';
 import { type EnumBountyTypeFilter } from '@/prisma/commonInputTypes';
 import { type BountyType } from '@/prisma/enums';
 import { type BountiesFindManyArgs } from '@/prisma/models/Bounties';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 
 import { type NextApiRequestWithAgent } from '@/features/auth/types';
 import { withAgentAuth } from '@/features/auth/utils/withAgentAuth';
@@ -14,7 +15,15 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
   const params = req.query;
 
   const type = params.type as EnumBountyTypeFilter | BountyType | undefined;
-  const take = params.take ? parseInt(params.take as string, 10) : 10;
+  const takeResult = parseBoundedIntegerParam(params.take, {
+    defaultValue: 10,
+    maxValue: 50,
+    name: 'take',
+  });
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+  const take = takeResult.value;
   const deadline = params.deadline as string;
   const exclusiveSponsorId = params.exclusiveSponsorId as string | undefined;
   let excludeIds = params['excludeIds[]'];

--- a/src/pages/api/comment/[id]/index.ts
+++ b/src/pages/api/comment/[id]/index.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { safeStringify } from '@/utils/safeStringify';
 
 import { fetchComments } from '@/features/comments/utils/fetchComments';
@@ -13,8 +14,26 @@ export default async function comment(
 
   const params = req.query;
   const refId = params.id as string;
-  const skip = params.skip ? parseInt(params.skip as string, 10) : 0;
-  const take = params.take ? parseInt(params.take as string, 10) : 0;
+  const skipResult = parseBoundedIntegerParam(params.skip, {
+    defaultValue: 0,
+    maxValue: 1000,
+    name: 'skip',
+  });
+  const takeResult = parseBoundedIntegerParam(params.take, {
+    defaultValue: 10,
+    maxValue: 50,
+    name: 'take',
+  });
+
+  if (!skipResult.ok) {
+    return res.status(400).json({ error: skipResult.error });
+  }
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+
+  const skip = skipResult.value;
+  const take = takeResult.value;
 
   logger.debug(`Fetching comments for listingId=${refId}, skip=${skip}`);
 

--- a/src/pages/api/feed/get.ts
+++ b/src/pages/api/feed/get.ts
@@ -7,6 +7,7 @@ import { type GrantApplicationInclude } from '@/prisma/models';
 import { type CommentFindManyArgs } from '@/prisma/models/Comment';
 import { type PoWGetPayload, type PoWInclude } from '@/prisma/models/PoW';
 import { type SubmissionInclude } from '@/prisma/models/Submission';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { getCloudinaryFetchUrl } from '@/utils/cloudinary';
 import { dayjs } from '@/utils/dayjs';
 import { safeStringify } from '@/utils/safeStringify';
@@ -19,14 +20,27 @@ export default async function handler(
   res: NextApiResponse,
 ): Promise<void> {
   logger.debug(`Request query: ${safeStringify(req.query)}`);
-  const {
-    timePeriod,
-    take = 15,
-    skip = 0,
-    isWinner,
-    filter,
-    userId,
-  } = req.query;
+  const { timePeriod, isWinner, filter, userId } = req.query;
+  const takeResult = parseBoundedIntegerParam(req.query.take, {
+    defaultValue: 15,
+    maxValue: 30,
+    name: 'take',
+  });
+  const skipResult = parseBoundedIntegerParam(req.query.skip, {
+    defaultValue: 0,
+    maxValue: 1000,
+    name: 'skip',
+  });
+
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+  if (!skipResult.ok) {
+    return res.status(400).json({ error: skipResult.error });
+  }
+
+  const take = takeResult.value;
+  const skip = skipResult.value;
 
   const profileUserId = typeof userId === 'string' ? userId : null;
 
@@ -45,7 +59,7 @@ export default async function handler(
 
   const highlightType = req.query.highlightType as FeedPostType;
   let highlightId = req.query.highlightId as string | undefined;
-  if (Number(skip) !== 0) highlightId = undefined;
+  if (skip !== 0) highlightId = undefined;
   const takeOnlyType = req.query.takeOnlyType as FeedPostType | undefined;
 
   try {
@@ -182,8 +196,8 @@ export default async function handler(
               ...profileSubmissionFilter,
               listing: profileUserId ? {} : { isPrivate: false },
             },
-            skip: parseInt(skip as string, 10),
-            take: parseInt(take as string, 10),
+            skip,
+            take,
             orderBy:
               highlightType === 'submission'
                 ? [
@@ -263,8 +277,8 @@ export default async function handler(
                 },
                 ...(userId ? { userId: userId as string } : {}),
               },
-              skip: parseInt(skip as string, 10),
-              take: parseInt(take as string, 10),
+              skip,
+              take,
               orderBy:
                 filter === 'popular'
                   ? [{ likeCount: 'desc' }, { createdAt: 'desc' }]
@@ -341,8 +355,8 @@ export default async function handler(
               ...(userId ? { userId: userId as string } : {}),
               grant: userId ? {} : { isPrivate: false },
             },
-            skip: parseInt(skip as string, 10),
-            take: parseInt(take as string, 10),
+            skip,
+            take,
             orderBy:
               filter === 'popular'
                 ? [{ likeCount: 'desc' }, { decidedAt: 'desc' }]

--- a/src/pages/api/grants/live.ts
+++ b/src/pages/api/grants/live.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { getChapterRegions } from '@/utils/chapterRegion';
 import { safeStringify } from '@/utils/safeStringify';
 
@@ -21,7 +22,15 @@ export default async function grants(
     logger.debug('Fetching grants from database');
 
     const params = req.query;
-    const take = params.take ? parseInt(params.take as string, 10) : 100;
+    const takeResult = parseBoundedIntegerParam(params.take, {
+      defaultValue: 100,
+      maxValue: 100,
+      name: 'take',
+    });
+    if (!takeResult.ok) {
+      return res.status(400).json({ error: takeResult.error });
+    }
+    const take = takeResult.value;
     let excludeIds = params['excludeIds[]'];
     if (typeof excludeIds === 'string') {
       excludeIds = [excludeIds];

--- a/src/pages/api/hackathon/list.ts
+++ b/src/pages/api/hackathon/list.ts
@@ -1,6 +1,7 @@
 import type { NextApiResponse } from 'next';
 
 import { prisma } from '@/prisma';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 
 import { type NextApiRequestWithUser } from '@/features/auth/types';
 import { withAuth } from '@/features/auth/utils/withAuth';
@@ -11,7 +12,16 @@ async function hackathons(req: NextApiRequestWithUser, res: NextApiResponse) {
   const userId = req.userId;
 
   const searchString = params.searchString as string;
-  const take = params.take ? parseInt(params.take as string, 10) : 30;
+  const takeResult = parseBoundedIntegerParam(params.take, {
+    defaultValue: 30,
+    maxValue: 100,
+    minValue: 1,
+    name: 'take',
+  });
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+  const take = takeResult.value;
   let finalHackathons = [];
   try {
     const user = await prisma.user.findUnique({

--- a/src/pages/api/hackathon/listings.ts
+++ b/src/pages/api/hackathon/listings.ts
@@ -2,6 +2,7 @@ import type { NextApiResponse } from 'next';
 
 import { prisma } from '@/prisma';
 import { status } from '@/prisma/enums';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 
 import { type NextApiRequestWithUser } from '@/features/auth/types';
 import { withAuth } from '@/features/auth/utils/withAuth';
@@ -26,8 +27,25 @@ async function getHackathonListings(
 
   const params = req.query;
   const searchText = params.searchText as string;
-  const skip = params.take ? parseInt(params.skip as string, 10) : 0;
-  const take = params.take ? parseInt(params.take as string, 10) : 15;
+  const skipResult = parseBoundedIntegerParam(params.skip, {
+    defaultValue: 0,
+    maxValue: 1000,
+    name: 'skip',
+  });
+  const takeResult = parseBoundedIntegerParam(params.take, {
+    defaultValue: 15,
+    maxValue: 50,
+    minValue: 1,
+    name: 'take',
+  });
+  if (!skipResult.ok) {
+    return res.status(400).json({ error: skipResult.error });
+  }
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+  const skip = skipResult.value;
+  const take = takeResult.value;
   const whereSearch = searchText
     ? {
         title: {

--- a/src/pages/api/listings/[listingId]/related.ts
+++ b/src/pages/api/listings/[listingId]/related.ts
@@ -9,6 +9,7 @@ import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
 import { type BountyType } from '@/prisma/enums';
 import { empty, join, raw, sql } from '@/prisma/internal/prismaNamespace';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { getRegionNameForLocation } from '@/utils/chapterRegion';
 import { safeStringify } from '@/utils/safeStringify';
 
@@ -20,7 +21,15 @@ export default async function relatedListings(
 ) {
   const params = req.query;
   const listingId = params.listingId as string;
-  const take = params.take ? parseInt(params.take as string, 10) : 5;
+  const takeResult = parseBoundedIntegerParam(params.take, {
+    defaultValue: 5,
+    maxValue: 20,
+    name: 'take',
+  });
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+  const take = takeResult.value;
   logger.debug(`Request query: ${safeStringify(req.query)}`);
 
   try {

--- a/src/pages/api/listings/bookmarks.ts
+++ b/src/pages/api/listings/bookmarks.ts
@@ -2,6 +2,7 @@ import type { NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { safeStringify } from '@/utils/safeStringify';
 
 import { type NextApiRequestWithUser } from '@/features/auth/types';
@@ -18,13 +19,16 @@ async function getBookmarks(req: NextApiRequestWithUser, res: NextApiResponse) {
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
-    const take = req.query.take
-      ? parseInt(req.query.take as string, 10)
-      : undefined;
-
-    if (take !== undefined && (isNaN(take) || take < 1)) {
-      return res.status(400).json({ error: 'Invalid take parameter' });
+    const takeResult = parseBoundedIntegerParam(req.query.take, {
+      defaultValue: 50,
+      maxValue: 100,
+      minValue: 1,
+      name: 'take',
+    });
+    if (!takeResult.ok) {
+      return res.status(400).json({ error: takeResult.error });
     }
+    const take = req.query.take ? takeResult.value : undefined;
 
     logger.debug(`Fetching bookmarks for user ID: ${userId}`);
 

--- a/src/pages/api/listings/live.ts
+++ b/src/pages/api/listings/live.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/prisma';
 import { type EnumBountyTypeFilter } from '@/prisma/commonInputTypes';
 import { type BountyType } from '@/prisma/enums';
 import { type BountiesFindManyArgs } from '@/prisma/models/Bounties';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { getChapterRegions } from '@/utils/chapterRegion';
 
 import { getPrivyToken } from '@/features/auth/utils/getPrivyToken';
@@ -22,7 +23,15 @@ export default async function listings(
   const params = req.query;
 
   const type = params.type as EnumBountyTypeFilter | BountyType | undefined;
-  const take = params.take ? parseInt(params.take as string, 10) : 10;
+  const takeResult = parseBoundedIntegerParam(params.take, {
+    defaultValue: 10,
+    maxValue: 50,
+    name: 'take',
+  });
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+  const take = takeResult.value;
   const deadline = params.deadline as string;
   const exclusiveSponsorId = params.exclusiveSponsorId as string | undefined;
   let excludeIds = params['excludeIds[]'];

--- a/src/pages/api/search/[query].ts
+++ b/src/pages/api/search/[query].ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
 import { status as Status } from '@/prisma/enums';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { getChapterRegions } from '@/utils/chapterRegion';
 
 import { getPrivyToken } from '@/features/auth/utils/getPrivyToken';
@@ -36,10 +37,50 @@ export default async function user(req: NextApiRequest, res: NextApiResponse) {
     ' ',
   );
 
-  const bountiesLimit = (req.query.bountiesLimit as string) || 5;
-  const grantsLimit = (req.query.grantsLimit as string) || 2;
-  const bountiesOffset = (req.query.bountiesOffset as string) || null;
-  const grantsOffset = (req.query.grantsOffset as string) || null;
+  const bountiesLimitResult = parseBoundedIntegerParam(
+    req.query.bountiesLimit,
+    {
+      defaultValue: 5,
+      maxValue: 25,
+      name: 'bountiesLimit',
+    },
+  );
+  const grantsLimitResult = parseBoundedIntegerParam(req.query.grantsLimit, {
+    defaultValue: 2,
+    maxValue: 10,
+    name: 'grantsLimit',
+  });
+  const bountiesOffsetResult = parseBoundedIntegerParam(
+    req.query.bountiesOffset,
+    {
+      defaultValue: 0,
+      maxValue: 1000,
+      name: 'bountiesOffset',
+    },
+  );
+  const grantsOffsetResult = parseBoundedIntegerParam(req.query.grantsOffset, {
+    defaultValue: 0,
+    maxValue: 1000,
+    name: 'grantsOffset',
+  });
+
+  if (!bountiesLimitResult.ok) {
+    return res.status(400).json({ error: bountiesLimitResult.error });
+  }
+  if (!grantsLimitResult.ok) {
+    return res.status(400).json({ error: grantsLimitResult.error });
+  }
+  if (!bountiesOffsetResult.ok) {
+    return res.status(400).json({ error: bountiesOffsetResult.error });
+  }
+  if (!grantsOffsetResult.ok) {
+    return res.status(400).json({ error: grantsOffsetResult.error });
+  }
+
+  const bountiesLimit = bountiesLimitResult.value;
+  const grantsLimit = grantsLimitResult.value;
+  const bountiesOffset = bountiesOffsetResult.value;
+  const grantsOffset = grantsOffsetResult.value;
 
   let userRegion = req.query.userRegion
     ? (req.query.userRegion as string).split(',')
@@ -264,7 +305,7 @@ s.name LIKE CONCAT('%', ?, '%')
         ELSE NULL
       END DESC,
       b.updatedAt DESC, b.id
-    LIMIT ? ${bountiesOffset ? `OFFSET ?` : ''}
+    LIMIT ? ${bountiesOffset > 0 ? `OFFSET ?` : ''}
     `;
 
   const grantsQuery = `
@@ -298,7 +339,7 @@ s.name LIKE CONCAT('%', ?, '%')
     ${skills ? ` AND (${skillsQuery})` : ''}
     ${regionFilter}
     ORDER BY b.createdAt DESC
-    LIMIT ? ${grantsOffset ? `OFFSET ?` : ''}
+    LIMIT ? ${grantsOffset > 0 ? `OFFSET ?` : ''}
   `;
 
   let bountiesValues: (string | number)[] = duplicateElements(words, 2);
@@ -326,8 +367,8 @@ s.name LIKE CONCAT('%', ?, '%')
         ...grantsValues,
       );
 
-      grantsValues.push(Number(grantsLimit));
-      if (grantsOffset) grantsValues.push(Number(grantsOffset));
+      grantsValues.push(grantsLimit);
+      if (grantsOffset > 0) grantsValues.push(grantsOffset);
 
       logger.debug(
         `Executing grants table sqlQuery with values: ${grantsValues}`,
@@ -355,8 +396,8 @@ s.name LIKE CONCAT('%', ?, '%')
       [{ totalCount: bigint }]
     >(bountiesCountQuery, ...bountiesValues);
 
-    bountiesValues.push(Number(bountiesLimit) - grants.length);
-    if (bountiesOffset) bountiesValues.push(Number(bountiesOffset));
+    bountiesValues.push(Math.max(bountiesLimit - grants.length, 0));
+    if (bountiesOffset > 0) bountiesValues.push(bountiesOffset);
 
     logger.debug(
       `Executing bounties table sqlQuery with values: ${bountiesValues}`,

--- a/src/pages/api/sponsor-dashboard/members/index.ts
+++ b/src/pages/api/sponsor-dashboard/members/index.ts
@@ -2,6 +2,7 @@ import type { NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { safeStringify } from '@/utils/safeStringify';
 
 import { type NextApiRequestWithSponsor } from '@/features/auth/types';
@@ -10,8 +11,25 @@ import { withSponsorAuth } from '@/features/auth/utils/withSponsorAuth';
 async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   const params = req.query;
   const sponsorId = req.userSponsorId;
-  const skip = params.skip ? parseInt(params.skip as string, 10) : 0;
-  const take = params.take ? parseInt(params.take as string, 10) : 15;
+  const skipResult = parseBoundedIntegerParam(params.skip, {
+    defaultValue: 0,
+    maxValue: 1000,
+    name: 'skip',
+  });
+  const takeResult = parseBoundedIntegerParam(params.take, {
+    defaultValue: 15,
+    maxValue: 50,
+    minValue: 1,
+    name: 'take',
+  });
+  if (!skipResult.ok) {
+    return res.status(400).json({ error: skipResult.error });
+  }
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+  const skip = skipResult.value;
+  const take = takeResult.value;
   const searchText = params.searchText as string;
 
   logger.debug(`Query params: ${safeStringify(params)}`);

--- a/src/pages/api/sponsors/list.ts
+++ b/src/pages/api/sponsors/list.ts
@@ -2,6 +2,7 @@ import type { NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 
 import { type NextApiRequestWithSponsor } from '@/features/auth/types';
 import { withSponsorAuth } from '@/features/auth/utils/withSponsorAuth';
@@ -11,7 +12,16 @@ async function sponsors(req: NextApiRequestWithSponsor, res: NextApiResponse) {
 
   const userId = req.userId;
   const searchString = params.searchString as string;
-  const take = params.take ? parseInt(params.take as string, 10) : 50;
+  const takeResult = parseBoundedIntegerParam(params.take, {
+    defaultValue: 50,
+    maxValue: 100,
+    minValue: 1,
+    name: 'take',
+  });
+  if (!takeResult.ok) {
+    return res.status(400).json({ error: takeResult.error });
+  }
+  const take = takeResult.value;
   let finalSponsors = [];
 
   try {

--- a/src/pages/api/user/search.ts
+++ b/src/pages/api/user/search.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
+import { parseBoundedIntegerParam } from '@/utils/apiPagination';
 import { safeStringify } from '@/utils/safeStringify';
 
 import { getPrivyToken } from '@/features/auth/utils/getPrivyToken';
@@ -40,8 +41,16 @@ export default async function searchUser(
       }
     }
 
-    let takeNum = Number(take) || MAX_COMMENT_SUGGESTIONS;
-    if (takeNum > MAX_COMMENT_SUGGESTIONS) takeNum = MAX_COMMENT_SUGGESTIONS;
+    const takeResult = parseBoundedIntegerParam(take, {
+      defaultValue: MAX_COMMENT_SUGGESTIONS,
+      maxValue: MAX_COMMENT_SUGGESTIONS,
+      minValue: 1,
+      name: 'take',
+    });
+    if (!takeResult.ok) {
+      return res.status(400).json({ error: takeResult.error });
+    }
+    const takeNum = takeResult.value;
     logger.debug(`Query parameter: ${query}, Take number: ${takeNum}`);
 
     const users = await prisma.user.findMany({

--- a/src/utils/apiPagination.ts
+++ b/src/utils/apiPagination.ts
@@ -1,0 +1,48 @@
+export type QueryParamValue = string | string[] | undefined;
+
+export type BoundedIntegerResult =
+  | { ok: true; value: number }
+  | { ok: false; error: string };
+
+export function getSingleQueryParam(value: QueryParamValue) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function parseBoundedIntegerParam(
+  value: QueryParamValue,
+  {
+    defaultValue,
+    maxValue,
+    minValue = 0,
+    name,
+  }: {
+    defaultValue: number;
+    maxValue: number;
+    minValue?: number;
+    name: string;
+  },
+): BoundedIntegerResult {
+  const rawValue = getSingleQueryParam(value);
+
+  if (rawValue === undefined) {
+    return { ok: true, value: defaultValue };
+  }
+
+  if (!/^\d+$/.test(rawValue)) {
+    return {
+      ok: false,
+      error: `${name} must be a non-negative integer`,
+    };
+  }
+
+  const parsedValue = Number(rawValue);
+  if (!Number.isSafeInteger(parsedValue)) {
+    return { ok: false, error: `${name} is too large` };
+  }
+
+  if (parsedValue < minValue) {
+    return { ok: false, error: `${name} must be at least ${minValue}` };
+  }
+
+  return { ok: true, value: Math.min(parsedValue, maxValue) };
+}


### PR DESCRIPTION
## What does this PR do?
- this was needed in order to prevent DB exhaustion, routes being stuck indefinitely and avoid exploiting of endpoints that have uncapped params.
- Introduces a utility function to parse and cap limits properly
- added the function to any and all endpoints that allowed uncapped `limit` and `offset` values

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination validation across listings, comments, feeds, search, sponsors, grants, and user suggestions.
  * Invalid, negative, oversized, or malformed pagination values now return clear `400` errors instead of being silently accepted or defaulted.
  * Added consistent limits and defaults to prevent excessive result requests.
  * Improved search pagination handling, including reliable offsets and prevention of invalid result limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->