### PR TITLE
fix(wallet/price): URL-encode mintAddress query parameter

### DIFF
--- a/src/app/api/wallet/price/route.ts
+++ b/src/app/api/wallet/price/route.ts
@@ -44,10 +44,13 @@ export async function GET(request: Request) {
       );
     }
 
-    const response = await fetch(`${baseUrl}?ids=${mintAddress}`, {
-      headers: { 'x-api-key': apiKey },
-      next: { revalidate: 60 },
-    });
+    const response = await fetch(
+      `${baseUrl}?ids=${encodeURIComponent(mintAddress)}`,
+      {
+        headers: { 'x-api-key': apiKey },
+        next: { revalidate: 60 },
+      },
+    );
 
     if (!response.ok) {
       throw new Error(`API error: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
`mintAddress` comes from the request query string and was interpolated into the upstream Jupiter price URL unescaped. Wrapped in `encodeURIComponent` so reserved characters can't alter the outgoing request.

Behaviour for valid mint addresses is unchanged. Formatting follows `oxfmt`.

`pnpm check-types` and `pnpm lint` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet token price lookups by safely encoding token addresses in API requests.
  * Preserved existing request headers and 60-second price refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->