### PR TITLE
chore(security): add HSTS, nosniff, Referrer-Policy and Permissions-Policy headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -108,6 +108,19 @@ const nextConfig: NextConfig = {
       headers: [
         { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
         { key: 'Content-Security-Policy', value: csp },
+        { key: 'X-Content-Type-Options', value: 'nosniff' },
+        {
+          key: 'Referrer-Policy',
+          value: 'strict-origin-when-cross-origin',
+        },
+        {
+          key: 'Permissions-Policy',
+          value: 'camera=(), microphone=(), geolocation=()',
+        },
+        {
+          key: 'Strict-Transport-Security',
+          value: 'max-age=63072000; includeSubDomains; preload',
+        },
       ],
     });
 


### PR DESCRIPTION
Adds standard hardening response headers alongside the existing `X-Frame-Options` and CSP on the global `/:path*` matcher:

- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`

Purely additive; no behavioural change to any route.

`pnpm check-types` and `pnpm lint` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added response headers that strengthen content handling, referrer privacy, browser feature permissions, and HTTPS enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->