### PR TITLE
fix(referral/verify): stop exposing inviter's internal user id in response

### DIFF
--- a/src/pages/api/user/referral/verify.ts
+++ b/src/pages/api/user/referral/verify.ts
@@ -33,7 +33,6 @@ export default async function handler(
       valid: remaining > 0,
       remaining,
       inviter: {
-        id: inviter.id,
         name:
           [inviter.firstName, inviter.lastName].filter(Boolean).join(' ') ||
           'A Superteamer',


### PR DESCRIPTION
The public, unauthenticated `referral/verify` endpoint returned the inviter's internal user `id` in the response alongside their display name and photo. The `id` isn't used by the invite UI and only aids enumeration, so it's removed from the response payload.

It remains in the Prisma `select` because the remaining-slots count keys on it. Display name and photo (needed to render the invite screen) are unchanged.

`pnpm check-types` and `pnpm lint` pass.