### PR TITLE
fix(grants): pick the previous tranche from the non-rejected list

### DIFF
--- a/src/features/grants/utils/createTranche.ts
+++ b/src/features/grants/utils/createTranche.ts
@@ -266,9 +266,10 @@ export async function createTranche({
   const isAgenticEngineering = isAgenticEngineeringGrant(application.grant);
   const requiresEventProof = isST && !isFirstTranche;
 
-  const existingTranches = application.GrantTranche.filter(
+  const activeTranches = application.GrantTranche.filter(
     (tranche) => tranche.status !== 'Rejected',
-  ).length;
+  );
+  const existingTranches = activeTranches.length;
   const requiresAgenticFinalProof =
     isAgenticEngineering && !isFirstTranche && existingTranches === 1;
   const maxTranches = 4;
@@ -304,12 +305,8 @@ export async function createTranche({
   }
 
   if (existingTranches > 0) {
-    const previousTranche = application.GrantTranche[existingTranches - 1];
-    if (
-      previousTranche &&
-      previousTranche.status !== 'Paid' &&
-      previousTranche.status !== 'Rejected'
-    ) {
+    const previousTranche = activeTranches[existingTranches - 1];
+    if (previousTranche && previousTranche.status !== 'Paid') {
       const errorMessage = `Previous tranche (ID: ${previousTranche.id}) must be paid before requesting a new tranche for application ${applicationId}`;
       logger.error(errorMessage);
       throw new Error(errorMessage);


### PR DESCRIPTION
### The bug

In `src/features/grants/utils/createTranche.ts`, `existingTranches` counts only tranches whose status is **not** `Rejected`:

```ts
const existingTranches = application.GrantTranche.filter(
  (tranche) => tranche.status !== 'Rejected',
).length;
```

but that count is then used as an index into the **unfiltered** array:

```ts
const previousTranche = application.GrantTranche[existingTranches - 1];
```

The two lists only line up when there are no rejected tranches, or when the rejected ones happen to sit at the end.

### Why it matters

The guard right below it is the thing that stops a grantee from stacking tranche requests while an earlier one is still unpaid. Concrete case — `GrantTranche` ordered by `createdAt asc`:

| index | tranche | status |
|---|---|---|
| 0 | T1 | Paid |
| 1 | T2 | Rejected |
| 2 | T3 | Pending |

- `existingTranches` = 2 (T1, T3)
- `previousTranche` = `GrantTranche[1]` = **T2**, which is `Rejected`

The guard only throws when the tranche is neither `Paid` nor `Rejected`, so T2 sails through and a new tranche is created **while T3 is still pending** — exactly what the check exists to prevent. `trancheNumber: existingTranches + 1` is derived from the same count, so the new row also collides with T3's number.

### The fix

Keep the filtered array and index into that. Since it can no longer contain a `Rejected` tranche, the status check collapses to `!== 'Paid'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rejected tranches no longer block the creation or ordering of subsequent tranches.
  * Previous-tranche validation now considers only active tranches and requires the latest active tranche to be paid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
