### PR TITLE
fix(likes): prevent TOCTOU race condition in updateLike with prisma transaction (#1435)

### DIFF
--- a/src/services/likeService.ts
+++ b/src/services/likeService.ts
@@ -5,96 +5,102 @@ export async function updateLike(
   itemId: string,
   userId: string,
 ) {
-  let result;
+  return await prisma.$transaction(async (tx) => {
+    let result: any;
 
-  if (model === 'submission') {
-    result = await prisma.submission.findFirst({
-      where: {
-        id: itemId,
-      },
-    });
-  } else if (model === 'poW') {
-    result = await prisma.poW.findFirst({
-      where: {
-        id: itemId,
-      },
-    });
-  } else if (model === 'grantApplication') {
-    result = await prisma.grantApplication.findFirst({
-      where: {
-        id: itemId,
-      },
-    });
-  } else {
-    throw new Error('Invalid model provided');
-  }
+    if (model === 'submission') {
+      result = await tx.submission.findUnique({
+        where: {
+          id: itemId,
+        },
+      });
+    } else if (model === 'poW') {
+      result = await tx.poW.findUnique({
+        where: {
+          id: itemId,
+        },
+      });
+    } else if (model === 'grantApplication') {
+      result = await tx.grantApplication.findUnique({
+        where: {
+          id: itemId,
+        },
+      });
+    } else {
+      throw new Error('Invalid model provided');
+    }
 
-  let newLikes = [];
-  const resLikes = result?.like as {
-    id: string;
-    date: number;
-  }[];
+    if (!result) {
+      throw new Error(`${model} with id ${itemId} not found`);
+    }
 
-  if (resLikes?.length > 0) {
-    const like = resLikes.find((e) => e?.id === userId);
-    if (like) {
-      newLikes = resLikes.filter((e) => e.id !== userId);
+    let newLikes = [];
+    const resLikes = (result.like as {
+      id: string;
+      date: number;
+    }[]) || [];
+
+    if (resLikes.length > 0) {
+      const like = resLikes.find((e) => e?.id === userId);
+      if (like) {
+        newLikes = resLikes.filter((e) => e.id !== userId);
+      } else {
+        newLikes = [
+          ...resLikes,
+          {
+            id: userId,
+            date: Date.now(),
+          },
+        ];
+      }
     } else {
       newLikes = [
-        ...resLikes,
         {
           id: userId,
           date: Date.now(),
         },
       ];
     }
-  } else {
-    newLikes = [
-      {
-        id: userId,
-        date: Date.now(),
-      },
-    ];
-  }
 
-  const likeCount = newLikes.length;
+    const likeCount = newLikes.length;
 
-  let updateLike;
+    let updateLike;
 
-  if (model === 'submission') {
-    updateLike = await prisma.submission.update({
-      where: {
-        id: itemId,
-      },
-      data: {
-        like: newLikes,
-        likeCount,
-      },
-    });
-  } else if (model === 'poW') {
-    updateLike = await prisma.poW.update({
-      where: {
-        id: itemId,
-      },
-      data: {
-        like: newLikes,
-        likeCount,
-      },
-    });
-  } else if (model === 'grantApplication') {
-    updateLike = await prisma.grantApplication.update({
-      where: {
-        id: itemId,
-      },
-      data: {
-        like: newLikes,
-        likeCount,
-      },
-    });
-  }
+    if (model === 'submission') {
+      updateLike = await tx.submission.update({
+        where: {
+          id: itemId,
+        },
+        data: {
+          like: newLikes,
+          likeCount,
+        },
+      });
+    } else if (model === 'poW') {
+      updateLike = await tx.poW.update({
+        where: {
+          id: itemId,
+        },
+        data: {
+          like: newLikes,
+          likeCount,
+        },
+      });
+    } else if (model === 'grantApplication') {
+      updateLike = await tx.grantApplication.update({
+        where: {
+          id: itemId,
+        },
+        data: {
+          like: newLikes,
+          likeCount,
+        },
+      });
+    }
 
-  return {
-    likesIncremented: likeCount > (result?.likeCount || 0),
-    updatedData: updateLike,
-  };
+    return {
+      likesIncremented: likeCount > (result.likeCount || 0),
+      updatedData: updateLike,
+    };
+  });
 }


### PR DESCRIPTION
Closes #1435

### Summary of Changes
- Wraps the read-modify-write cycle in \src/services/likeService.ts\ inside \prisma.\\ using the transactional client \	x\ and \indUnique\ by ID.
- Prevents concurrent likes from silently overwriting each other and dropping user reactions.
- Returns accurate \likesIncremented\ state based on atomic transaction updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when liking or unliking content.
  * Like counts now update atomically, preventing inconsistent results.
  * Added clearer handling when the selected content cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->