### PR TITLE
fix(agents): sanitize and validate slug parameter on listing details endpoint

### DIFF
--- a/src/pages/api/agents/listings/details/[slug].ts
+++ b/src/pages/api/agents/listings/details/[slug].ts
@@ -70,16 +70,23 @@ async function getAgentListingDetailsBySlug(slug: string): Promise<any> {
 
 async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
   const params = req.query;
-  const slug = params.slug as string;
+  const rawSlug = params.slug;
+  const slug =
+    typeof rawSlug === 'string'
+      ? rawSlug.trim()
+      : Array.isArray(rawSlug)
+        ? rawSlug[0]?.trim()
+        : '';
 
   logger.debug(`Request query: ${safeStringify(params)}`);
 
-  if (!slug) {
+  if (!slug || slug.length === 0) {
     logger.warn('Missing required query parameters: slug');
     return res.status(400).json({
       error: 'Missing required query parameters: slug',
     });
   }
+
 
   try {
     const result = await getAgentListingDetailsBySlug(slug);


### PR DESCRIPTION
### Summary of Changes
- Sanitizes and validates the \slug\ query parameter in \src/pages/api/agents/listings/details/[slug].ts\.
- Handles potential string arrays (\string[]\), trims whitespace, and rejects empty strings with HTTP 400 Bad Request (\Missing required query parameters: slug\).
- Prevents Prisma query errors and ensures consistent validation with \src/pages/api/agents/listings/live.ts\.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of listing detail requests when the listing identifier is missing, empty, or provided in an unexpected format.
  * Prevented invalid requests from triggering unnecessary listing detail lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->