### PR TITLE
Delete Image ownership check

### DIFF
--- a/src/app/api/image/delete/route.ts
+++ b/src/app/api/image/delete/route.ts
@@ -49,8 +49,6 @@ async function isLegacyGrantImageOwnedByUser(
   source: GrantImageSource,
   userId: string,
 ): Promise<boolean> {
-  if (!validatePublicIdFolder(publicId, source)) return false;
-
   const tranches = await prisma.grantTranche.findMany({
     where: {
       GrantApplication: { userId },
@@ -111,6 +109,16 @@ export async function DELETE(request: NextRequest) {
 
     const { publicId, source } = validationResult.data;
 
+    if (!validatePublicIdFolder(publicId, source)) {
+      logger.warn(
+        `Public ID ${publicId} does not match expected folder for source ${source}`,
+      );
+      return NextResponse.json(
+        { error: 'Invalid public ID for the specified source' },
+        { status: 400 },
+      );
+    }
+
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: {
@@ -136,16 +144,6 @@ export async function DELETE(request: NextRequest) {
     }
 
     if (source === 'description') {
-      if (!validatePublicIdFolder(publicId, source)) {
-        logger.warn(
-          `Public ID ${publicId} does not match expected folder for source ${source}`,
-        );
-        return NextResponse.json(
-          { error: 'Invalid public ID for the specified source' },
-          { status: 400 },
-        );
-      }
-
       if (!user.currentSponsorId && user.UserSponsors.length === 0) {
         logger.warn(
           `User ${userId} attempted to delete description image without sponsor access`,
@@ -186,19 +184,15 @@ export async function DELETE(request: NextRequest) {
         );
       }
     } else if (source === 'user') {
-      if (!user.photo) {
-        logger.info(
-          `User ${userId} attempted to delete user image but has no photo set - treating as successful no-op`,
-        );
-        return NextResponse.json({
-          message: 'No profile photo to delete',
-        });
-      }
+      const isPersistedPhoto =
+        !!user.photo && extractPublicIdFromUrl(user.photo) === publicId;
+      const isOwnedUpload =
+        !isPersistedPhoto && (await getImageOwnerId(publicId)) === userId;
 
-      const userPhotoPublicId = extractPublicIdFromUrl(user.photo);
-      if (userPhotoPublicId !== publicId) {
+      if (!isPersistedPhoto && !isOwnedUpload) {
         logger.warn(
-          `User ${userId} attempted to delete image ${publicId} but their photo is ${userPhotoPublicId}`,
+          `User ${userId} attempted to delete a profile image they do not own`,
+          { publicId },
         );
         return NextResponse.json(
           {
@@ -209,31 +203,16 @@ export async function DELETE(request: NextRequest) {
         );
       }
     } else if (source === 'sponsor') {
-      if (!user.currentSponsorId) {
-        logger.warn(
-          `User ${userId} attempted to delete sponsor image without current sponsor`,
-        );
-        return NextResponse.json(
-          { error: 'You do not have a current sponsor' },
-          { status: 403 },
-        );
-      }
+      const isPersistedSponsorLogo =
+        !!user.currentSponsor?.logo &&
+        extractPublicIdFromUrl(user.currentSponsor.logo) === publicId;
+      const isOwnedUpload =
+        !isPersistedSponsorLogo && (await getImageOwnerId(publicId)) === userId;
 
-      if (!user.currentSponsor?.logo) {
-        logger.info(
-          `User ${userId} attempted to delete sponsor logo but sponsor has no logo - treating as successful no-op`,
-        );
-        return NextResponse.json({
-          message: 'No sponsor logo to delete',
-        });
-      }
-
-      const sponsorLogoPublicId = extractPublicIdFromUrl(
-        user.currentSponsor.logo,
-      );
-      if (sponsorLogoPublicId !== publicId) {
+      if (!isPersistedSponsorLogo && !isOwnedUpload) {
         logger.warn(
-          `User ${userId} attempted to delete image ${publicId} but sponsor logo is ${sponsorLogoPublicId}`,
+          `User ${userId} attempted to delete a sponsor image they do not own`,
+          { publicId },
         );
         return NextResponse.json(
           {
@@ -244,11 +223,13 @@ export async function DELETE(request: NextRequest) {
         );
       }
 
-      const hasAccess = user.UserSponsors.some(
-        (us) =>
-          us.sponsorId === user.currentSponsorId &&
-          (us.role === 'ADMIN' || us.role === 'MEMBER'),
-      );
+      const hasAccess =
+        !isPersistedSponsorLogo ||
+        user.UserSponsors.some(
+          (us) =>
+            us.sponsorId === user.currentSponsorId &&
+            (us.role === 'ADMIN' || us.role === 'MEMBER'),
+        );
 
       if (!hasAccess) {
         logger.warn(
@@ -264,18 +245,13 @@ export async function DELETE(request: NextRequest) {
       source === 'grant-event-receipts' ||
       source === 'grant-agentic-receipts'
     ) {
-      if (!validatePublicIdFolder(publicId, source)) {
-        return NextResponse.json(
-          { error: 'Invalid public ID for the specified source' },
-          { status: 400 },
-        );
-      }
-
-      const imageOwnerId = await getImageOwnerId(publicId);
-      const isMetadataOwner = imageOwnerId === userId;
-      const isLegacyOwner =
-        imageOwnerId === null &&
-        (await isLegacyGrantImageOwnedByUser(publicId, source, userId));
+      const isLegacyOwner = await isLegacyGrantImageOwnedByUser(
+        publicId,
+        source,
+        userId,
+      );
+      const isMetadataOwner =
+        !isLegacyOwner && (await getImageOwnerId(publicId)) === userId;
 
       if (!isMetadataOwner && !isLegacyOwner) {
         logger.warn(

--- a/src/app/api/image/delete/route.ts
+++ b/src/app/api/image/delete/route.ts
@@ -6,7 +6,9 @@ import {
   deleteRequestSchema,
   extractPublicIdFromUrl,
   getImageOwnerId,
+  type GrantImageSource,
   ImageUploadError,
+  isGrantImageSource,
   UPLOAD_CONFIGS,
 } from '@/lib/image-upload';
 import logger from '@/lib/logger';
@@ -29,11 +31,6 @@ function validatePublicIdFolder(
   const config = UPLOAD_CONFIGS[source];
   return publicId.startsWith(config.folder + '/');
 }
-
-type GrantImageSource =
-  | 'grant-event-pictures'
-  | 'grant-event-receipts'
-  | 'grant-agentic-receipts';
 
 function jsonContainsPublicId(value: unknown, publicId: string): boolean {
   if (!Array.isArray(value)) return false;
@@ -240,11 +237,7 @@ export async function DELETE(request: NextRequest) {
           { status: 403 },
         );
       }
-    } else if (
-      source === 'grant-event-pictures' ||
-      source === 'grant-event-receipts' ||
-      source === 'grant-agentic-receipts'
-    ) {
+    } else if (isGrantImageSource(source)) {
       const isLegacyOwner = await isLegacyGrantImageOwnedByUser(
         publicId,
         source,

--- a/src/app/api/image/delete/route.ts
+++ b/src/app/api/image/delete/route.ts
@@ -5,6 +5,7 @@ import {
   deleteImage,
   deleteRequestSchema,
   extractPublicIdFromUrl,
+  getImageOwnerId,
   ImageUploadError,
   UPLOAD_CONFIGS,
 } from '@/lib/image-upload';
@@ -23,10 +24,54 @@ function escapeLikePattern(str: string): string {
 
 function validatePublicIdFolder(
   publicId: string,
-  source: 'user' | 'sponsor' | 'description',
+  source: keyof typeof UPLOAD_CONFIGS,
 ): boolean {
   const config = UPLOAD_CONFIGS[source];
   return publicId.startsWith(config.folder + '/');
+}
+
+type GrantImageSource =
+  | 'grant-event-pictures'
+  | 'grant-event-receipts'
+  | 'grant-agentic-receipts';
+
+function jsonContainsPublicId(value: unknown, publicId: string): boolean {
+  if (!Array.isArray(value)) return false;
+
+  return value.some((item) => {
+    if (typeof item !== 'string') return false;
+    return extractPublicIdFromUrl(item) === publicId;
+  });
+}
+
+async function isLegacyGrantImageOwnedByUser(
+  publicId: string,
+  source: GrantImageSource,
+  userId: string,
+): Promise<boolean> {
+  if (!validatePublicIdFolder(publicId, source)) return false;
+
+  const tranches = await prisma.grantTranche.findMany({
+    where: {
+      GrantApplication: { userId },
+    },
+    select: {
+      eventPictures: true,
+      eventReceipts: true,
+      aiReceipts: true,
+    },
+  });
+
+  const fieldBySource = {
+    'grant-event-pictures': 'eventPictures',
+    'grant-event-receipts': 'eventReceipts',
+    'grant-agentic-receipts': 'aiReceipts',
+  } as const;
+  const field = fieldBySource[source];
+
+  return tranches.some((tranche) =>
+    jsonContainsPublicId(tranche[field], publicId),
+  );
 }
 
 export async function DELETE(request: NextRequest) {
@@ -214,6 +259,42 @@ export async function DELETE(request: NextRequest) {
           { status: 403 },
         );
       }
+    } else if (
+      source === 'grant-event-pictures' ||
+      source === 'grant-event-receipts' ||
+      source === 'grant-agentic-receipts'
+    ) {
+      if (!validatePublicIdFolder(publicId, source)) {
+        return NextResponse.json(
+          { error: 'Invalid public ID for the specified source' },
+          { status: 400 },
+        );
+      }
+
+      const imageOwnerId = await getImageOwnerId(publicId);
+      const isMetadataOwner = imageOwnerId === userId;
+      const isLegacyOwner =
+        imageOwnerId === null &&
+        (await isLegacyGrantImageOwnedByUser(publicId, source, userId));
+
+      if (!isMetadataOwner && !isLegacyOwner) {
+        logger.warn(
+          `User ${userId} attempted to delete a grant image they do not own`,
+          { publicId, source },
+        );
+        return NextResponse.json(
+          { error: 'You do not have permission to delete this grant image' },
+          { status: 403 },
+        );
+      }
+    } else {
+      // Keep this default-deny guard even though Zod currently makes the branch
+      // unreachable. It prevents future schema additions from silently gaining
+      // delete access without an explicit authorization policy.
+      logger.error('Image source has no deletion authorization policy', {
+        source,
+      });
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     logger.info(`Deleting image with public ID: ${publicId}`);

--- a/src/app/api/image/sign/route.ts
+++ b/src/app/api/image/sign/route.ts
@@ -100,16 +100,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const grantImageSources = new Set([
-      'grant-event-pictures',
-      'grant-event-receipts',
-      'grant-agentic-receipts',
-    ]);
-    const signedParams = generateSignedUploadParams(
-      source,
-      undefined,
-      grantImageSources.has(source) ? userId : undefined,
-    );
+    const signedParams = generateSignedUploadParams(source, undefined, userId);
 
     logger.info(`Image upload signature generated for user ${userId}`, {
       source,

--- a/src/app/api/image/sign/route.ts
+++ b/src/app/api/image/sign/route.ts
@@ -100,7 +100,16 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const signedParams = generateSignedUploadParams(source);
+    const grantImageSources = new Set([
+      'grant-event-pictures',
+      'grant-event-receipts',
+      'grant-agentic-receipts',
+    ]);
+    const signedParams = generateSignedUploadParams(
+      source,
+      undefined,
+      grantImageSources.has(source) ? userId : undefined,
+    );
 
     logger.info(`Image upload signature generated for user ${userId}`, {
       source,

--- a/src/components/tiptap/hooks/use-minimal-tiptap.ts
+++ b/src/components/tiptap/hooks/use-minimal-tiptap.ts
@@ -103,6 +103,10 @@ async function uploadImageToCloudinary(
   formData.append('folder', signedParams.folder);
   formData.append('api_key', signedParams.apiKey);
 
+  if (signedParams.context) {
+    formData.append('context', signedParams.context);
+  }
+
   if (signedParams.publicId) {
     formData.append('public_id', signedParams.publicId);
   }

--- a/src/hooks/use-image-upload.ts
+++ b/src/hooks/use-image-upload.ts
@@ -160,6 +160,10 @@ export function useImageUpload({
         formData.append('folder', signedParams.folder);
         formData.append('api_key', signedParams.apiKey);
 
+        if (signedParams.context) {
+          formData.append('context', signedParams.context);
+        }
+
         if (signedParams.publicId) {
           formData.append('public_id', signedParams.publicId);
         }

--- a/src/lib/image-upload/cloudinary-client.ts
+++ b/src/lib/image-upload/cloudinary-client.ts
@@ -1,5 +1,7 @@
 import { v2 as cloudinary } from 'cloudinary';
 
+import logger from '@/lib/logger';
+
 import { CLOUDINARY_CONFIG, UPLOAD_CONFIGS } from './config';
 import type { ImageSource, SignedUploadParams } from './types';
 
@@ -82,7 +84,18 @@ export async function deleteImage(publicId: string): Promise<boolean> {
         resource_type: resourceType,
       });
       if (result.result === 'ok') return true;
-    } catch {}
+    } catch (error: any) {
+      const isNotFound =
+        error?.http_code === 404 || error?.error?.http_code === 404;
+      if (isNotFound) continue;
+
+      logger.error('Cloudinary asset deletion failed', {
+        publicId,
+        resourceType,
+        error,
+      });
+      throw error;
+    }
   }
 
   return false;

--- a/src/lib/image-upload/cloudinary-client.ts
+++ b/src/lib/image-upload/cloudinary-client.ts
@@ -16,14 +16,18 @@ cloudinary.config({
 export function generateSignedUploadParams(
   source: ImageSource,
   publicId?: string,
+  ownerId?: string,
 ): SignedUploadParams {
   const config = UPLOAD_CONFIGS[source];
   const timestamp = Math.round(Date.now() / 1000);
+  const context = ownerId ? `owner_id=${ownerId}` : undefined;
 
   const paramsToSign: Record<string, string | number> = {
     timestamp,
     folder: config.folder,
   };
+
+  if (context) paramsToSign.context = context;
 
   if (publicId) {
     paramsToSign.public_id = publicId;
@@ -45,17 +49,42 @@ export function generateSignedUploadParams(
     apiKey: CLOUDINARY_CONFIG.apiKey,
     folder: config.folder,
     publicId,
+    context,
     eager: config.eager,
   };
 }
 
-export async function deleteImage(publicId: string): Promise<boolean> {
-  try {
-    const result = await cloudinary.uploader.destroy(publicId);
-    return result.result === 'ok';
-  } catch {
-    return false;
+export async function getImageOwnerId(
+  publicId: string,
+): Promise<string | null> {
+  for (const resourceType of ['image', 'raw'] as const) {
+    try {
+      const resource = await cloudinary.api.resource(publicId, {
+        resource_type: resourceType,
+      });
+      const ownerId = resource.context?.custom?.owner_id;
+      return typeof ownerId === 'string' && ownerId ? ownerId : null;
+    } catch (error: any) {
+      if (error?.http_code !== 404 && error?.error?.http_code !== 404) {
+        throw error;
+      }
+    }
   }
+
+  return null;
+}
+
+export async function deleteImage(publicId: string): Promise<boolean> {
+  for (const resourceType of ['image', 'raw'] as const) {
+    try {
+      const result = await cloudinary.uploader.destroy(publicId, {
+        resource_type: resourceType,
+      });
+      if (result.result === 'ok') return true;
+    } catch {}
+  }
+
+  return false;
 }
 
 export function extractPublicIdFromUrl(url: string): string | null {

--- a/src/lib/image-upload/cloudinary-client.ts
+++ b/src/lib/image-upload/cloudinary-client.ts
@@ -61,6 +61,7 @@ export async function getImageOwnerId(
     try {
       const resource = await cloudinary.api.resource(publicId, {
         resource_type: resourceType,
+        context: true,
       });
       const ownerId = resource.context?.custom?.owner_id;
       return typeof ownerId === 'string' && ownerId ? ownerId : null;

--- a/src/lib/image-upload/index.ts
+++ b/src/lib/image-upload/index.ts
@@ -8,3 +8,9 @@ export { UPLOAD_CONFIGS } from './config';
 export { ImageUploadError } from './errors';
 export { deleteRequestSchema, signRequestSchema } from './schemas';
 export { getRateLimitHeaders } from './security/rate-limiter';
+export {
+  GRANT_IMAGE_SOURCES,
+  IMAGE_SOURCES,
+  isGrantImageSource,
+} from './types';
+export type { GrantImageSource, ImageSource } from './types';

--- a/src/lib/image-upload/index.ts
+++ b/src/lib/image-upload/index.ts
@@ -2,6 +2,7 @@ export {
   deleteImage,
   extractPublicIdFromUrl,
   generateSignedUploadParams,
+  getImageOwnerId,
 } from './cloudinary-client';
 export { UPLOAD_CONFIGS } from './config';
 export { ImageUploadError } from './errors';

--- a/src/lib/image-upload/schemas.ts
+++ b/src/lib/image-upload/schemas.ts
@@ -1,16 +1,11 @@
 import { z } from 'zod';
 
+import { IMAGE_SOURCES, isGrantImageSource } from './types';
+
 export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 export const MAX_FILE_SIZE_LARGE = 15 * 1024 * 1024; // 15MB for event pictures
 
-const imageSourceSchema = z.enum([
-  'user',
-  'sponsor',
-  'description',
-  'grant-event-pictures',
-  'grant-event-receipts',
-  'grant-agentic-receipts',
-]);
+const imageSourceSchema = z.enum(IMAGE_SOURCES);
 
 const contentTypeSchema = z.enum([
   'image/jpeg',
@@ -25,12 +20,6 @@ const publicIdSchema = z
   .max(500, 'Public ID too long')
   .regex(/^[a-zA-Z0-9_\-/]+$/, 'Public ID contains invalid characters');
 
-const LARGE_FILE_SOURCES: string[] = [
-  'grant-event-pictures',
-  'grant-event-receipts',
-  'grant-agentic-receipts',
-];
-
 export const signRequestSchema = z
   .object({
     source: imageSourceSchema,
@@ -42,7 +31,7 @@ export const signRequestSchema = z
   .refine(
     (data) => {
       if (data.contentLength === undefined) return true;
-      const maxSize = LARGE_FILE_SOURCES.includes(data.source)
+      const maxSize = isGrantImageSource(data.source)
         ? MAX_FILE_SIZE_LARGE
         : MAX_FILE_SIZE;
       return data.contentLength <= maxSize;

--- a/src/lib/image-upload/types.ts
+++ b/src/lib/image-upload/types.ts
@@ -1,10 +1,24 @@
-export type ImageSource =
-  | 'user'
-  | 'sponsor'
-  | 'description'
-  | 'grant-event-pictures'
-  | 'grant-event-receipts'
-  | 'grant-agentic-receipts';
+export const GRANT_IMAGE_SOURCES = [
+  'grant-event-pictures',
+  'grant-event-receipts',
+  'grant-agentic-receipts',
+] as const;
+
+export const IMAGE_SOURCES = [
+  'user',
+  'sponsor',
+  'description',
+  ...GRANT_IMAGE_SOURCES,
+] as const;
+
+export type ImageSource = (typeof IMAGE_SOURCES)[number];
+export type GrantImageSource = (typeof GRANT_IMAGE_SOURCES)[number];
+
+export function isGrantImageSource(
+  source: ImageSource,
+): source is GrantImageSource {
+  return GRANT_IMAGE_SOURCES.some((grantSource) => grantSource === source);
+}
 export type ImageFormat = 'jpeg' | 'png' | 'webp';
 
 export interface UploadResult {

--- a/src/lib/image-upload/types.ts
+++ b/src/lib/image-upload/types.ts
@@ -23,6 +23,7 @@ export interface SignedUploadParams {
   apiKey: string;
   folder: string;
   publicId?: string;
+  context?: string;
   eager?: string;
 }
 


### PR DESCRIPTION
## What does this PR do?
- Adds a proper ownership to images metadata for grants and profile/sponsor uploads.
- delete-image endpoint is no longer unrestricted and has validations in place to only allow auth users to delete their own images.
- does not break any legacy image uploads, fallback added wherever necessary.
- consolidate the image source types to be a single source of truth.
- fixed a bug where profile/sponsor image would not delete previously uploaded images if save/update was not performed in the session.

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization for deleting grant, profile, and sponsor images.
  * Unauthorized and unsupported deletion requests are now safely denied.
  * Improved removal of image and raw media uploads.
  * Removed redundant validation and legacy handling for missing images.

* **Enhancements**
  * Uploads now retain ownership metadata for more reliable authorization.
  * Grant-related uploads and signing include ownership information where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->