### PR TITLE
Restricted several sponsor endpoints responses

### DIFF
--- a/src/app/api/sponsor-dashboard/listing/[id]/scout/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/[id]/scout/route.ts
@@ -8,6 +8,7 @@ import { Decimal } from '@/prisma/internal/prismaNamespace';
 import { safeStringify } from '@/utils/safeStringify';
 
 import { validateSession } from '@/features/auth/utils/getSponsorSession';
+import { scoutUserSelect } from '@/features/sponsor-dashboard/constants/scouts';
 
 function flattenSubSkills(skillsArray: any[]): string[] {
   const flattenedSubSkills: string[] = [];
@@ -115,8 +116,18 @@ export async function GET(
       orderBy: {
         score: 'desc',
       },
-      include: {
-        user: true,
+      select: {
+        id: true,
+        userId: true,
+        listingId: true,
+        dollarsEarned: true,
+        score: true,
+        invited: true,
+        skills: true,
+        createdAt: true,
+        user: {
+          select: scoutUserSelect,
+        },
       },
     });
 
@@ -519,15 +530,17 @@ END)
       orderBy: {
         score: 'desc',
       },
-      include: {
+      select: {
+        id: true,
+        userId: true,
+        listingId: true,
+        dollarsEarned: true,
+        score: true,
+        invited: true,
+        skills: true,
+        createdAt: true,
         user: {
-          select: {
-            stRecommended: true,
-            firstName: true,
-            lastName: true,
-            username: true,
-            photo: true,
-          },
+          select: scoutUserSelect,
         },
       },
     });

--- a/src/features/grants/components/GrantModal.tsx
+++ b/src/features/grants/components/GrantModal.tsx
@@ -4,9 +4,9 @@ import { useRef } from 'react';
 
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { type GrantApplicationModel } from '@/prisma/models/GrantApplication';
 
 import { applicationStateAtom } from '../atoms/applicationStateAtom';
+import { type UserApplicationResponse } from '../constants/userApplication';
 import { type Grant } from '../types';
 import { ApplicationModal } from './Modals/ApplicationModal';
 import { KYCModal } from './Modals/KYCModal';
@@ -16,7 +16,7 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   grant: Grant;
-  editableGrantApplication?: GrantApplicationModel;
+  editableGrantApplication?: UserApplicationResponse;
   applicationId?: string;
   tranches?: number;
 }

--- a/src/features/grants/components/Modals/ApplicationModal.tsx
+++ b/src/features/grants/components/Modals/ApplicationModal.tsx
@@ -31,7 +31,6 @@ import {
 } from '@/components/ui/sheet';
 import { useDisclosure } from '@/hooks/use-disclosure';
 import { api } from '@/lib/api';
-import { type GrantApplicationModel } from '@/prisma/models/GrantApplication';
 import { useUser } from '@/store/user';
 import { cn } from '@/utils/cn';
 import { dayjs } from '@/utils/dayjs';
@@ -48,6 +47,7 @@ import {
   isHandleVerified,
 } from '@/features/social/utils/x-verification';
 
+import { type UserApplicationResponse } from '../../constants/userApplication';
 import { userApplicationQuery } from '../../queries/user-application';
 import { type Grant, type GrantQuestion } from '../../types';
 import {
@@ -78,7 +78,7 @@ type FormData = z.infer<ReturnType<typeof grantApplicationSchema>>;
 
 interface Props {
   grant: Grant;
-  grantApplication: GrantApplicationModel | undefined;
+  grantApplication: UserApplicationResponse | undefined;
   modalRef: React.RefObject<HTMLDivElement | null>;
   onClose: () => void;
 }

--- a/src/features/grants/constants/userApplication.ts
+++ b/src/features/grants/constants/userApplication.ts
@@ -1,0 +1,56 @@
+import {
+  type GrantApplicationGetPayload,
+  type GrantApplicationSelect,
+} from '@/prisma/models/GrantApplication';
+
+export const userApplicationSelect = {
+  id: true,
+  applicationStatus: true,
+  projectTitle: true,
+  projectOneLiner: true,
+  projectDetails: true,
+  projectTimeline: true,
+  proofOfWork: true,
+  walletAddress: true,
+  twitter: true,
+  github: true,
+  milestones: true,
+  kpi: true,
+  answers: true,
+  ask: true,
+  approvedAmount: true,
+  decidedAt: true,
+  isCooldownSkipped: true,
+  totalTranches: true,
+  lumaLink: true,
+  expenseBreakdown: true,
+  GrantTranche: {
+    orderBy: { createdAt: 'asc' as const },
+    select: {
+      status: true,
+      trancheNumber: true,
+      ask: true,
+      approvedAmount: true,
+      decidedAt: true,
+      walletAddress: true,
+    },
+  },
+  user: {
+    select: {
+      isKYCVerified: true,
+      kycVerifiedAt: true,
+    },
+  },
+} satisfies GrantApplicationSelect;
+
+type JsonResponse<T> = T extends Date
+  ? string
+  : T extends readonly (infer Item)[]
+    ? JsonResponse<Item>[]
+    : T extends object
+      ? { [Key in keyof T]: JsonResponse<T[Key]> }
+      : T;
+
+export type UserApplicationResponse = JsonResponse<
+  GrantApplicationGetPayload<{ select: typeof userApplicationSelect }>
+>;

--- a/src/features/grants/queries/user-application.ts
+++ b/src/features/grants/queries/user-application.ts
@@ -1,14 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';
-import { type GrantApplicationModel } from '@/prisma/models/GrantApplication';
-import { type GrantTrancheModel } from '@/prisma/models/GrantTranche';
-import { type UserModel } from '@/prisma/models/User';
 
-export interface GrantApplicationWithTranchesAndUser extends GrantApplicationModel {
-  GrantTranche: GrantTrancheModel[];
-  user: UserModel;
-}
+import { type UserApplicationResponse } from '../constants/userApplication';
+
+export type GrantApplicationWithTranchesAndUser = UserApplicationResponse;
 
 const fetchUserApplication = async (grantId: string) => {
   const response = await api.get<GrantApplicationWithTranchesAndUser>(

--- a/src/features/sponsor-dashboard/constants/grantApplicationMutation.ts
+++ b/src/features/sponsor-dashboard/constants/grantApplicationMutation.ts
@@ -1,0 +1,16 @@
+import {
+  type GrantApplicationGetPayload,
+  type GrantApplicationSelect,
+} from '@/prisma/models/GrantApplication';
+
+export const grantApplicationMutationSelect = {
+  id: true,
+  applicationStatus: true,
+  totalPaid: true,
+  totalTranches: true,
+  paymentDetails: true,
+} satisfies GrantApplicationSelect;
+
+export type GrantApplicationMutationResponse = GrantApplicationGetPayload<{
+  select: typeof grantApplicationMutationSelect;
+}>;

--- a/src/features/sponsor-dashboard/constants/scouts.ts
+++ b/src/features/sponsor-dashboard/constants/scouts.ts
@@ -1,0 +1,13 @@
+import { type UserGetPayload, type UserSelect } from '@/prisma/models/User';
+
+export const scoutUserSelect = {
+  stRecommended: true,
+  firstName: true,
+  lastName: true,
+  username: true,
+  photo: true,
+} satisfies UserSelect;
+
+export type ScoutUserResponse = UserGetPayload<{
+  select: typeof scoutUserSelect;
+}>;

--- a/src/features/sponsor-dashboard/constants/sponsorGrantDetails.ts
+++ b/src/features/sponsor-dashboard/constants/sponsorGrantDetails.ts
@@ -1,0 +1,70 @@
+import { type GrantsSelect } from '@/prisma/models/Grants';
+
+import { type Grant } from '@/features/grants/types';
+
+export const sponsorGrantDetailsSelect = {
+  id: true,
+  title: true,
+  slug: true,
+  token: true,
+  maxReward: true,
+  historicalApplications: true,
+  sponsorId: true,
+  isPublished: true,
+  isActive: true,
+  isArchived: true,
+  isPaused: true,
+  questions: true,
+  region: true,
+  status: true,
+  references: true,
+  airtableId: true,
+  isNative: true,
+  ai: true,
+  emailSalutation: true,
+  isST: true,
+  sponsor: {
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      logo: true,
+      entityName: true,
+      isVerified: true,
+      chapter: {
+        select: {
+          id: true,
+        },
+      },
+    },
+  },
+} satisfies GrantsSelect;
+
+export type SponsorGrantDetailsResponse = Pick<
+  Grant,
+  | 'id'
+  | 'title'
+  | 'slug'
+  | 'token'
+  | 'maxReward'
+  | 'historicalApplications'
+  | 'sponsorId'
+  | 'isPublished'
+  | 'isActive'
+  | 'isArchived'
+  | 'isPaused'
+  | 'questions'
+  | 'region'
+  | 'status'
+  | 'references'
+  | 'airtableId'
+  | 'isNative'
+  | 'ai'
+  | 'emailSalutation'
+  | 'isST'
+  | 'sponsor'
+  | 'approvedAmountTotal'
+> & {
+  totalApplications: number;
+  grantTrancheCount: number;
+};

--- a/src/features/sponsor-dashboard/queries/grant.ts
+++ b/src/features/sponsor-dashboard/queries/grant.ts
@@ -2,12 +2,7 @@ import { queryOptions } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';
 
-import { type Grant } from '@/features/grants/types';
-
-interface GrantWithApplicationCount extends Grant {
-  totalApplications: number;
-  grantTrancheCount: number;
-}
+import { type SponsorGrantDetailsResponse } from '../constants/sponsorGrantDetails';
 
 export const sponsorGrantQuery = (
   slug: string,
@@ -15,8 +10,10 @@ export const sponsorGrantQuery = (
 ) =>
   queryOptions({
     queryKey: ['grant', slug],
-    queryFn: async (): Promise<GrantWithApplicationCount> => {
-      const response = await api.get(`/api/sponsor-dashboard/grants/${slug}/`);
+    queryFn: async (): Promise<SponsorGrantDetailsResponse> => {
+      const response = await api.get<SponsorGrantDetailsResponse>(
+        `/api/sponsor-dashboard/grants/${slug}/`,
+      );
       return response.data;
     },
     enabled: !!currentSponsorId,

--- a/src/interface/scouts.ts
+++ b/src/interface/scouts.ts
@@ -1,4 +1,4 @@
-import { type User } from './user';
+import { type ScoutUserResponse } from '@/features/sponsor-dashboard/constants/scouts';
 
 interface Scouts {
   id: string;
@@ -9,7 +9,7 @@ interface Scouts {
   invited: boolean;
   skills: string[];
   createdAt: Date;
-  user: User;
+  user: ScoutUserResponse;
 }
 
 export type { Scouts };

--- a/src/pages/api/grant-application/get.ts
+++ b/src/pages/api/grant-application/get.ts
@@ -5,6 +5,7 @@ import { prisma } from '@/prisma';
 
 import { type NextApiRequestWithUser } from '@/features/auth/types';
 import { withAuth } from '@/features/auth/utils/withAuth';
+import { userApplicationSelect } from '@/features/grants/constants/userApplication';
 
 async function application(req: NextApiRequestWithUser, res: NextApiResponse) {
   const userId = req.userId;
@@ -24,18 +25,7 @@ async function application(req: NextApiRequestWithUser, res: NextApiResponse) {
         applicationStatus: { not: { in: ['Completed'] } },
       },
       orderBy: { createdAt: 'desc' },
-      omit: {
-        ai: true,
-        label: true,
-        notes: true,
-        paymentDetails: true,
-      },
-      include: {
-        GrantTranche: {
-          orderBy: { createdAt: 'asc' },
-        },
-        user: true,
-      },
+      select: userApplicationSelect,
     });
 
     if (!result) {

--- a/src/pages/api/sponsor-dashboard/grants/[slug]/index.ts
+++ b/src/pages/api/sponsor-dashboard/grants/[slug]/index.ts
@@ -7,6 +7,10 @@ import { safeStringify } from '@/utils/safeStringify';
 import { type NextApiRequestWithSponsor } from '@/features/auth/types';
 import { checkGrantSponsorAuth } from '@/features/auth/utils/checkGrantSponsorAuth';
 import { withSponsorAuth } from '@/features/auth/utils/withSponsorAuth';
+import {
+  sponsorGrantDetailsSelect,
+  type SponsorGrantDetailsResponse,
+} from '@/features/sponsor-dashboard/constants/sponsorGrantDetails';
 
 async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   const userId = req.userId;
@@ -21,11 +25,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
 
     const grant = await prisma.grants.findFirst({
       where: { slug },
-      include: { sponsor: true, poc: true, GrantApplication: true },
-    });
-
-    const grantTrancheCount = await prisma.grantTranche.count({
-      where: { grantId: grant?.id },
+      select: sponsorGrantDetailsSelect,
     });
 
     if (!grant) {
@@ -62,28 +62,58 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       return res.status(error.status).json(response);
     }
 
-    const totalApplications = grant.GrantApplication.length;
-    const approvedAmountTotal = grant.GrantApplication.reduce(
-      (sum, application) => {
-        if (
-          application.applicationStatus !== 'Approved' &&
-          application.applicationStatus !== 'Completed'
-        ) {
-          return sum;
-        }
+    const [totalApplications, approvedAmount, grantTrancheCount] =
+      await Promise.all([
+        prisma.grantApplication.count({ where: { grantId: grant.id } }),
+        prisma.grantApplication.aggregate({
+          where: {
+            grantId: grant.id,
+            applicationStatus: { in: ['Approved', 'Completed'] },
+          },
+          _sum: { approvedAmountInUSD: true },
+        }),
+        prisma.grantTranche.count({ where: { grantId: grant.id } }),
+      ]);
 
-        return sum + (application.approvedAmountInUSD || 0);
+    const response: SponsorGrantDetailsResponse = {
+      id: grant.id,
+      title: grant.title,
+      slug: grant.slug,
+      token: grant.token ?? undefined,
+      maxReward: grant.maxReward ?? undefined,
+      historicalApplications: grant.historicalApplications,
+      sponsorId: grant.sponsorId,
+      isPublished: grant.isPublished,
+      isActive: grant.isActive,
+      isArchived: grant.isArchived,
+      isPaused: grant.isPaused,
+      questions: grant.questions as SponsorGrantDetailsResponse['questions'],
+      region: grant.region,
+      status: grant.status,
+      references:
+        (grant.references as unknown as SponsorGrantDetailsResponse['references']) ??
+        [],
+      airtableId: grant.airtableId ?? undefined,
+      isNative: grant.isNative,
+      ai: grant.ai as SponsorGrantDetailsResponse['ai'],
+      emailSalutation: grant.emailSalutation,
+      isST: grant.isST,
+      sponsor: {
+        id: grant.sponsor.id,
+        name: grant.sponsor.name,
+        slug: grant.sponsor.slug,
+        logo: grant.sponsor.logo ?? '',
+        entityName: grant.sponsor.entityName ?? undefined,
+        isVerified: grant.sponsor.isVerified,
+        chapter: grant.sponsor.chapter,
       },
-      0,
-    );
-
-    logger.info(`Grant details fetched successfully for slug=${slug}`);
-    return res.status(200).json({
-      ...grant,
-      approvedAmountTotal,
+      approvedAmountTotal: approvedAmount._sum.approvedAmountInUSD ?? 0,
       totalApplications,
       grantTrancheCount,
-    });
+    };
+
+    logger.info(`Grant details fetched successfully for slug=${slug}`);
+    return res.status(200).json(response);
   } catch (error: any) {
     logger.error(
       `Error fetching grant with slug=${slug} for user=${userId}: ${safeStringify(error)}`,

--- a/src/pages/api/sponsor-dashboard/grants/add-tranche.ts
+++ b/src/pages/api/sponsor-dashboard/grants/add-tranche.ts
@@ -9,6 +9,7 @@ import { type NextApiRequestWithSponsor } from '@/features/auth/types';
 import { checkGrantSponsorAuth } from '@/features/auth/utils/checkGrantSponsorAuth';
 import { withSponsorAuth } from '@/features/auth/utils/withSponsorAuth';
 import { queueEmail } from '@/features/emails/utils/queueEmail';
+import { grantApplicationMutationSelect } from '@/features/sponsor-dashboard/constants/grantApplicationMutation';
 import {
   findUsedPaymentTxIds,
   normalizePaymentTxId,
@@ -42,7 +43,20 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     logger.info(`Fetching grant application with ID: ${id}`);
     const currentApplication = await prisma.grantApplication.findUnique({
       where: { id },
-      include: { grant: true },
+      select: {
+        grantId: true,
+        userId: true,
+        approvedAmount: true,
+        totalPaid: true,
+        paymentDetails: true,
+        totalTranches: true,
+        walletAddress: true,
+        grant: {
+          select: {
+            token: true,
+          },
+        },
+      },
     });
 
     if (!currentApplication) {
@@ -134,10 +148,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
           paymentDetails: updatedPaymentDetails as any,
           ...(isFullyPaid && { applicationStatus: 'Completed' }),
         },
-        include: {
-          user: true,
-          grant: true,
-        },
+        select: grantApplicationMutationSelect,
       });
 
       return updatedGrantApplication;

--- a/src/pages/api/sponsor-dashboard/grants/update-ship-progress.ts
+++ b/src/pages/api/sponsor-dashboard/grants/update-ship-progress.ts
@@ -7,6 +7,7 @@ import { type NextApiRequestWithSponsor } from '@/features/auth/types';
 import { checkGrantSponsorAuth } from '@/features/auth/utils/checkGrantSponsorAuth';
 import { withSponsorAuth } from '@/features/auth/utils/withSponsorAuth';
 import { queueEmail } from '@/features/emails/utils/queueEmail';
+import { grantApplicationMutationSelect } from '@/features/sponsor-dashboard/constants/grantApplicationMutation';
 
 async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   if (req.method !== 'PUT') {
@@ -26,7 +27,13 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       where: { id },
       select: {
         grantId: true,
+        userId: true,
         applicationStatus: true,
+        grant: {
+          select: {
+            pocId: true,
+          },
+        },
       },
     });
 
@@ -55,10 +62,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       data: {
         applicationStatus: 'Completed',
       },
-      include: {
-        user: true,
-        grant: true,
-      },
+      select: grantApplicationMutationSelect,
     });
 
     if (!result) {
@@ -70,8 +74,8 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       await queueEmail({
         type: 'grantCompleted',
         id: result.id,
-        userId: result.user.id,
-        triggeredBy: result.grant.pocId,
+        userId: currentApplication.userId,
+        triggeredBy: currentApplication.grant.pocId,
       });
     } catch (err) {
       logger.error(


### PR DESCRIPTION
## What does this PR do?
- Added restricted select with required fields only to the following endpoints,
  - /api/sponsor-dashboard/grants/[slug]
  - /api/sponsor-dashboard/listing/[id]/scout
  - /api/sponsor-dashboard/grants/update-ship-progress
  - /api/sponsor-dashboard/grants/add-tranche
  - /api/grant-application/get
-  Selects are added to avoid sensitive and extra information from these endpoints.
- All consumers of the said endpoints, use properly typed responses for better type checks.

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved grant application and sponsor dashboard data handling for more consistent responses.
  * Grant details now display application counts, approved totals, and tranche counts accurately.
  * Scout profiles consistently show recommendation status, names, usernames, and photos.
  * Grant application and tranche updates continue to support authorization, payment validation, and notifications with streamlined data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->