### PR TITLE
fix(credits): stop pinning effectiveMonth to module-load time

### DIFF
--- a/src/features/credits/utils/allocateCredits.ts
+++ b/src/features/credits/utils/allocateCredits.ts
@@ -2,8 +2,8 @@ import { prisma } from '@/prisma';
 import { CreditEventType, SubmissionLabels } from '@/prisma/enums';
 import { dayjs } from '@/utils/dayjs';
 
-const currentMonth = dayjs.utc().startOf('month').toDate();
-const nextMonth = dayjs.utc().add(1, 'month').startOf('month').toDate();
+const currentMonth = () => dayjs.utc().startOf('month').toDate();
+const nextMonth = () => dayjs.utc().add(1, 'month').startOf('month').toDate();
 
 type PrismaLike = Pick<typeof prisma, 'creditLedger'>;
 
@@ -18,7 +18,7 @@ export async function consumeCredit(
         userId,
         submissionId,
         type: CreditEventType.SUBMISSION,
-        effectiveMonth: currentMonth,
+        effectiveMonth: currentMonth(),
         change: -1,
       },
     });
@@ -39,7 +39,7 @@ export async function addWinBonusCredit(userId: string, submissionId: string) {
         userId,
         submissionId,
         type: CreditEventType.WIN_BONUS,
-        effectiveMonth: nextMonth,
+        effectiveMonth: nextMonth(),
         change: 1,
       },
     });
@@ -62,7 +62,7 @@ export async function addGrantWinBonusCredit(
       userId,
       applicationId,
       type: CreditEventType.GRANT_WIN_BONUS,
-      effectiveMonth: nextMonth,
+      effectiveMonth: nextMonth(),
       change: 1,
     },
   });
@@ -84,7 +84,7 @@ export async function addSpamPenaltyCredit(submissionId: string) {
         userId: submission.userId,
         submissionId: submission.id,
         type: CreditEventType.SPAM_PENALTY,
-        effectiveMonth: nextMonth,
+        effectiveMonth: nextMonth(),
         change: -1,
       },
     });
@@ -106,7 +106,7 @@ export async function addSpamPenaltyGrant(
       userId,
       applicationId,
       type: CreditEventType.GRANT_SPAM_PENALTY,
-      effectiveMonth: nextMonth,
+      effectiveMonth: nextMonth(),
       change: -1,
     },
   });
@@ -122,7 +122,7 @@ export async function addCreditDispute(
       data: {
         userId,
         type: CreditEventType.SPAM_DISPUTE,
-        effectiveMonth: nextMonth,
+        effectiveMonth: nextMonth(),
         change: 0,
         submissionId: id,
         decision: 'Pending',
@@ -133,7 +133,7 @@ export async function addCreditDispute(
       data: {
         userId,
         type: CreditEventType.GRANT_SPAM_DISPUTE,
-        effectiveMonth: nextMonth,
+        effectiveMonth: nextMonth(),
         change: 0,
         applicationId: id,
         decision: 'Pending',
@@ -156,7 +156,7 @@ export async function refundCredits(listingId: string) {
             userId: submission.userId,
             submissionId: submission.id,
             type: CreditEventType.CREDIT_REFUND,
-            effectiveMonth: nextMonth,
+            effectiveMonth: nextMonth(),
             change: +1,
           },
         }),
@@ -190,7 +190,7 @@ export async function addReferralInviterWinBonus(
         userId: inviterUserId,
         submissionId,
         type: CreditEventType.REFERRAL_INVITEE_WIN_BONUS_INVITER,
-        effectiveMonth: nextMonth,
+        effectiveMonth: nextMonth(),
         change: 1,
       },
     });
@@ -263,7 +263,7 @@ export async function awardReferralFirstSubmissionBonusesForListing(
             userId,
             submissionId: earliest.id,
             type: CreditEventType.REFERRAL_FIRST_SUBMISSION_BONUS_INVITEE,
-            effectiveMonth: nextMonth,
+            effectiveMonth: nextMonth(),
             change: 1,
           },
         });
@@ -282,7 +282,7 @@ export async function awardReferralFirstSubmissionBonusesForListing(
             userId: inviterUserId,
             submissionId: earliest.id,
             type: CreditEventType.REFERRAL_FIRST_SUBMISSION_BONUS_INVITER,
-            effectiveMonth: nextMonth,
+            effectiveMonth: nextMonth(),
             change: 1,
           },
         });


### PR DESCRIPTION
### The bug

`src/features/credits/utils/allocateCredits.ts` computes the ledger month **once, at module load**:

```ts
const currentMonth = dayjs.utc().startOf('month').toDate();
const nextMonth = dayjs.utc().add(1, 'month').startOf('month').toDate();
```

Every `creditLedger` write in the file then reuses those two frozen `Date`s for the entire lifetime of the process. Next.js server instances stay warm for a long time, so any instance that survives a month boundary keeps stamping rows with the previous month.

### Why it matters

Every **reader** computes the month per call — `creditAggregate` uses `dayjs.utc().startOf('month')`, and `/api/user/credit/history` builds its month list from `dayjs().utc()`. So after the rollover, writers and readers disagree:

- `consumeCredit` writes `effectiveMonth = <last month>` with `change: -1`. `creditAggregate` only sums the current month, so the debit is invisible. `canUserSubmit` keeps returning `true` and **the submission cap stops being enforced**.
- `addWinBonusCredit`, `addGrantWinBonusCredit`, `addSpamPenaltyCredit`, `addSpamPenaltyGrant`, `refundCredits`, `addCreditDispute` and the referral bonuses all land one month earlier than intended — into a month that has already expired — so those credits and penalties are effectively voided.

It resolves itself on the next cold start, which makes it intermittent and easy to misread as a data problem.

### The fix

Turn both into functions so the month is resolved at call time, matching what every reader already does. All 11 call sites updated; no other behaviour changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credit allocations now use the correct effective month when ledger entries are created, improving accuracy across month boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
