### PR TITLE
fix: Prevent Duplicate Spam Credit Penalties

### DIFF
--- a/src/features/credits/utils/allocateCredits.ts
+++ b/src/features/credits/utils/allocateCredits.ts
@@ -1,11 +1,13 @@
 import { prisma } from '@/prisma';
 import { CreditEventType, SubmissionLabels } from '@/prisma/enums';
+import { LockNotAcquiredError, withRedisLock } from '@/lib/with-redis-lock';
 import { dayjs } from '@/utils/dayjs';
 
 const currentMonth = dayjs.utc().startOf('month').toDate();
 const nextMonth = dayjs.utc().add(1, 'month').startOf('month').toDate();
 
 type PrismaLike = Pick<typeof prisma, 'creditLedger'>;
+type CreditPenaltyResult = { created: boolean };
 
 export async function consumeCredit(
   userId: string,
@@ -68,27 +70,52 @@ export async function addGrantWinBonusCredit(
   });
 }
 
-export async function addSpamPenaltyCredit(submissionId: string) {
+export async function addSpamPenaltyCredit(
+  submissionId: string,
+): Promise<CreditPenaltyResult> {
   try {
-    const submission = await prisma.submission.findFirst({
-      where: { id: submissionId, label: SubmissionLabels.Spam },
-      select: { id: true, userId: true },
-    });
+    return await withRedisLock(
+      `locks:credit-penalty:submission:${submissionId}`,
+      async () => {
+        const submission = await prisma.submission.findFirst({
+          where: { id: submissionId, label: SubmissionLabels.Spam },
+          select: { id: true, userId: true },
+        });
 
-    if (!submission) {
-      throw new Error('Submission not found');
+        if (!submission) {
+          throw new Error('Submission not found');
+        }
+
+        const existingPenalty = await prisma.creditLedger.findFirst({
+          where: {
+            submissionId: submission.id,
+            type: CreditEventType.SPAM_PENALTY,
+          },
+          select: { id: true },
+        });
+
+        if (existingPenalty) {
+          return { created: false };
+        }
+
+        await prisma.creditLedger.create({
+          data: {
+            userId: submission.userId,
+            submissionId: submission.id,
+            type: CreditEventType.SPAM_PENALTY,
+            effectiveMonth: nextMonth,
+            change: -1,
+          },
+        });
+
+        return { created: true };
+      },
+    );
+  } catch (error) {
+    if (error instanceof LockNotAcquiredError) {
+      return { created: false };
     }
 
-    await prisma.creditLedger.create({
-      data: {
-        userId: submission.userId,
-        submissionId: submission.id,
-        type: CreditEventType.SPAM_PENALTY,
-        effectiveMonth: nextMonth,
-        change: -1,
-      },
-    });
-  } catch (error) {
     console.error('[CreditAllocation] Failed to add spam penalty credit', {
       submissionId,
       error,
@@ -100,16 +127,48 @@ export async function addSpamPenaltyCredit(submissionId: string) {
 export async function addSpamPenaltyGrant(
   userId: string,
   applicationId: string,
-) {
-  await prisma.creditLedger.create({
-    data: {
+): Promise<CreditPenaltyResult> {
+  try {
+    return await withRedisLock(
+      `locks:credit-penalty:grant-application:${applicationId}`,
+      async () => {
+        const existingPenalty = await prisma.creditLedger.findFirst({
+          where: {
+            applicationId,
+            type: CreditEventType.GRANT_SPAM_PENALTY,
+          },
+          select: { id: true },
+        });
+
+        if (existingPenalty) {
+          return { created: false };
+        }
+
+        await prisma.creditLedger.create({
+          data: {
+            userId,
+            applicationId,
+            type: CreditEventType.GRANT_SPAM_PENALTY,
+            effectiveMonth: nextMonth,
+            change: -1,
+          },
+        });
+
+        return { created: true };
+      },
+    );
+  } catch (error) {
+    if (error instanceof LockNotAcquiredError) {
+      return { created: false };
+    }
+
+    console.error('[CreditAllocation] Failed to add grant spam penalty credit', {
       userId,
       applicationId,
-      type: CreditEventType.GRANT_SPAM_PENALTY,
-      effectiveMonth: nextMonth,
-      change: -1,
-    },
-  });
+      error,
+    });
+    throw error;
+  }
 }
 
 export async function addCreditDispute(

--- a/src/pages/api/sponsor-dashboard/submission/update-label.ts
+++ b/src/pages/api/sponsor-dashboard/submission/update-label.ts
@@ -116,7 +116,12 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       });
 
       if (label === 'Spam') {
-        await addSpamPenaltyCredit(submission.id);
+        const penaltyResult = await addSpamPenaltyCredit(submission.id);
+        if (!penaltyResult.created) {
+          results.push({ ...result, autoFixed });
+          continue;
+        }
+
         try {
           await queueEmail({
             type: 'spamCredit',


### PR DESCRIPTION
## Summary

Prevents duplicate credit penalties when a submission or grant application is marked as Spam more than once.

## Changes

- Made spam penalty creation idempotent for submissions and grant applications.
- Added per-record Redis locks around spam penalty creation to avoid concurrent duplicate ledger entries.
- Skips duplicate spam-credit notification emails when a submission already has a spam penalty.

## Validation

- `npm run lint` passed.
- `git diff --check` passed, only CRLF warnings.
- `npm run check-types` is currently blocked by unrelated existing type errors outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate spam-penalty credits when the same action is processed more than once.
  * Added safeguards to handle concurrent penalty processing reliably.
  * Avoided sending duplicate email notifications when no new penalty is created.
  * Spam penalties now apply only after confirming the submission is correctly labeled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->