### PR TITLE
fix(listings): don't collapse the feed to Global for non-chapter locations

### DIFF
--- a/src/utils/chapterRegion.ts
+++ b/src/utils/chapterRegion.ts
@@ -254,9 +254,11 @@ export async function getRegionsForUserLocationUsingChapters(
 
   const chapterRegions = await getChapterRegions();
   const chapter = await findChapterByLocation(userLocation);
-  if (!chapter) return ['Global'];
 
-  const regions: string[] = ['Global', userLocation, chapter.region];
+  const regions: string[] = ['Global', userLocation];
+  if (chapter) {
+    regions.push(chapter.region);
+  }
 
   const multiCountryRegionsFromCountries = countries
     .filter(


### PR DESCRIPTION
### The bug

`getRegionsForUserLocationUsingChapters` in `src/utils/chapterRegion.ts` gives up as soon as the user's location has no Superteam chapter:

```ts
const chapter = await findChapterByLocation(userLocation);
if (!chapter) return ['Global'];

const regions: string[] = ['Global', userLocation, chapter.region];
```

`buildListingQuery` feeds the result straight into the Prisma filter for the `home` and `all` contexts:

```ts
if (user?.isTalentFilled && (context === 'all' || context === 'home')) {
  where.region = { in: await getUserRegionFilter(user.location) };
}
```

so for those users the region filter degrades to *Global only*.

### Why it matters

The early return throws away `userLocation` itself **and** skips the two multi-country lookups below it, which never needed a chapter — they key off `userLocation` directly. Two kinds of listing vanish from the feed:

- listings whose region is the user's own country;
- listings scoped to a multi-country region containing that country — e.g. a `European Union` listing for a user in Sweden, or a `North America` listing for a user in Canada. Both regions are defined statically in `src/constants/country.ts` and don't depend on any chapter existing.

These are listings the user is **allowed** to submit to: `userRegionEligibilty` resolves them via `countries[].regions` and returns `true`. So the feed hides work that `validateSubmissionRequest` would happily accept — a silent discovery gap for every talent user outside a chapter country.

### The fix

The chapter lookup is only needed to contribute `chapter.region`. Push it conditionally instead of returning early; the rest of the function already works without a chapter.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
