### PR TITLE
fix(listing): require an authenticated session on sponsor utility endpoints

### DIFF
--- a/src/app/api/sponsor-dashboard/listing/check-slug/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/check-slug/route.ts
@@ -1,14 +1,24 @@
+import { headers } from 'next/headers';
 import { type NextRequest, NextResponse } from 'next/server';
 
 import logger from '@/lib/logger';
 import { safeStringify } from '@/utils/safeStringify';
 
+import { getUserSession } from '@/features/auth/utils/getUserSession';
 import {
   checkSlug,
   generateUniqueSlug,
 } from '@/features/listing-builder/utils/getValidSlug';
 
 export async function GET(request: NextRequest) {
+  const session = await getUserSession(await headers());
+  if (session.status !== 200 || !session.data) {
+    return NextResponse.json(
+      { error: session.error || 'Unauthorized' },
+      { status: session.status || 401 },
+    );
+  }
+
   const { searchParams } = new URL(request.url);
   const slug = searchParams.get('slug');
   const check = searchParams.get('check');

--- a/src/app/api/sponsor-dashboard/listing/email-estimate/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/email-estimate/route.ts
@@ -1,8 +1,10 @@
+import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { skillsArraySchema } from '@/interface/skills';
 
+import { getUserSession } from '@/features/auth/utils/getUserSession';
 import { getEmailEstimate } from '@/features/listing-builder/components/Form/Boost/server-queries';
 
 const BodySchema = z.object({
@@ -11,6 +13,14 @@ const BodySchema = z.object({
 });
 
 export async function POST(request: Request) {
+  const session = await getUserSession(await headers());
+  if (session.status !== 200 || !session.data) {
+    return NextResponse.json(
+      { error: session.error || 'Unauthorized' },
+      { status: session.status || 401 },
+    );
+  }
+
   try {
     const json = await request.json();
     const { skills, region } = BodySchema.parse(json);

--- a/src/app/api/sponsor-dashboard/listing/featured-posts/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/featured-posts/route.ts
@@ -1,10 +1,20 @@
+import { headers } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { prisma } from '@/prisma';
 
+import { getUserSession } from '@/features/auth/utils/getUserSession';
 import { buildFeaturedAvailabilityWhere } from '@/features/listing-builder/utils/featured-availability';
 
 export async function POST() {
+  const session = await getUserSession(await headers());
+  if (session.status !== 200 || !session.data) {
+    return NextResponse.json(
+      { error: session.error || 'Unauthorized' },
+      { status: session.status || 401 },
+    );
+  }
+
   try {
     const count = await prisma.bounties.count({
       where: buildFeaturedAvailabilityWhere(),


### PR DESCRIPTION
`check-slug`, `email-estimate` and `featured-posts` under `/api/sponsor-dashboard/listing` are only called from the authenticated listing builder but had no session check. Adds a `getUserSession` gate to each, matching the other sponsor-dashboard routes, so they aren't callable anonymously.

Checked all call sites before changing:
- `featured-posts` / `email-estimate` — relative `fetch` from React Query, browser-side, cookies sent.
- `check-slug` — `fetchSlugCheck` uses plain `axios` rather than `@/lib/api`, so no `Authorization` header; `getPrivyToken` falls back to the `privy-token` cookie, so this still authenticates.

Happy to adjust if any of these are intended to be public.

`pnpm check-types` and `pnpm lint` pass.