### PR TITLE
fix(agents): default live listings deadline to now and parse deadline queries (#1440)

### DIFF
--- a/src/pages/api/agents/listings/live.ts
+++ b/src/pages/api/agents/listings/live.ts
@@ -24,7 +24,14 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
     return res.status(400).json({ error: takeResult.error });
   }
   const take = takeResult.value;
-  const deadline = params.deadline as string;
+  let parsedDeadline: string = new Date().toISOString();
+  if (params.deadline && typeof params.deadline === 'string') {
+    const d = new Date(params.deadline);
+    if (!isNaN(d.getTime())) {
+      parsedDeadline = d.toISOString();
+    }
+  }
+
   const exclusiveSponsorId = params.exclusiveSponsorId as string | undefined;
   let excludeIds = params['excludeIds[]'];
   if (typeof excludeIds === 'string') {
@@ -41,7 +48,7 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
       isPrivate: false,
       isArchived: false,
       status: 'OPEN',
-      deadline: { gte: deadline },
+      deadline: { gte: parsedDeadline },
       type: type || { in: ['bounty', 'project', 'hackathon'] },
       agentAccess: { in: ['AGENT_ALLOWED', 'AGENT_ONLY'] },
       sponsor: {


### PR DESCRIPTION
Closes #1440

### Summary of Changes
- Defaults \deadline\ in \src/pages/api/agents/listings/live.ts\ to the current timestamp (\
ew Date().toISOString()\) if no deadline is passed, preventing expired listings from being returned in discovery.
- Safely parses string deadlines into valid ISO dates when passed via query parameters.
- Guarantees AI agents and solvers only retrieve active, non-expired listings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved listing results by consistently applying a valid deadline filter.
  * Invalid or unsupported deadline values now safely fall back to the current time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->