### PR TITLE
Add member Sumsub source key setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,11 +75,11 @@ JUPITER_API_KEY=""
 
 # Sumsub KYC
 SUMSUB_API_KEY=""
-SUMSUB_SECRET_KEY=""
 SUMSUB_LEVEL_NAME="id-and-liveness"
+SUMSUB_SECRET_KEY=""
 
-# Optional: existing Sumsub source key configured to allow duplicate KYC for
-# Superteam members. Users linked to People records with type "member" or "core"
-# will be assigned to this source key before SDK token generation. Leave empty
-# to preserve the current no-source-key KYC flow for everyone.
+# Optional: Sumsub source key configured to allow duplicate KYC for Superteam
+# members. Applies only when creating brand-new member/core applicants; existing
+# applicants are left unchanged even if they have no source key or a different
+# source key. Leave empty to preserve the current no-source-key KYC flow.
 SUMSUB_MEMBER_SOURCE_KEY=""

--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,14 @@ OPENROUTER_API_KEY=""
 
 # Jupiter API KEY
 JUPITER_API_KEY=""
+
+# Sumsub KYC
+SUMSUB_API_KEY=""
+SUMSUB_SECRET_KEY=""
+SUMSUB_LEVEL_NAME="id-and-liveness"
+
+# Optional: existing Sumsub source key configured to allow duplicate KYC for
+# Superteam members. Users linked to People records with type "member" or "core"
+# will be assigned to this source key before SDK token generation. Leave empty
+# to preserve the current no-source-key KYC flow for everyone.
+SUMSUB_MEMBER_SOURCE_KEY=""

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -344,38 +344,41 @@ model GrantTranche {
 }
 
 model Submission {
-  id                 String           @id @default(uuid())
-  link               String?          @db.VarChar(500)
-  tweet              String?          @db.VarChar(500)
-  status             SubmissionStatus @default(Pending)
-  eligibilityAnswers Json?            @default("[]")
-  userId             String
-  agentId            String?
-  listingId          String
-  isWinner           Boolean          @default(false)
-  winnerPosition     Int?
-  isActive           Boolean          @default(true)
-  isArchived         Boolean          @default(false)
-  createdAt          DateTime         @default(now())
-  updatedAt          DateTime         @updatedAt
-  like               Json?
-  likeCount          Int              @default(0)
-  isPaid             Boolean          @default(false)
-  paymentDetails     Json?
-  otherInfo          String?          @db.Text
-  ask                Float?
-  telegram           String?          @db.Text
-  label              SubmissionLabels @default(Unreviewed)
-  rewardInUSD        Float            @default(0)
-  listing            Bounties         @relation(fields: [listingId], references: [id])
-  user               User             @relation(fields: [userId], references: [id])
-  agent              Agent?           @relation(fields: [agentId], references: [id])
-  ogImage            String?          @db.Text
-  notes              String?          @db.VarChar(10000)
-  Comments           Comment[]
-  CreditLedger       CreditLedger[]
-  ai                 Json?
-  paymentSynced      Boolean          @default(false)
+  id                           String                   @id @default(uuid())
+  link                         String?                  @db.VarChar(500)
+  tweet                        String?                  @db.VarChar(500)
+  status                       SubmissionStatus         @default(Pending)
+  eligibilityAnswers           Json?                    @default("[]")
+  userId                       String
+  agentId                      String?
+  listingId                    String
+  isWinner                     Boolean                  @default(false)
+  winnerPosition               Int?
+  isActive                     Boolean                  @default(true)
+  isArchived                   Boolean                  @default(false)
+  createdAt                    DateTime                 @default(now())
+  updatedAt                    DateTime                 @updatedAt
+  like                         Json?
+  likeCount                    Int                      @default(0)
+  isPaid                       Boolean                  @default(false)
+  paymentDetails               Json?
+  otherInfo                    String?                  @db.Text
+  ask                          Float?
+  telegram                     String?                  @db.Text
+  label                        SubmissionLabels         @default(Unreviewed)
+  rewardInUSD                  Float                    @default(0)
+  listing                      Bounties                 @relation(fields: [listingId], references: [id])
+  user                         User                     @relation(fields: [userId], references: [id])
+  agent                        Agent?                   @relation(fields: [agentId], references: [id])
+  ogImage                      String?                  @db.Text
+  notes                        String?                  @db.VarChar(10000)
+  Comments                     Comment[]
+  CreditLedger                 CreditLedger[]
+  ai                           Json?
+  paymentSynced                Boolean                  @default(false)
+  regionVerificationStatus     RegionVerificationStatus @default(NotRequired)
+  regionVerificationCountry    String?
+  regionVerificationVerifiedAt DateTime?
 
   @@index([id, listingId])
   @@index([isWinner])
@@ -1268,6 +1271,14 @@ enum SubmissionStatus {
   Pending
   Approved
   Rejected
+}
+
+enum RegionVerificationStatus {
+  NotRequired
+  KycCountryMatched
+  PoaRequired
+  PoaVerified
+  Ineligible
 }
 
 enum GrantTrancheStatus {

--- a/src/features/kyc/utils/ensureApplicantSourceKey.ts
+++ b/src/features/kyc/utils/ensureApplicantSourceKey.ts
@@ -7,8 +7,42 @@ import { SUMSUB_BASE_URL } from '../constants/SUMSUB_BASE_URL';
 import { createSumSubHeaders } from './createSumSubHeaders';
 
 type SumsubApplicant = {
-  id?: string;
-  sourceKey?: string;
+  readonly id: string | undefined;
+  readonly sourceKey: string | undefined;
+};
+
+type SumsubErrorResponse = {
+  readonly code: unknown;
+  readonly message: unknown;
+  readonly description: unknown;
+};
+
+const SUMSUB_SOURCE_KEY_REQUEST_TIMEOUT_MS = 10_000;
+
+const matchesDuplicateApplicantMessage = (value: unknown): boolean =>
+  typeof value === 'string' &&
+  [
+    'applicant already exists',
+    'applicant with externaluserid already exists',
+  ].includes(value.toLowerCase());
+
+const isApplicantAlreadyExistsError = (error: unknown): boolean => {
+  if (!axios.isAxiosError(error)) {
+    return false;
+  }
+
+  if (error.response?.status === 409) {
+    return true;
+  }
+
+  const data = error.response?.data as Partial<SumsubErrorResponse> | undefined;
+
+  return (
+    data?.code === 'applicant_already_exists' ||
+    data?.code === 'applicant_exists' ||
+    matchesDuplicateApplicantMessage(data?.message) ||
+    matchesDuplicateApplicantMessage(data?.description)
+  );
 };
 
 const getApplicantByExternalUserId = async (
@@ -24,6 +58,7 @@ const getApplicantByExternalUserId = async (
   try {
     const response = await axios.get<SumsubApplicant>(`${SUMSUB_BASE_URL}${url}`, {
       headers,
+      timeout: SUMSUB_SOURCE_KEY_REQUEST_TIMEOUT_MS,
     });
     return response.data;
   } catch (error) {
@@ -51,7 +86,7 @@ const createApplicantWithSourceKey = async ({
   sourceKey: string;
   secretKey: string;
   appToken: string;
-}) => {
+}): Promise<boolean> => {
   const url = `/resources/applicants?levelName=${encodeURIComponent(levelName)}`;
   const method = 'POST';
   const body = JSON.stringify({
@@ -67,15 +102,11 @@ const createApplicantWithSourceKey = async ({
         externalUserId: userId,
         sourceKey,
       },
-      { headers },
+      { headers, timeout: SUMSUB_SOURCE_KEY_REQUEST_TIMEOUT_MS },
     );
     return true;
   } catch (error) {
-    if (
-      axios.isAxiosError(error) &&
-      (error.response?.status === 409 ||
-        safeStringify(error.response?.data).toLowerCase().includes('exist'))
-    ) {
+    if (isApplicantAlreadyExistsError(error)) {
       logger.info('Sumsub applicant already exists during source key setup', {
         userId,
         sourceKey,
@@ -104,7 +135,7 @@ export const ensureApplicantSourceKey = async ({
   sourceKey: string;
   secretKey: string;
   appToken: string;
-}) => {
+}): Promise<boolean> => {
   const applicant = await getApplicantByExternalUserId(
     userId,
     secretKey,

--- a/src/features/kyc/utils/ensureApplicantSourceKey.ts
+++ b/src/features/kyc/utils/ensureApplicantSourceKey.ts
@@ -1,0 +1,133 @@
+import axios from 'axios';
+
+import logger from '@/lib/logger';
+import { safeStringify } from '@/utils/safeStringify';
+
+import { SUMSUB_BASE_URL } from '../constants/SUMSUB_BASE_URL';
+import { createSumSubHeaders } from './createSumSubHeaders';
+
+type SumsubApplicant = {
+  id?: string;
+  sourceKey?: string;
+};
+
+const getApplicantByExternalUserId = async (
+  userId: string,
+  secretKey: string,
+  appToken: string,
+): Promise<SumsubApplicant | null> => {
+  const url = `/resources/applicants/-;externalUserId=${userId}/one`;
+  const method = 'GET';
+  const body = '';
+  const headers = createSumSubHeaders(method, url, body, secretKey, appToken);
+
+  try {
+    const response = await axios.get<SumsubApplicant>(`${SUMSUB_BASE_URL}${url}`, {
+      headers,
+    });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response?.status === 404) {
+      return null;
+    }
+
+    logger.warn('Skipping Sumsub source key lookup after error', {
+      userId,
+      error: safeStringify(error),
+    });
+    return null;
+  }
+};
+
+const createApplicantWithSourceKey = async ({
+  userId,
+  levelName,
+  sourceKey,
+  secretKey,
+  appToken,
+}: {
+  userId: string;
+  levelName: string;
+  sourceKey: string;
+  secretKey: string;
+  appToken: string;
+}) => {
+  const url = `/resources/applicants?levelName=${encodeURIComponent(levelName)}`;
+  const method = 'POST';
+  const body = JSON.stringify({
+    externalUserId: userId,
+    sourceKey,
+  });
+  const headers = createSumSubHeaders(method, url, body, secretKey, appToken);
+
+  try {
+    await axios.post(
+      `${SUMSUB_BASE_URL}${url}`,
+      {
+        externalUserId: userId,
+        sourceKey,
+      },
+      { headers },
+    );
+    return true;
+  } catch (error) {
+    if (
+      axios.isAxiosError(error) &&
+      (error.response?.status === 409 ||
+        safeStringify(error.response?.data).toLowerCase().includes('exist'))
+    ) {
+      logger.info('Sumsub applicant already exists during source key setup', {
+        userId,
+        sourceKey,
+      });
+      return false;
+    }
+
+    logger.warn('Skipping Sumsub source key setup after create error', {
+      userId,
+      sourceKey,
+      error: safeStringify(error),
+    });
+    return false;
+  }
+};
+
+export const ensureApplicantSourceKey = async ({
+  userId,
+  levelName,
+  sourceKey,
+  secretKey,
+  appToken,
+}: {
+  userId: string;
+  levelName: string;
+  sourceKey: string;
+  secretKey: string;
+  appToken: string;
+}) => {
+  const applicant = await getApplicantByExternalUserId(
+    userId,
+    secretKey,
+    appToken,
+  );
+
+  if (!applicant?.id) {
+    return createApplicantWithSourceKey({
+      userId,
+      levelName,
+      sourceKey,
+      secretKey,
+      appToken,
+    });
+  }
+
+  if (applicant.sourceKey !== sourceKey) {
+    logger.info('Leaving existing Sumsub applicant source key unchanged', {
+      applicantId: applicant.id,
+      userId,
+      sourceKey,
+    });
+  }
+
+  return false;
+};

--- a/src/features/kyc/utils/ensureApplicantSourceKey.ts
+++ b/src/features/kyc/utils/ensureApplicantSourceKey.ts
@@ -49,7 +49,7 @@ const getApplicantByExternalUserId = async (
   userId: string,
   secretKey: string,
   appToken: string,
-): Promise<SumsubApplicant | null> => {
+): Promise<SumsubApplicant | null | undefined> => {
   const url = `/resources/applicants/-;externalUserId=${userId}/one`;
   const method = 'GET';
   const body = '';
@@ -70,7 +70,7 @@ const getApplicantByExternalUserId = async (
       userId,
       error: safeStringify(error),
     });
-    return null;
+    return undefined;
   }
 };
 
@@ -141,6 +141,10 @@ export const ensureApplicantSourceKey = async ({
     secretKey,
     appToken,
   );
+
+  if (applicant === undefined) {
+    return false;
+  }
 
   if (!applicant?.id) {
     return createApplicantWithSourceKey({

--- a/src/features/kyc/utils/ensureApplicantSourceKey.ts
+++ b/src/features/kyc/utils/ensureApplicantSourceKey.ts
@@ -86,7 +86,7 @@ const createApplicantWithSourceKey = async ({
   sourceKey: string;
   secretKey: string;
   appToken: string;
-}): Promise<boolean> => {
+}): Promise<void> => {
   const url = `/resources/applicants?levelName=${encodeURIComponent(levelName)}`;
   const method = 'POST';
   const body = JSON.stringify({
@@ -104,14 +104,17 @@ const createApplicantWithSourceKey = async ({
       },
       { headers, timeout: SUMSUB_SOURCE_KEY_REQUEST_TIMEOUT_MS },
     );
-    return true;
+    logger.info('Created Sumsub applicant with member source key', {
+      userId,
+      sourceKey,
+    });
   } catch (error) {
     if (isApplicantAlreadyExistsError(error)) {
       logger.info('Sumsub applicant already exists during source key setup', {
         userId,
         sourceKey,
       });
-      return false;
+      return;
     }
 
     logger.warn('Skipping Sumsub source key setup after create error', {
@@ -119,7 +122,6 @@ const createApplicantWithSourceKey = async ({
       sourceKey,
       error: safeStringify(error),
     });
-    return false;
   }
 };
 
@@ -135,7 +137,7 @@ export const ensureApplicantSourceKey = async ({
   sourceKey: string;
   secretKey: string;
   appToken: string;
-}): Promise<boolean> => {
+}): Promise<void> => {
   const applicant = await getApplicantByExternalUserId(
     userId,
     secretKey,
@@ -143,17 +145,18 @@ export const ensureApplicantSourceKey = async ({
   );
 
   if (applicant === undefined) {
-    return false;
+    return;
   }
 
   if (!applicant?.id) {
-    return createApplicantWithSourceKey({
+    await createApplicantWithSourceKey({
       userId,
       levelName,
       sourceKey,
       secretKey,
       appToken,
     });
+    return;
   }
 
   if (applicant.sourceKey !== sourceKey) {
@@ -163,6 +166,4 @@ export const ensureApplicantSourceKey = async ({
       sourceKey,
     });
   }
-
-  return false;
 };

--- a/src/pages/api/sumsub/access-token.ts
+++ b/src/pages/api/sumsub/access-token.ts
@@ -3,6 +3,9 @@ import type { NextApiResponse } from 'next';
 import { type NextApiRequestWithUser } from '@/features/auth/types';
 import { withAuth } from '@/features/auth/utils/withAuth';
 import { createSumsubAccessToken } from '@/features/kyc/utils/createSumsubAccessToken';
+import { ensureApplicantSourceKey } from '@/features/kyc/utils/ensureApplicantSourceKey';
+import { isEligiblePeopleType } from '@/features/membership/utils/peopleEligibility';
+import { prisma } from '@/prisma';
 
 const handler = async (req: NextApiRequestWithUser, res: NextApiResponse) => {
   const userId = req.userId;
@@ -11,9 +14,33 @@ const handler = async (req: NextApiRequestWithUser, res: NextApiResponse) => {
     const secretKey = process.env.SUMSUB_SECRET_KEY;
     const appToken = process.env.SUMSUB_API_KEY;
     const levelName = process.env.SUMSUB_LEVEL_NAME;
+    const memberSourceKey = process.env.SUMSUB_MEMBER_SOURCE_KEY;
 
     if (!secretKey || !appToken || !userId || !levelName) {
       return res.status(500).json({ message: 'Missing environment variables' });
+    }
+
+    if (memberSourceKey) {
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        select: {
+          people: {
+            select: {
+              type: true,
+            },
+          },
+        },
+      });
+
+      if (isEligiblePeopleType(user?.people?.type)) {
+        await ensureApplicantSourceKey({
+          userId,
+          levelName,
+          sourceKey: memberSourceKey,
+          secretKey,
+          appToken,
+        });
+      }
     }
 
     const result = await createSumsubAccessToken(

--- a/src/pages/api/sumsub/access-token.ts
+++ b/src/pages/api/sumsub/access-token.ts
@@ -5,23 +5,42 @@ import { withAuth } from '@/features/auth/utils/withAuth';
 import { createSumsubAccessToken } from '@/features/kyc/utils/createSumsubAccessToken';
 import { ensureApplicantSourceKey } from '@/features/kyc/utils/ensureApplicantSourceKey';
 import { isEligiblePeopleType } from '@/features/membership/utils/peopleEligibility';
+import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
+import { safeStringify } from '@/utils/safeStringify';
+
+type PeopleTypeLookupResult =
+  | {
+      readonly ok: true;
+      readonly peopleType: string | null | undefined;
+    }
+  | {
+      readonly ok: false;
+    };
 
 const getEligiblePeopleType = async (
   userId: string,
-): Promise<string | null | undefined> => {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: {
-      people: {
-        select: {
-          type: true,
+): Promise<PeopleTypeLookupResult> => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        people: {
+          select: {
+            type: true,
+          },
         },
       },
-    },
-  });
+    });
 
-  return user?.people?.type;
+    return { ok: true, peopleType: user?.people?.type };
+  } catch (error) {
+    logger.warn('Skipping Sumsub member source key setup after lookup error', {
+      userId,
+      error: safeStringify(error),
+    });
+    return { ok: false };
+  }
 };
 
 const handler = async (req: NextApiRequestWithUser, res: NextApiResponse) => {
@@ -38,17 +57,12 @@ const handler = async (req: NextApiRequestWithUser, res: NextApiResponse) => {
     }
 
     if (memberSourceKey) {
-      let peopleType;
+      const peopleTypeLookup = await getEligiblePeopleType(userId);
 
-      try {
-        peopleType = await getEligiblePeopleType(userId);
-      } catch {
-        return res
-          .status(500)
-          .json({ message: 'Failed to load user KYC eligibility' });
-      }
-
-      if (isEligiblePeopleType(peopleType)) {
+      if (
+        peopleTypeLookup.ok &&
+        isEligiblePeopleType(peopleTypeLookup.peopleType)
+      ) {
         await ensureApplicantSourceKey({
           userId,
           levelName,

--- a/src/pages/api/sumsub/access-token.ts
+++ b/src/pages/api/sumsub/access-token.ts
@@ -7,6 +7,23 @@ import { ensureApplicantSourceKey } from '@/features/kyc/utils/ensureApplicantSo
 import { isEligiblePeopleType } from '@/features/membership/utils/peopleEligibility';
 import { prisma } from '@/prisma';
 
+const getEligiblePeopleType = async (
+  userId: string,
+): Promise<string | null | undefined> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      people: {
+        select: {
+          type: true,
+        },
+      },
+    },
+  });
+
+  return user?.people?.type;
+};
+
 const handler = async (req: NextApiRequestWithUser, res: NextApiResponse) => {
   const userId = req.userId;
 
@@ -21,18 +38,17 @@ const handler = async (req: NextApiRequestWithUser, res: NextApiResponse) => {
     }
 
     if (memberSourceKey) {
-      const user = await prisma.user.findUnique({
-        where: { id: userId },
-        select: {
-          people: {
-            select: {
-              type: true,
-            },
-          },
-        },
-      });
+      let peopleType;
 
-      if (isEligiblePeopleType(user?.people?.type)) {
+      try {
+        peopleType = await getEligiblePeopleType(userId);
+      } catch {
+        return res
+          .status(500)
+          .json({ message: 'Failed to load user KYC eligibility' });
+      }
+
+      if (isEligiblePeopleType(peopleType)) {
         await ensureApplicantSourceKey({
           userId,
           levelName,


### PR DESCRIPTION
## Why

We are seeing a repeated pattern where legit Superteam members/core members create another Earn profile and then hit Sumsub duplicate-profile rejection when they try to KYC again.

Sumsub is technically doing the strict/default thing here, and we do not want to weaken that globally because KYC is sensitive. The goal is narrower: keep the default duplicate policy for everyone, but give trusted Superteam member/core users a separate Sumsub source-key path that can be configured to allow duplicate applicants.

## What changed

- Added optional `SUMSUB_MEMBER_SOURCE_KEY`.
- If that env var is empty, the current KYC flow stays unchanged for everyone.
- When a user starts KYC, we check their linked People record.
- Only `member` and `core` People types are eligible for the member source key.
- For eligible users, we look for an existing Sumsub applicant by `externalUserId`.
- If no applicant exists yet, we create the applicant with the configured member source key before generating the SDK token.
- Non-members never use this source key.

## Safety choices

- We do not PATCH/update existing Sumsub applicants or move them between source keys.
- Existing applicants are left untouched even if they have no source key or a different source key.
- If source-key setup fails, we log it and still continue generating the normal Sumsub SDK token so KYC is not blocked.
- If the source-key lookup fails for a non-404 reason, we skip source-key setup instead of trying to create anything.
- The source key is env-gated, so merging this code alone does not change KYC behavior.

## Rollout

1. Merge/deploy code to staging with `SUMSUB_MEMBER_SOURCE_KEY` empty.
2. Confirm normal KYC still works.
3. Create/configure the Sumsub source key in sandbox/staging with the same id-and-liveness level and member duplicate policy.
4. Add `SUMSUB_MEMBER_SOURCE_KEY=<member source key>` only to staging env.
5. Test member/core duplicate profile flow.
6. Test non-member duplicate profile flow and confirm it still stays strict.
7. Only after staging looks good, consider production env rollout.

## Testing

- `prisma generate` passed locally with a dummy `DATABASE_URL`.
- `tsc --noEmit` passed locally.
- `oxlint . --quiet` passed locally with 0 errors.
- `git diff --check` passed.
- Vercel deployment is green.
- CodeRabbit is green/rate-limited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved KYC onboarding by automatically preparing eligible applicants for verification when configured.
  * Added region-verification tracking, including country matching, proof-of-address requirements, verification completion, and ineligible statuses.
  * Existing applicants and previously established source settings remain unchanged.

* **Bug Fixes**
  * Improved handling of duplicate applicants and temporary lookup or creation failures without disrupting access-token generation.

* **Documentation**
  * Added configuration guidance for optional KYC applicant source settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->