### PR TITLE
Fix token icon SVG issue

### DIFF
--- a/src/pages/api/token-icon.ts
+++ b/src/pages/api/token-icon.ts
@@ -3,9 +3,11 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import logger from '@/lib/logger';
 import { isSafeRemoteUrl, safeRemoteFetch } from '@/utils/safeRemoteFetch';
 import { safeStringify } from '@/utils/safeStringify';
-import { sanitizeTokenIcon } from '@/utils/tokenIconImage';
+import {
+  MAX_TOKEN_ICON_SIZE_BYTES,
+  sanitizeTokenIcon,
+} from '@/utils/tokenIconImage';
 
-const MAX_ICON_SIZE_BYTES = 5 * 1024 * 1024;
 const MAX_REDIRECTS = 4;
 const UPSTREAM_FETCH_TIMEOUT_MS = 5000;
 const CACHE_CONTROL =
@@ -70,7 +72,7 @@ export default async function handler(
       },
       maxRedirects: MAX_REDIRECTS,
       timeoutMs: UPSTREAM_FETCH_TIMEOUT_MS,
-      maxResponseBytes: MAX_ICON_SIZE_BYTES,
+      maxResponseBytes: MAX_TOKEN_ICON_SIZE_BYTES,
     });
 
     if (!iconResponse.ok) {
@@ -79,12 +81,12 @@ export default async function handler(
 
     const contentType = iconResponse.headers.get('content-type') || '';
     const contentLength = Number(iconResponse.headers.get('content-length'));
-    if (contentLength > MAX_ICON_SIZE_BYTES) {
+    if (contentLength > MAX_TOKEN_ICON_SIZE_BYTES) {
       return res.status(413).end();
     }
 
     const icon = Buffer.from(await iconResponse.arrayBuffer());
-    if (icon.byteLength > MAX_ICON_SIZE_BYTES) {
+    if (icon.byteLength > MAX_TOKEN_ICON_SIZE_BYTES) {
       return res.status(413).end();
     }
 

--- a/src/pages/api/token-icon.ts
+++ b/src/pages/api/token-icon.ts
@@ -1,25 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import sharp from 'sharp';
 
 import logger from '@/lib/logger';
 import { isSafeRemoteUrl, safeRemoteFetch } from '@/utils/safeRemoteFetch';
 import { safeStringify } from '@/utils/safeStringify';
+import { sanitizeTokenIcon } from '@/utils/tokenIconImage';
 
 const MAX_ICON_SIZE_BYTES = 5 * 1024 * 1024;
-const MAX_ICON_PIXELS = 16 * 1024 * 1024;
 const MAX_REDIRECTS = 4;
 const UPSTREAM_FETCH_TIMEOUT_MS = 5000;
 const CACHE_CONTROL =
   'public, max-age=86400, s-maxage=86400, stale-while-revalidate=604800';
-const PNG_CONTENT_TYPE = 'image/png';
-
-const convertToPng = (image: Buffer) =>
-  sharp(image, {
-    failOn: 'error',
-    limitInputPixels: MAX_ICON_PIXELS,
-  })
-    .png()
-    .toBuffer();
 
 const sendImage = (
   res: NextApiResponse,
@@ -28,6 +18,7 @@ const sendImage = (
 ) => {
   res.setHeader('Cache-Control', CACHE_CONTROL);
   res.setHeader('Content-Type', contentType);
+  res.setHeader('Content-Security-Policy', "default-src 'none'; sandbox");
   res.setHeader('X-Content-Type-Options', 'nosniff');
   return res.status(200).send(image);
 };
@@ -87,10 +78,6 @@ export default async function handler(
     }
 
     const contentType = iconResponse.headers.get('content-type') || '';
-    if (!contentType.toLowerCase().startsWith('image/')) {
-      return res.status(415).end();
-    }
-
     const contentLength = Number(iconResponse.headers.get('content-length'));
     if (contentLength > MAX_ICON_SIZE_BYTES) {
       return res.status(413).end();
@@ -101,27 +88,25 @@ export default async function handler(
       return res.status(413).end();
     }
 
-    if (requiresPng) {
-      try {
-        return sendImage(res, await convertToPng(icon), PNG_CONTENT_TYPE);
-      } catch (error) {
-        logger.warn(
-          `Failed to convert token icon to PNG: ${safeStringify({
-            iconUrl: iconUrl.toString(),
-            contentType,
-            error,
-          })}`,
-        );
-        return res.status(415).end();
-      }
+    try {
+      const sanitizedIcon = await sanitizeTokenIcon(icon, contentType, {
+        forcePng: requiresPng,
+      });
+      return sendImage(res, sanitizedIcon.image, sanitizedIcon.contentType);
+    } catch (error) {
+      logger.warn(
+        `Failed to sanitize token icon: ${safeStringify({
+          iconUrl: iconUrl.toString(),
+          contentType,
+          error,
+        })}`,
+      );
+      return res.status(415).end();
     }
-
-    return sendImage(res, icon, contentType);
   } catch (error) {
     logger.error(
       `Failed to proxy token icon: ${safeStringify({
         iconUrl: iconUrl.toString(),
-        requiresPng,
         error,
       })}`,
     );

--- a/src/utils/tokenIconImage.ts
+++ b/src/utils/tokenIconImage.ts
@@ -1,0 +1,50 @@
+import sharp from 'sharp';
+
+const MAX_ICON_PIXELS = 16 * 1024 * 1024;
+
+const CONTENT_TYPE_BY_FORMAT = new Map([
+  ['gif', 'image/gif'],
+  ['heif', 'image/avif'],
+  ['jpeg', 'image/jpeg'],
+  ['png', 'image/png'],
+  ['svg', 'image/svg+xml'],
+  ['webp', 'image/webp'],
+]);
+
+const normalizeContentType = (contentType: string) =>
+  contentType.split(';', 1)[0]?.trim().toLowerCase() || '';
+
+export const sanitizeTokenIcon = async (
+  image: Buffer,
+  declaredContentType: string,
+  options?: { forcePng?: boolean },
+) => {
+  const pipeline = sharp(image, {
+    failOn: 'error',
+    limitInputPixels: MAX_ICON_PIXELS,
+  });
+  const metadata = await pipeline.metadata();
+  const detectedContentType = metadata.format
+    ? CONTENT_TYPE_BY_FORMAT.get(metadata.format)
+    : undefined;
+
+  if (!detectedContentType) {
+    throw new Error('Unsupported token icon format');
+  }
+
+  const normalizedDeclaredContentType =
+    normalizeContentType(declaredContentType);
+  const shouldRasterize =
+    options?.forcePng ||
+    metadata.format === 'svg' ||
+    normalizedDeclaredContentType !== detectedContentType;
+
+  if (shouldRasterize) {
+    return {
+      image: await pipeline.png().toBuffer(),
+      contentType: 'image/png',
+    };
+  }
+
+  return { image, contentType: detectedContentType };
+};

--- a/src/utils/tokenIconImage.ts
+++ b/src/utils/tokenIconImage.ts
@@ -1,6 +1,9 @@
 import sharp from 'sharp';
 
+export const MAX_TOKEN_ICON_SIZE_BYTES = 5 * 1024 * 1024;
+
 const MAX_ICON_PIXELS = 16 * 1024 * 1024;
+const MAX_NORMALIZED_ICON_DIMENSION = 1024;
 
 const CONTENT_TYPE_BY_FORMAT = new Map([
   ['gif', 'image/gif'],
@@ -13,6 +16,33 @@ const CONTENT_TYPE_BY_FORMAT = new Map([
 
 const normalizeContentType = (contentType: string) =>
   contentType.split(';', 1)[0]?.trim().toLowerCase() || '';
+
+const encodeBoundedPng = async (pipeline: sharp.Sharp) => {
+  const output = pipeline
+    .resize({
+      width: MAX_NORMALIZED_ICON_DIMENSION,
+      height: MAX_NORMALIZED_ICON_DIMENSION,
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .png();
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  for await (const chunk of output) {
+    const buffer = Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+
+    if (totalBytes > MAX_TOKEN_ICON_SIZE_BYTES) {
+      output.destroy();
+      throw new Error('Normalized token icon is too large');
+    }
+
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks, totalBytes);
+};
 
 export const sanitizeTokenIcon = async (
   image: Buffer,
@@ -41,7 +71,7 @@ export const sanitizeTokenIcon = async (
 
   if (shouldRasterize) {
     return {
-      image: await pipeline.png().toBuffer(),
+      image: await encodeBoundedPng(pipeline),
       contentType: 'image/png',
     };
   }


### PR DESCRIPTION
## What does this PR do?
- Restricts SVG's to strictly be PNG to avoid inline js acceptance.
- Updated pipeline for rasterization for OG images and SVG token icons.
- Other formats for OG and token icons is preserved

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added stricter security headers when serving token icons.
  * Validates supported image formats, pixel dimensions, and file size before delivery.
  * Converts images to PNG when needed for safer, consistent handling.

* **Bug Fixes**
  * Improved handling of mismatched or inaccurate image content types.
  * Unsupported or invalid images now return a clear error response instead of being served.
  * Sanitization failures are reported with an appropriate unsupported-media response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->