### PR TITLE
fix(wallet): repair the withdraw amount key filter (paste is currently blocked)

### DIFF
--- a/src/features/wallet/components/withdraw/TokenAmountInput.tsx
+++ b/src/features/wallet/components/withdraw/TokenAmountInput.tsx
@@ -22,6 +22,20 @@ interface TokenAmountInputProps {
   className?: string;
 }
 
+const EDITING_KEYS = [
+  'Backspace',
+  'Delete',
+  'Tab',
+  'Enter',
+  'Escape',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowDown',
+  'Home',
+  'End',
+];
+
 export const TokenAmountInput = ({
   tokens,
   selectedToken,
@@ -55,6 +69,24 @@ export const TokenAmountInput = ({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       handleMaxClick();
+    }
+  };
+
+  const handleAmountKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // let the browser handle shortcuts (copy, paste, select all, undo)
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+    if (EDITING_KEYS.includes(e.key)) return;
+
+    if (e.key === '.') {
+      if (e.currentTarget.value.includes('.')) {
+        e.preventDefault();
+      }
+      return;
+    }
+
+    if (!/^[0-9]$/.test(e.key)) {
+      e.preventDefault();
     }
   };
 
@@ -121,16 +153,7 @@ export const TokenAmountInput = ({
           placeholder="0.00"
           inputMode="decimal"
           min="0"
-          onKeyDown={(e) => {
-            if (
-              !/[0-9]|\.|\.|\Backspace|Tab|\Delete|ArrowLeft|ArrowRight/.test(
-                e.key,
-              ) ||
-              (e.key === '.' && e.currentTarget.value.includes('.'))
-            ) {
-              e.preventDefault();
-            }
-          }}
+          onKeyDown={handleAmountKeyDown}
         />
       </div>
     </>


### PR DESCRIPTION
### The bug

`TokenAmountInput` filters keystrokes on the withdraw amount field with:

```js
!/[0-9]|\.|\.|\Backspace|Tab|\Delete|ArrowLeft|ArrowRight/.test(e.key)
```

This doesn't mean what it reads as. In a regex literal `\B` is the **non-word-boundary assertion** and `\D` is **"any non-digit"**, so the two alternatives compile to `\B` + `ackspace` and `\D` + `elete`. They match those key names by accident. The pattern is also unanchored, so it tests for a substring of `e.key` rather than the whole key, and `\.` is listed twice.

### Why it matters

The real problem is the fallthrough: anything not matched gets `preventDefault()`, and modifier combos are never exempted. `Ctrl`/`Cmd` + `V`, `A`, `C`, `Z` all report `e.key` as a plain letter, so they're all swallowed.

In the withdraw flow that means **you cannot paste an amount**, select it, copy it, or undo. `Home`, `End` and the vertical arrows are blocked too. Users copying a figure from their balance or another app have to retype it digit by digit.

### The fix

An explicit handler instead of the regex:

- return early when `ctrlKey` / `metaKey` / `altKey` is held, so the browser keeps its shortcuts;
- return early for editing and navigation keys (listed by name, no accidental escapes);
- allow a single `.`;
- otherwise require the key to be exactly one digit (`/^[0-9]$/`, anchored).

Pasted values stay safe — `onChange` already runs everything through `clampToDecimals`, and `withdrawFormSchema` validates the amount on submit.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
