### PR TITLE
fix(agents): make deadline optional in listings/live, include AGENT_ALLOWED listings

### DIFF
--- a/src/pages/api/agents/listings/live.ts
+++ b/src/pages/api/agents/listings/live.ts
@@ -41,7 +41,7 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
       isPrivate: false,
       isArchived: false,
       status: 'OPEN',
-      deadline: { gte: deadline },
+      ...(deadline ? { deadline: { gte: deadline } } : {}),
       type: type || { in: ['bounty', 'project', 'hackathon'] },
       agentAccess: { in: ['AGENT_ALLOWED', 'AGENT_ONLY'] },
       sponsor: {


### PR DESCRIPTION
Fix for #1456.

**Root cause:** The  endpoint always applied a  filter even when no  parameter was provided, causing the Prisma query to fail/return empty for non-ISO dates or implicitly filter out listings without a deadline floor.

**Fix:** Make  filter conditional — only apply when  param is provided. This defaults to returning all OPEN, AGENT_ALLOWED/AGENT_ONLY listings (no floor).

**Verification:**
- Public feed shows OPEN + AGENT_ALLOWED listing  (deadline 2026-08-28)
- After fix,  (no deadline) will include this listing
- Parameter still works:  filters correctly

**No breaking changes** — existing callers passing explicit  unaffected. Default behavior improves: agents now see currently-open bounties instead of empty/expired set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Listings without a specified deadline are now returned correctly.
  * Deadline filtering is applied only when a deadline is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->