### PR TITLE
fixed preview og image

### DIFF
--- a/src/app/api/dynamic-og/listing/route.tsx
+++ b/src/app/api/dynamic-og/listing/route.tsx
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import { ASSET_URL } from '@/constants/ASSET_URL';
 import logger from '@/lib/logger';
+import { prisma } from '@/prisma';
 import { getTokenIcon } from '@/server/tokenList';
 import { convertToJpegUrl } from '@/utils/cloudinary';
 import { formatNumber, formatString, loadGoogleFont } from '@/utils/ogHelpers';
@@ -57,8 +58,12 @@ const loadOgFont = async (font: string, text: string) => {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
+  const isDraftPreview = searchParams.get('preview') === '1';
+  const slug = searchParams.get('slug');
 
   const requestContext = {
+    slug,
+    isDraftPreview,
     title: searchParams.get('title'),
     token: searchParams.get('token'),
     sponsor: searchParams.get('sponsor'),
@@ -69,8 +74,53 @@ export async function GET(request: Request) {
   try {
     const bgColors = ['#FFFBEB', '#FAFAF9', '#ECFDF5', '#EFF6FF', '#EEF2FF'];
 
+    const previewListing =
+      isDraftPreview && slug
+        ? await prisma.bounties.findFirst({
+            where: {
+              slug,
+              isPublished: false,
+              isActive: true,
+              isArchived: false,
+            },
+            select: {
+              title: true,
+              rewardAmount: true,
+              token: true,
+              type: true,
+              compensationType: true,
+              minRewardAsk: true,
+              maxRewardAsk: true,
+              sponsor: {
+                select: {
+                  name: true,
+                  logo: true,
+                  isVerified: true,
+                },
+              },
+            },
+          })
+        : null;
+
+    const previewParams: Record<string, string | null | undefined> = {
+      title: previewListing?.title,
+      reward: previewListing?.rewardAmount?.toString(),
+      token: previewListing?.token,
+      sponsor: previewListing?.sponsor?.name,
+      logo: previewListing?.sponsor?.logo,
+      type: previewListing?.type,
+      compensationType: previewListing?.compensationType,
+      minRewardAsk: previewListing?.minRewardAsk?.toString(),
+      maxRewardAsk: previewListing?.maxRewardAsk?.toString(),
+      isSponsorVerified: previewListing?.sponsor?.isVerified?.toString(),
+    };
+
     const getParam = (name: any, processFn = (x: any) => x) =>
-      searchParams.has(name) ? processFn(searchParams.get(name)) : null;
+      previewParams[name] != null
+        ? processFn(previewParams[name])
+        : searchParams.has(name)
+          ? processFn(searchParams.get(name))
+          : null;
 
     const title = getParam('title', (x) =>
       formatString(safeDecodeURIComponent(x), 100),
@@ -359,7 +409,9 @@ export async function GET(request: Request) {
 
     response.headers.set(
       'Cache-Control',
-      'public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000',
+      isDraftPreview
+        ? 'public, max-age=60, s-maxage=300'
+        : 'public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000',
     );
 
     return response;

--- a/src/layouts/Listing.tsx
+++ b/src/layouts/Listing.tsx
@@ -39,6 +39,7 @@ export function ListingPageLayout({
   maxW = '7xl',
   isTemplate = false,
 }: ListingPageProps) {
+  const router = useRouter();
   const [, setBountySnackbar] = useAtom(bountySnackbarAtom);
   const { user } = useUser();
 
@@ -76,6 +77,13 @@ export function ListingPageLayout({
 
   const ogImage = new URL(`${getURL()}api/dynamic-og/listing/`);
 
+  const previewSlug =
+    typeof router.query.slug === 'string' ? router.query.slug : undefined;
+  if (router.query.preview === '1' && previewSlug) {
+    ogImage.searchParams.set('preview', '1');
+    ogImage.searchParams.set('slug', previewSlug);
+  }
+
   ogImage.searchParams.set('title', initialListing?.title || '');
   ogImage.searchParams.set(
     'reward',
@@ -102,7 +110,6 @@ export function ListingPageLayout({
     initialListing?.sponsor?.isVerified?.toString() || 'false',
   );
 
-  const router = useRouter();
   const isSubmissionPage = router.pathname.endsWith('/submission');
   const canonicalUrl = initialListing?.slug
     ? normalizeCanonicalUrl(`${getURL()}earn/listing/${initialListing.slug}/`)

--- a/src/pages/earn/listing/[slug]/index.tsx
+++ b/src/pages/earn/listing/[slug]/index.tsx
@@ -37,11 +37,13 @@ const ListingWinners = dynamic(
 
 interface ListingDetailsProps {
   listing: PublicListingDetails | null;
+  isPreview: boolean;
   dehydratedState: DehydratedState;
 }
 
 function ListingDetails({
   listing: initialListing,
+  isPreview,
   dehydratedState,
 }: ListingDetailsProps) {
   const jobPostingSchema = initialListing
@@ -62,7 +64,7 @@ function ListingDetails({
   return (
     <>
       <HydrationBoundary state={dehydratedState}>
-        {initialListing?.isPrivate && (
+        {(initialListing?.isPrivate || isPreview) && (
           <Head>
             <meta name="robots" content="noindex, nofollow" />
             <meta name="googlebot" content="noindex, nofollow" />
@@ -103,11 +105,12 @@ function ListingDetails({
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { preview, slug } = context.query;
   const { res } = context;
+  const isPreview = preview === '1';
   let listingData: PublicListingDetails | null;
   try {
     let canViewAllUnpublished = false;
     let unpublishedSponsorIds: string[] | undefined;
-    if (preview === '1') {
+    if (isPreview) {
       const privyDid = await getPrivyToken(context.req);
       if (privyDid) {
         const previewUser = await prisma.user.findUnique({
@@ -154,11 +157,16 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     }
 
     await Promise.all(prefetchPromises);
+  }
+  if (isPreview) {
+    res.setHeader('Cache-Control', 'private, no-store');
+  } else if (listingData?.id) {
     res.setHeader('Cache-Control', 's-maxage=60, stale-while-revalidate=600');
   }
   return {
     props: {
       listing: listingData,
+      isPreview,
       dehydratedState: dehydrate(queryClient),
     },
   };


### PR DESCRIPTION
## What does this PR do?
- allows preview listings to generate og images for preview urls only

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draft preview support for listing pages and Open Graph images.
  * Preview mode loads eligible unpublished listings using their database data.
  * Preview pages are excluded from search indexing and use private, non-cached responses.
  * Published listings retain existing caching and indexing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->