### PR TITLE
Resticted select for public templates endpoint

### DIFF
--- a/src/app/api/sponsor-dashboard/templates/[slug]/route.ts
+++ b/src/app/api/sponsor-dashboard/templates/[slug]/route.ts
@@ -2,8 +2,59 @@ import { NextResponse } from 'next/server';
 
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
+import { type BountiesTemplatesSelect } from '@/prisma/models/BountiesTemplates';
 import { dayjs } from '@/utils/dayjs';
 import { safeStringify } from '@/utils/safeStringify';
+
+export const publicTemplateDetailsSelect = {
+  id: true,
+  title: true,
+  deadline: true,
+  slug: true,
+  description: true,
+  skills: true,
+  type: true,
+  requirements: true,
+  region: true,
+  status: true,
+  token: true,
+  references: true,
+  referredBy: true,
+  publishedAt: true,
+  compensationType: true,
+  maxRewardAsk: true,
+  minRewardAsk: true,
+  language: true,
+  rewardAmount: true,
+  rewards: true,
+  maxBonusSpots: true,
+  usdValue: true,
+  sponsorId: true,
+  pocId: true,
+  pocSocials: true,
+  source: true,
+  isPublished: true,
+  sponsor: {
+    select: {
+      name: true,
+      logo: true,
+      slug: true,
+      url: true,
+      entityName: true,
+      isVerified: true,
+      isCaution: true,
+    },
+  },
+  poc: {
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      username: true,
+      photo: true,
+    },
+  },
+} satisfies BountiesTemplatesSelect;
 
 export async function GET(
   _: Request,
@@ -20,10 +71,7 @@ export async function GET(
         slug,
         isActive: true,
       },
-      include: {
-        poc: true,
-        sponsor: true,
-      },
+      select: publicTemplateDetailsSelect,
     });
 
     if (!result) {
@@ -46,10 +94,9 @@ export async function GET(
     );
     return NextResponse.json(
       {
-        error: error.message,
-        message: `Error occurred while fetching bounty template with slug=${slug}.`,
+        message: 'Error occurred while fetching bounty template.',
       },
-      { status: 400 },
+      { status: 500 },
     );
   }
 }


### PR DESCRIPTION
## What does this PR do?
- Adds a defined select to prisma query to avoid sharing all of information in response

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Template details now return only the relevant public template, sponsor, and point-of-contact information.
  * Error responses are standardized with a generic message and HTTP 500 status, providing more consistent behavior and avoiding sensitive diagnostic details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->