### PR TITLE
fix(lock): release the Redis lock atomically

### DIFF
--- a/src/lib/with-redis-lock.ts
+++ b/src/lib/with-redis-lock.ts
@@ -6,6 +6,14 @@ interface RedisLockOptions {
   readonly ttlSeconds?: number;
 }
 
+// Compare-and-delete, so a holder can only ever release its own lock.
+const RELEASE_LOCK_SCRIPT = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+end
+return 0
+`;
+
 export class LockNotAcquiredError extends Error {
   public constructor(key: string) {
     super(`Failed to acquire Redis lock for key="${key}"`);
@@ -30,10 +38,7 @@ export async function withRedisLock<TResult>(
     return await callback();
   } finally {
     try {
-      const currentToken = await redis.get<string>(key);
-      if (currentToken === token) {
-        await redis.del(key);
-      }
+      await redis.eval(RELEASE_LOCK_SCRIPT, [key], [token]);
     } catch (releaseError) {
       console.error(
         `Failed to release Redis lock for key="${key}":`,


### PR DESCRIPTION
### The bug

`withRedisLock` releases with a `GET` followed by a separate `DEL`:

```ts
const currentToken = await redis.get<string>(key);
if (currentToken === token) {
  await redis.del(key);
}
```

The token comparison narrows the race but doesn't close it. If the lock's TTL expires **between** the `GET` and the `DEL`, another request can acquire the key in that gap — and this call then deletes a lock it no longer owns.

### Why it matters

Not theoretical for the current callers:

- `locks:announce-winners:${id}` is taken with `ttlSeconds: 300` on a route that itself declares `export const maxDuration = 300`. A slow announcement (winner updates, credit writes, referral bonuses) can run right up to expiry.
- `locks:create-tranche:${applicationId}` uses the same 300s TTL.

Losing mutual exclusion there means two concurrent winner announcements, or two concurrent tranche creations, for the same id — which is the whole reason these routes are locked.

### The fix

Replace `GET` + `DEL` with the standard compare-and-delete Lua script, which Redis executes as a single atomic unit. `@upstash/redis` exposes `eval(script, keys, args)` for this.

```lua
if redis.call("get", KEYS[1]) == ARGV[1] then
  return redis.call("del", KEYS[1])
end
return 0
```

Error handling around the release is unchanged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
