### PR TITLE
Better restricted winners endpoint

### DIFF
--- a/src/app/api/dynamic-og/winners/route.tsx
+++ b/src/app/api/dynamic-og/winners/route.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og';
 
 import { ExternalImage } from '@/components/ui/cloudinary-image';
-import type { SubmissionWithUser } from '@/interface/submission';
+import type { ListingWinner } from '@/interface/submission';
 import { convertToJpegUrl } from '@/utils/cloudinary';
 import { formatString, loadGoogleFont } from '@/utils/ogHelpers';
 import { nthLabelGenerator } from '@/utils/rank';
@@ -26,7 +26,11 @@ const BORING_AVATAR_COLORS = [
 
 const AVATAR_SIZE = 80;
 
-const getAvatarSeed = (winner: SubmissionWithUser) => {
+type WinnerOgSubmission = Pick<ListingWinner, 'id' | 'winnerPosition'> & {
+  user: Pick<ListingWinner['user'], 'id' | 'firstName' | 'lastName' | 'photo'>;
+};
+
+const getAvatarSeed = (winner: WinnerOgSubmission) => {
   return (
     winner?.user?.id ||
     [winner?.user?.firstName, winner?.user?.lastName, winner?.id]
@@ -129,7 +133,7 @@ export async function GET(request: Request) {
 
     const submissions = getParam('submissions', (x) =>
       JSON.parse(decodeURIComponent(x)),
-    ) as SubmissionWithUser[];
+    ) as WinnerOgSubmission[];
 
     if (!id) throw new Error('ID IS MISSING');
     if (!rewards) throw new Error('REWARDS IS MISSING');

--- a/src/features/listings/components/ListingPage/ListingWinners.tsx
+++ b/src/features/listings/components/ListingPage/ListingWinners.tsx
@@ -6,7 +6,7 @@ import { useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
-import { type SubmissionWithUser } from '@/interface/submission';
+import { type ListingWinner } from '@/interface/submission';
 import { cn } from '@/utils/cn';
 import { nthLabelGenerator } from '@/utils/rank';
 import { tweetEmbedLink } from '@/utils/socialEmbeds';
@@ -24,7 +24,7 @@ interface Props {
 }
 
 const getOrRemoveBonuses = (
-  submissions: SubmissionWithUser[],
+  submissions: ListingWinner[],
   removeBonus: boolean,
 ) => {
   if (removeBonus)

--- a/src/features/listings/queries/listing-winners.ts
+++ b/src/features/listings/queries/listing-winners.ts
@@ -1,11 +1,13 @@
 import { queryOptions } from '@tanstack/react-query';
 
-import { type SubmissionWithUser } from '@/interface/submission';
+import { type ListingWinner } from '@/interface/submission';
 import { api } from '@/lib/api';
 
-const fetchWinners = async (id: string): Promise<SubmissionWithUser[]> => {
-  const { data } = await api.get(`/api/listings/${id}/winners/`);
-  return data.sort((a: SubmissionWithUser, b: SubmissionWithUser) => {
+const fetchWinners = async (id: string): Promise<ListingWinner[]> => {
+  const { data } = await api.get<ListingWinner[]>(
+    `/api/listings/${id}/winners/`,
+  );
+  return data.sort((a, b) => {
     if (!a.winnerPosition) return 1;
     if (!b.winnerPosition) return -1;
     return Number(a.winnerPosition) - Number(b.winnerPosition);

--- a/src/interface/submission.ts
+++ b/src/interface/submission.ts
@@ -42,4 +42,16 @@ interface SubmissionWithUser {
   ai?: ProjectApplicationAi;
 }
 
-export type { SubmissionWithUser };
+interface ListingWinner {
+  id: string;
+  winnerPosition: number | null;
+  user: {
+    id: string;
+    username: string | null;
+    firstName: string | null;
+    lastName: string | null;
+    photo: string | null;
+  };
+}
+
+export type { ListingWinner, SubmissionWithUser };

--- a/src/pages/api/listings/[listingId]/winners.ts
+++ b/src/pages/api/listings/[listingId]/winners.ts
@@ -1,11 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { type SubmissionWithUser } from '@/interface/submission';
+import { type ListingWinner } from '@/interface/submission';
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
-import { convertDatesToISO, safeStringify } from '@/utils/safeStringify';
+import { safeStringify } from '@/utils/safeStringify';
 
-export async function getWinningSubmissionsByListingId(listingId: string) {
+export async function getWinningSubmissionsByListingId(
+  listingId: string,
+): Promise<ListingWinner[]> {
   if (!listingId) {
     throw new Error('Missing required query parameters: listingId');
   }
@@ -16,9 +18,14 @@ export async function getWinningSubmissionsByListingId(listingId: string) {
       isActive: true,
       isArchived: false,
       isWinner: true,
+      listing: {
+        isWinnersAnnounced: true,
+      },
     },
     orderBy: { updatedAt: 'desc' },
-    include: {
+    select: {
+      id: true,
+      winnerPosition: true,
       user: {
         select: {
           id: true,
@@ -37,7 +44,7 @@ export async function getWinningSubmissionsByListingId(listingId: string) {
     return Number(a.winnerPosition) - Number(b.winnerPosition);
   });
 
-  return convertDatesToISO(result) as unknown as SubmissionWithUser[];
+  return result;
 }
 
 export default async function submission(

--- a/src/pages/earn/listing/[slug]/winner.tsx
+++ b/src/pages/earn/listing/[slug]/winner.tsx
@@ -3,20 +3,20 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
-import type { SubmissionWithUser } from '@/interface/submission';
+import type { ListingWinner } from '@/interface/submission';
 import { getWinningSubmissionsByListingId } from '@/pages/api/listings/[listingId]/winners';
 import { getListingDetailsBySlug } from '@/pages/api/listings/details/[slug]';
 import { sortRank } from '@/utils/rank';
 import { getURL } from '@/utils/validUrl';
 
 import { BONUS_REWARD_POSITION } from '@/features/listing-builder/constants';
-import { type Listing, type Rewards } from '@/features/listings/types';
+import { type Listing } from '@/features/listings/types';
 import { getListingTypeLabel } from '@/features/listings/utils/status';
 
 interface BountyDetailsProps {
   bounty: Listing | null;
   url: string;
-  submissions: SubmissionWithUser[];
+  submissions: StrippedSubmission[];
 }
 
 function WinnerBounty({
@@ -88,12 +88,12 @@ function WinnerBounty({
 
 interface StrippedSubmission {
   id: string;
-  winnerPosition: keyof Rewards | undefined;
+  winnerPosition: number | null;
   user: {
-    id: string | undefined;
-    firstName: string | undefined;
-    lastName: string | undefined;
-    photo: string | undefined;
+    id: string;
+    firstName: string | null;
+    lastName: string | null;
+    photo: string | null;
   };
 }
 
@@ -114,9 +114,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     const winners = sortRank(
       data.map((submission) => submission.winnerPosition || NaN),
     );
-    const sortedSubmissions = winners.map((position) =>
-      data.find((d: SubmissionWithUser) => d.winnerPosition === position),
-    ) as SubmissionWithUser[];
+    const sortedSubmissions = winners
+      .map((position) =>
+        data.find((submission) => submission.winnerPosition === position),
+      )
+      .filter((submission): submission is ListingWinner => !!submission);
     sortedSubmissions.forEach((s) => {
       submissions.push({
         id: s.id,


### PR DESCRIPTION
## What does this PR do?
- Restricts the public /winners endpoint to expose only the required fields from db fetch instead of all.
- updated types for the endpoint and consumers to match types for better readability and type checking.

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved winner data handling across listing pages and winner previews.
  * Winner results now appear only when winners have been announced.
  * Updated winner displays to better handle missing winner positions and profile details.
  * Preserved existing winner sorting, rendering, and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->