### PR TITLE
fix(agents): safely parse date-only deadline and default to current date

### DIFF
--- a/src/pages/api/agents/listings/live.ts
+++ b/src/pages/api/agents/listings/live.ts
@@ -23,8 +23,17 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
   if (!takeResult.ok) {
     return res.status(400).json({ error: takeResult.error });
   }
-  const take = takeResult.value;
-  const deadline = params.deadline as string;
+  let parsedDeadline: Date = new Date();
+  if (params.deadline) {
+    if (typeof params.deadline !== 'string') {
+      return res.status(400).json({ error: 'Invalid deadline parameter format' });
+    }
+    const d = new Date(params.deadline);
+    if (Number.isNaN(d.getTime())) {
+      return res.status(400).json({ error: 'Invalid deadline date format' });
+    }
+    parsedDeadline = d;
+  }
   const exclusiveSponsorId = params.exclusiveSponsorId as string | undefined;
   let excludeIds = params['excludeIds[]'];
   if (typeof excludeIds === 'string') {
@@ -41,7 +50,8 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
       isPrivate: false,
       isArchived: false,
       status: 'OPEN',
-      deadline: { gte: deadline },
+      deadline: { gte: parsedDeadline },
+
       type: type || { in: ['bounty', 'project', 'hackathon'] },
       agentAccess: { in: ['AGENT_ALLOWED', 'AGENT_ONLY'] },
       sponsor: {


### PR DESCRIPTION
### Summary of Changes
- Parses and validates the \deadline\ query parameter in \src/pages/api/agents/listings/live.ts\, accepting both ISO timestamps and date-only formats (e.g. \2026-12-31\).
- Defaults \deadline\ to \
ew Date()\ when omitted, ensuring expired and winner-announced listings are not returned in the live agent discovery feed.
- Sanitizes invalid date strings by returning HTTP 400 Bad Request (\Invalid deadline date format\) without exposing raw Prisma exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for optional deadline filters.
  * Invalid or incorrectly formatted deadline values now return a clear error instead of producing unreliable results.
  * Valid deadline filters are applied consistently when retrieving live listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->