### PR TITLE
fix(submission): sanitize listingId query parameter and handle array inputs

### DIFF
--- a/src/pages/api/submission/get.ts
+++ b/src/pages/api/submission/get.ts
@@ -8,20 +8,24 @@ import { withAuth } from '@/features/auth/utils/withAuth';
 
 async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
   const userId = req.userId;
-  const id = req.query.id as string;
+  const rawId = req.query.id;
+  const id = Array.isArray(rawId) ? rawId[0] : rawId;
 
-  if (!id) {
+  if (!id || typeof id !== 'string' || id.trim() === '') {
     return res.status(400).json({
       message: 'Listing ID is required in the query parameters.',
     });
   }
 
+  const cleanId = id.trim();
+
   try {
     const result = await prisma.submission.findFirst({
       where: {
         userId,
-        listingId: id,
+        listingId: cleanId,
       },
+
       omit: {
         ai: true,
         label: true,


### PR DESCRIPTION
### Summary of Changes
- Sanitizes the \id\ query parameter in \src/pages/api/submission/get.ts\, handling \string[]\ arrays and trimming string whitespace.
- Rejects missing, non-string, or empty strings with HTTP 400 Bad Request (\Listing ID is required in the query parameters.\).
- Prevents Prisma runtime exceptions caused by un-sanitized array query parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submission lookup validation for listing IDs.
  * Handles array-valued query parameters safely.
  * Trims surrounding whitespace and rejects empty IDs for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->