### PR TITLE
Fixed token url for dynamic OG image 

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "react-textarea-autosize": "^8.5.9",
     "react-use-measure": "^2.1.7",
     "resend": "^6.4.0",
+    "sharp": "^0.34.5",
     "slugify": "^1.6.6",
     "sonner": "^2.0.7",
     "styled-jsx": "^5.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,6 +397,9 @@ importers:
       resend:
         specifier: ^6.4.0
         version: 6.4.0(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       slugify:
         specifier: ^1.6.6
         version: 1.6.6

--- a/src/app/api/dynamic-og/grant/route.tsx
+++ b/src/app/api/dynamic-og/grant/route.tsx
@@ -56,7 +56,9 @@ export async function GET(request: Request) {
     const displayReward =
       minReward === '0' ? `Up to ${maxReward}` : `${minReward} - ${maxReward}`;
 
-    const icon = resolveAbsoluteUrl((await getTokenIcon(token)) ?? null);
+    const icon = resolveAbsoluteUrl(
+      (await getTokenIcon(token, { format: 'png' })) ?? null,
+    );
 
     return new ImageResponse(
       <div

--- a/src/app/api/dynamic-og/listing/route.tsx
+++ b/src/app/api/dynamic-og/listing/route.tsx
@@ -129,7 +129,9 @@ export async function GET(request: Request) {
         break;
     }
 
-    const icon = resolveAbsoluteUrl((await getTokenIcon(token)) ?? null);
+    const icon = resolveAbsoluteUrl(
+      (await getTokenIcon(token, { format: 'png' })) ?? null,
+    );
 
     const capitalizedType = type
       ? type?.charAt(0).toUpperCase() + type?.slice(1).toLowerCase()

--- a/src/pages/api/token-icon.ts
+++ b/src/pages/api/token-icon.ts
@@ -1,14 +1,36 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import sharp from 'sharp';
 
 import logger from '@/lib/logger';
 import { isSafeRemoteUrl, safeRemoteFetch } from '@/utils/safeRemoteFetch';
 import { safeStringify } from '@/utils/safeStringify';
 
 const MAX_ICON_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_ICON_PIXELS = 16 * 1024 * 1024;
 const MAX_REDIRECTS = 4;
 const UPSTREAM_FETCH_TIMEOUT_MS = 5000;
 const CACHE_CONTROL =
   'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800';
+const PNG_CONTENT_TYPE = 'image/png';
+
+const convertToPng = (image: Buffer) =>
+  sharp(image, {
+    failOn: 'error',
+    limitInputPixels: MAX_ICON_PIXELS,
+  })
+    .png()
+    .toBuffer();
+
+const sendImage = (
+  res: NextApiResponse,
+  image: Buffer,
+  contentType: string,
+) => {
+  res.setHeader('Cache-Control', CACHE_CONTROL);
+  res.setHeader('Content-Type', contentType);
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  return res.status(200).send(image);
+};
 
 export default async function handler(
   req: NextApiRequest,
@@ -32,15 +54,28 @@ export default async function handler(
     return res.status(400).end();
   }
 
-  if (!(await isSafeRemoteUrl(iconUrl))) {
-    return res.status(400).end();
+  const requiresPng = req.query.format === 'png';
+
+  try {
+    if (!(await isSafeRemoteUrl(iconUrl))) {
+      return res.status(400).end();
+    }
+  } catch (error) {
+    logger.error(
+      `Failed to validate token icon URL: ${safeStringify({
+        iconUrl: iconUrl.toString(),
+        error,
+      })}`,
+    );
+    return res.status(502).end();
   }
 
   try {
     const iconResponse = await safeRemoteFetch(iconUrl, {
       headers: {
-        Accept:
-          'image/avif,image/webp,image/png,image/jpeg,image/svg+xml,image/*',
+        Accept: requiresPng
+          ? 'image/png,image/jpeg,image/svg+xml,image/*;q=0.8'
+          : 'image/avif,image/webp,image/png,image/jpeg,image/svg+xml,image/*',
       },
       maxRedirects: MAX_REDIRECTS,
       timeoutMs: UPSTREAM_FETCH_TIMEOUT_MS,
@@ -66,12 +101,30 @@ export default async function handler(
       return res.status(413).end();
     }
 
-    res.setHeader('Cache-Control', CACHE_CONTROL);
-    res.setHeader('Content-Type', contentType);
-    res.setHeader('X-Content-Type-Options', 'nosniff');
-    return res.status(200).send(icon);
+    if (requiresPng) {
+      try {
+        return sendImage(res, await convertToPng(icon), PNG_CONTENT_TYPE);
+      } catch (error) {
+        logger.warn(
+          `Failed to convert token icon to PNG: ${safeStringify({
+            iconUrl: iconUrl.toString(),
+            contentType,
+            error,
+          })}`,
+        );
+        return res.status(415).end();
+      }
+    }
+
+    return sendImage(res, icon, contentType);
   } catch (error) {
-    logger.error(`Failed to proxy token icon: ${safeStringify(error)}`);
+    logger.error(
+      `Failed to proxy token icon: ${safeStringify({
+        iconUrl: iconUrl.toString(),
+        requiresPng,
+        error,
+      })}`,
+    );
     return res.status(502).end();
   }
 }

--- a/src/server/tokenList.ts
+++ b/src/server/tokenList.ts
@@ -293,7 +293,22 @@ export async function getTokenByMintAddress(
 
 export async function getTokenIcon(
   symbol?: string | null,
+  options?: {
+    format?: 'png';
+  },
 ): Promise<string | null> {
   const token = await getTokenBySymbol(symbol, { includeInactive: true });
-  return token?.icon ?? null;
+  const icon = token?.icon;
+
+  if (!icon || options?.format !== 'png') {
+    return icon ?? null;
+  }
+
+  if (!icon.startsWith(`${TOKEN_ICON_PROXY_PATH}?`)) {
+    return icon;
+  }
+
+  const proxyUrl = new URL(icon, 'https://superteam.fun');
+  proxyUrl.searchParams.set('format', 'png');
+  return `${proxyUrl.pathname}${proxyUrl.search}`;
 }


### PR DESCRIPTION
## What does this PR do?
- Solves the issue of OG images failing due to token-icon's being in a format other thn PNG.
- adds a any to PNG convertor for token icons in OG images, since tokens can now be added permissionlessly and only PNG would create a valid OG image(standardized the format)
- introduced the png changes to grant and listing dynamic OG endpoints.

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PNG output support for token icons.
  * Dynamic grant and listing images now request token icons in PNG format for improved compatibility.

* **Bug Fixes**
  * Improved token image proxy responses with consistent content headers and caching.
  * Added safer handling for invalid image URLs and unsupported image conversions.
  * Enhanced error responses when remote image fetching or processing fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->