### PR TITLE
fixed preview listing not rendering

### DIFF
--- a/src/features/sponsor-dashboard/components/ListingTable.tsx
+++ b/src/features/sponsor-dashboard/components/ListingTable.tsx
@@ -217,6 +217,10 @@ export const ListingTable = ({
                 listing?.type === 'grant'
                   ? `${getURL()}earn/grants/${listing.slug}`
                   : `${getURL()}earn/listing/${listing.slug}`;
+              const viewListingLink =
+                !listing.isPublished && listing.type !== 'grant'
+                  ? `${listingLink}?preview=1`
+                  : listingLink;
 
               const listingSubmissionLink =
                 listing.type === 'grant'
@@ -391,7 +395,7 @@ export const ListingTable = ({
                       <DropdownMenuContent align="end" className="max-w-60">
                         <DropdownMenuItem
                           className="cursor-pointer text-sm font-medium text-slate-500"
-                          onClick={() => window.open(listingLink, '_blank')}
+                          onClick={() => window.open(viewListingLink, '_blank')}
                         >
                           <ExternalLink className="mr-2 h-4 w-4" />
                           View {listingLabel}

--- a/src/pages/api/listings/details/[slug].ts
+++ b/src/pages/api/listings/details/[slug].ts
@@ -9,6 +9,7 @@ import { type PublicListingDetails } from '@/features/listings/types';
 
 export async function getListingDetailsBySlug(
   slug: string,
+  options: { includeUnpublished?: boolean } = {},
 ): Promise<PublicListingDetails | null> {
   if (!slug) {
     throw new Error('Missing required query parameters: slug');
@@ -18,7 +19,7 @@ export async function getListingDetailsBySlug(
     where: {
       slug,
       isActive: true,
-      isPublished: true,
+      ...(!options.includeUnpublished && { isPublished: true }),
       isArchived: false,
     },
     select: publicListingDetailsSelect,

--- a/src/pages/api/listings/details/[slug].ts
+++ b/src/pages/api/listings/details/[slug].ts
@@ -9,7 +9,10 @@ import { type PublicListingDetails } from '@/features/listings/types';
 
 export async function getListingDetailsBySlug(
   slug: string,
-  options: { includeUnpublished?: boolean } = {},
+  options: {
+    canViewAllUnpublished?: boolean;
+    unpublishedSponsorIds?: string[];
+  } = {},
 ): Promise<PublicListingDetails | null> {
   if (!slug) {
     throw new Error('Missing required query parameters: slug');
@@ -19,8 +22,19 @@ export async function getListingDetailsBySlug(
     where: {
       slug,
       isActive: true,
-      ...(!options.includeUnpublished && { isPublished: true }),
       isArchived: false,
+      ...(options.canViewAllUnpublished
+        ? {
+            OR: [{ isPublished: true }, { isPublished: false }],
+          }
+        : options.unpublishedSponsorIds?.length
+          ? {
+              OR: [
+                { isPublished: true },
+                { sponsorId: { in: options.unpublishedSponsorIds } },
+              ],
+            }
+          : { isPublished: true }),
     },
     select: publicListingDetailsSelect,
   });

--- a/src/pages/earn/listing/[slug]/index.tsx
+++ b/src/pages/earn/listing/[slug]/index.tsx
@@ -14,11 +14,13 @@ import { ListingPageLayout } from '@/layouts/Listing';
 import { getSubmissionCount } from '@/pages/api/listings/[listingId]/submission-count';
 import { getWinningSubmissionsByListingId } from '@/pages/api/listings/[listingId]/winners';
 import { getListingDetailsBySlug } from '@/pages/api/listings/details/[slug]';
+import { prisma } from '@/prisma';
 import {
   generateBreadcrumbListSchema,
   generateJobPostingSchema,
 } from '@/utils/json-ld';
 
+import { getPrivyToken } from '@/features/auth/utils/getPrivyToken';
 import { ListingPop } from '@/features/conversion-popups/components/ListingPop';
 import { DescriptionUI } from '@/features/listings/components/ListingPage/DescriptionUI';
 import { listingWinnersQuery } from '@/features/listings/queries/listing-winners';
@@ -102,8 +104,31 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const { preview, slug } = context.query;
   let listingData: PublicListingDetails | null;
   try {
+    let canViewAllUnpublished = false;
+    let unpublishedSponsorIds: string[] | undefined;
+    if (preview === '1') {
+      const privyDid = await getPrivyToken(context.req);
+      if (privyDid) {
+        const previewUser = await prisma.user.findUnique({
+          where: { privyDid },
+          select: {
+            isBlocked: true,
+            role: true,
+            UserSponsors: { select: { sponsorId: true } },
+          },
+        });
+        if (!previewUser?.isBlocked) {
+          canViewAllUnpublished = previewUser?.role === 'GOD';
+          unpublishedSponsorIds = previewUser?.UserSponsors.map(
+            ({ sponsorId }) => sponsorId,
+          );
+        }
+      }
+    }
+
     listingData = await getListingDetailsBySlug(String(slug), {
-      includeUnpublished: preview === '1',
+      canViewAllUnpublished,
+      unpublishedSponsorIds,
     });
   } catch (e) {
     console.error(e);

--- a/src/pages/earn/listing/[slug]/index.tsx
+++ b/src/pages/earn/listing/[slug]/index.tsx
@@ -99,10 +99,12 @@ function ListingDetails({
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { slug } = context.query;
+  const { preview, slug } = context.query;
   let listingData: PublicListingDetails | null;
   try {
-    listingData = await getListingDetailsBySlug(String(slug));
+    listingData = await getListingDetailsBySlug(String(slug), {
+      includeUnpublished: preview === '1',
+    });
   } catch (e) {
     console.error(e);
     listingData = null;


### PR DESCRIPTION
## What does this PR do?
- reintroduces the preview fetch in listing endpoint
- adds restriction to sponsor and their team mates for preview fetch

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preview access for unpublished listings when authorized.
  * GOD users and eligible sponsors can preview unpublished listings, while blocked users remain restricted.
  * Added preview links for unpublished listings in the sponsor dashboard.
  * Regular listing views continue to show only published, non-archived listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->