### PR TITLE
Restricted remaining endpoints

### DIFF
--- a/public/skill.md
+++ b/public/skill.md
@@ -48,6 +48,12 @@ curl -s "$BASE_URL/api/agents/listings/details/some-listing-slug" \
   -H "Authorization: Bearer sk_..."
 ```
 
+The response contains the public listing contract needed to evaluate and
+submit work: listing IDs and content, eligibility questions, skills,
+compensation, rewards, sponsor/POC display details, and hackathon context when
+applicable. Internal review/AI state, notification IDs, publishing controls,
+and social-distribution metadata are intentionally not exposed.
+
 5. Submit a listing
 
 ```bash

--- a/src/app/api/user-sponsors/route.ts
+++ b/src/app/api/user-sponsors/route.ts
@@ -7,7 +7,13 @@ import { safeStringify } from '@/utils/safeStringify';
 
 import { getUserSession } from '@/features/auth/utils/getUserSession';
 
+export interface UserSponsorsResponse {
+  hasSponsorMembership: boolean;
+}
+
 export async function GET(_request: NextRequest) {
+  let userId: string | undefined;
+
   try {
     const headersList = await headers();
     const sessionResponse = await getUserSession(headersList);
@@ -19,27 +25,29 @@ export async function GET(_request: NextRequest) {
       );
     }
 
-    const { userId } = sessionResponse.data;
+    userId = sessionResponse.data.userId;
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
-    const result = await prisma.userSponsors.findMany({
+    const sponsorMembership = await prisma.userSponsors.findFirst({
       where: { userId },
-      orderBy: { updatedAt: 'asc' },
-      include: { sponsor: true },
+      select: { userId: true },
     });
 
-    logger.info(`Fetched user sponsors for user ID: ${userId}`);
-    return NextResponse.json(result);
-  } catch (error: any) {
-    const { userId } = (await getUserSession(await headers())).data || {};
+    logger.info(`Checked sponsor membership for user ID: ${userId}`);
+    return NextResponse.json<UserSponsorsResponse>({
+      hasSponsorMembership: sponsorMembership !== null,
+    });
+  } catch (error: unknown) {
     logger.error(
-      `Error occurred while fetching user sponsors for user ID: ${userId} - ${safeStringify(error)}`,
+      `Error occurred while checking sponsor membership for user ID: ${userId ?? 'unknown'} - ${safeStringify(error)}`,
     );
     return NextResponse.json(
       {
-        error,
-        message: 'Error occurred while fetching user sponsors.',
+        error: 'Unable to check sponsor membership.',
       },
-      { status: 400 },
+      { status: 500 },
     );
   }
 }

--- a/src/features/listings/components/Submission/SubmissionDrawer.tsx
+++ b/src/features/listings/components/Submission/SubmissionDrawer.tsx
@@ -47,7 +47,7 @@ import {
 
 import { submissionCountQuery } from '../../queries/submission-count';
 import { userSubmissionQuery } from '../../queries/user-submission-status';
-import { type Listing } from '../../types';
+import { type Listing, type SubmissionMutationResponse } from '../../types';
 import { getCombinedRegion } from '../../utils/region';
 import { submissionSchema } from '../../utils/submissionFormSchema';
 import { SubmissionTerms } from './SubmissionTerms';
@@ -454,7 +454,7 @@ export const SubmissionDrawer = ({
         ? '/api/submission/update/'
         : '/api/submission/create/';
 
-      await api.post(submissionEndpoint, {
+      await api.post<SubmissionMutationResponse>(submissionEndpoint, {
         listingId: id,
         link: data.link || '',
         tweet: data.tweet || '',

--- a/src/features/listings/types/index.ts
+++ b/src/features/listings/types/index.ts
@@ -114,6 +114,11 @@ export type PublicListingDetails = Omit<
   slug: string;
 };
 
+export interface SubmissionMutationResponse {
+  success: true;
+  submissionId: string;
+}
+
 export interface ListingHackathon {
   name: string;
   logo: string;

--- a/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
+++ b/src/features/sponsor-dashboard/components/ApplicationsTab.tsx
@@ -13,6 +13,7 @@ import { GrantApplicationStatus, type SubmissionLabels } from '@/prisma/enums';
 import { useUser } from '@/store/user';
 
 import { applicationsAtom, selectedGrantApplicationAtom } from '../atoms';
+import { type GrantApplicationStatusMutationResponse } from '../constants/grantApplicationMutation';
 import { useRejectGrantApplications } from '../mutations/useRejectGrantApplications';
 import {
   applicationsQuery,
@@ -197,7 +198,7 @@ export const ApplicationsTab = ({ slug }: Props) => {
       customNote?: string;
     }) => {
       const reviewerNote = customNote?.trim();
-      const response = await api.post(
+      await api.post<GrantApplicationStatusMutationResponse>(
         '/api/sponsor-dashboard/grants/update-application-status',
         {
           data: [{ id: applicationId, approvedAmount }],
@@ -205,7 +206,6 @@ export const ApplicationsTab = ({ slug }: Props) => {
           ...(reviewerNote ? { customNote: reviewerNote } : {}),
         },
       );
-      return response.data;
     },
     onMutate: async ({ applicationId, approvedAmount }) => {
       const previousApplications =

--- a/src/features/sponsor-dashboard/constants/grantApplicationMutation.ts
+++ b/src/features/sponsor-dashboard/constants/grantApplicationMutation.ts
@@ -14,3 +14,8 @@ export const grantApplicationMutationSelect = {
 export type GrantApplicationMutationResponse = GrantApplicationGetPayload<{
   select: typeof grantApplicationMutationSelect;
 }>;
+
+export interface GrantApplicationStatusMutationResponse {
+  success: true;
+  applicationIds: string[];
+}

--- a/src/features/sponsor-dashboard/mutations/useRejectGrantApplications.ts
+++ b/src/features/sponsor-dashboard/mutations/useRejectGrantApplications.ts
@@ -6,6 +6,7 @@ import { api } from '@/lib/api';
 import { GrantApplicationStatus } from '@/prisma/enums';
 
 import { selectedGrantApplicationAtom } from '../atoms';
+import { type GrantApplicationStatusMutationResponse } from '../constants/grantApplicationMutation';
 import { type GrantApplicationsReturn } from '../queries/applications';
 import { type GrantApplicationWithUser } from '../types';
 
@@ -79,7 +80,7 @@ export const useRejectGrantApplications = (slug: string) => {
       const batchSize = 10;
       for (let i = 0; i < applicationIds.length; i += batchSize) {
         const batch = applicationIds.slice(i, i + batchSize);
-        await api.post(
+        await api.post<GrantApplicationStatusMutationResponse>(
           '/api/sponsor-dashboard/grants/update-application-status',
           {
             data: batch.map((id) => ({ id })),

--- a/src/pages/api/agents/listings/details/[slug].ts
+++ b/src/pages/api/agents/listings/details/[slug].ts
@@ -6,8 +6,14 @@ import { convertDatesToISO, safeStringify } from '@/utils/safeStringify';
 
 import { type NextApiRequestWithAgent } from '@/features/auth/types';
 import { withAgentAuth } from '@/features/auth/utils/withAgentAuth';
+import { publicListingDetailsSelect } from '@/features/listings/constants/publicListingDetails';
+import { type PublicListingDetails } from '@/features/listings/types';
 
-async function getAgentListingDetailsBySlug(slug: string): Promise<any> {
+export type AgentListingDetailsResponse = PublicListingDetails;
+
+async function getAgentListingDetailsBySlug(
+  slug: string,
+): Promise<AgentListingDetailsResponse | null> {
   if (!slug) {
     throw new Error('Missing required query parameters: slug');
   }
@@ -21,51 +27,12 @@ async function getAgentListingDetailsBySlug(slug: string): Promise<any> {
         isVerified: true,
       },
     },
-    include: {
-      sponsor: {
-        select: {
-          name: true,
-          logo: true,
-          slug: true,
-          entityName: true,
-          isVerified: true,
-          isCaution: true,
-        },
-      },
-      poc: {
-        select: {
-          id: true,
-          firstName: true,
-          lastName: true,
-          username: true,
-          photo: true,
-        },
-      },
-      Hackathon: {
-        select: {
-          logo: true,
-          altLogo: true,
-          startDate: true,
-          name: true,
-          description: true,
-          slug: true,
-          announceDate: true,
-          sponsorId: true,
-          Sponsor: {
-            select: {
-              name: true,
-              logo: true,
-              entityName: true,
-              isVerified: true,
-              isCaution: true,
-            },
-          },
-        },
-      },
-    },
+    select: publicListingDetailsSelect,
   });
 
-  return convertDatesToISO(result);
+  return convertDatesToISO(
+    result,
+  ) as unknown as AgentListingDetailsResponse | null;
 }
 
 async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
@@ -93,13 +60,13 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
 
     logger.info(`Successfully fetched bounty details for slug=${slug}`);
     return res.status(200).json(result);
-  } catch (error: any) {
+  } catch (error: unknown) {
     logger.error(
       `Error fetching bounty with slug=${slug}:`,
       safeStringify(error),
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching bounty with slug=${slug}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/grants/update-application-status.ts
+++ b/src/pages/api/sponsor-dashboard/grants/update-application-status.ts
@@ -18,6 +18,7 @@ import { queueEmail } from '@/features/emails/utils/queueEmail';
 import { convertGrantApplicationToAirtable } from '@/features/grants/utils/convertGrantApplicationToAirtable';
 import { createTranche } from '@/features/grants/utils/createTranche';
 import { COINDCX_GRANT_ID } from '@/features/grants/utils/stGrant';
+import { type GrantApplicationStatusMutationResponse } from '@/features/sponsor-dashboard/constants/grantApplicationMutation';
 import { validateCustomEmailNote } from '@/features/sponsor-dashboard/utils/customEmailSanitizer';
 import {
   getGrantApprovedEmailBody,
@@ -380,13 +381,18 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       }
     }
 
-    return res.status(200).json(result);
+    const response: GrantApplicationStatusMutationResponse = {
+      success: true,
+      applicationIds: result.map((application) => application.id),
+    };
+
+    return res.status(200).json(response);
   } catch (error: any) {
     logger.error(
       `Error occurred while updating grant application ID: ${data.map((c) => c.id)}:  ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while updating the grant application.',
     });
   }

--- a/src/pages/api/submission/create.ts
+++ b/src/pages/api/submission/create.ts
@@ -14,6 +14,7 @@ import {
   sanitizeGrantApplicationAnswers,
   sanitizeGrantApplicationHtml,
 } from '@/features/grants/utils/sanitizeGrantApplicationHtml';
+import { type SubmissionMutationResponse } from '@/features/listings/types';
 import { submissionSchema } from '@/features/listings/utils/submissionFormSchema';
 import { validateSubmissionRequest } from '@/features/listings/utils/validateSubmissionRequest';
 import { extractSocialUsername } from '@/features/social/utils/extractUsername';
@@ -186,7 +187,12 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
       );
     }
 
-    return res.status(200).json(result);
+    const response: SubmissionMutationResponse = {
+      success: true,
+      submissionId: result.id,
+    };
+
+    return res.status(200).json(response);
   } catch (error: any) {
     const statusCode = error.message.includes('Validation') ? 400 : 403;
     logger.error(`User ${userId} unable to submit: ${safeStringify(error)}`);

--- a/src/pages/api/submission/update.ts
+++ b/src/pages/api/submission/update.ts
@@ -11,6 +11,7 @@ import {
   sanitizeGrantApplicationAnswers,
   sanitizeGrantApplicationHtml,
 } from '@/features/grants/utils/sanitizeGrantApplicationHtml';
+import { type SubmissionMutationResponse } from '@/features/listings/types';
 import { submissionSchema } from '@/features/listings/utils/submissionFormSchema';
 import { validateSubmissionRequest } from '@/features/listings/utils/validateSubmissionRequest';
 
@@ -141,7 +142,12 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
       );
     }
 
-    return res.status(200).json(result);
+    const response: SubmissionMutationResponse = {
+      success: true,
+      submissionId: result.id,
+    };
+
+    return res.status(200).json(response);
   } catch (error: any) {
     logger.error(
       `User ${userId} unable to update submission: ${safeStringify(error)}`,

--- a/src/pages/earn/new/index.tsx
+++ b/src/pages/earn/new/index.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/router';
 import React, { useState } from 'react';
 
+import { type UserSponsorsResponse } from '@/app/api/user-sponsors/route';
 import MdCheck from '@/components/icons/MdCheck';
 import { SponsorButton } from '@/components/ProfileSetup/SponsorButton';
 import { TalentButton } from '@/components/ProfileSetup/TalentButton';
@@ -68,8 +69,9 @@ export default function NewProfilePage({
     if (!user) return;
     try {
       // localStorage.removeItem(ONBOARDING_KEY);
-      const sponsors = await api.get('/api/user-sponsors');
-      if (sponsors?.data?.length && user.currentSponsorId) {
+      const { data } =
+        await api.get<UserSponsorsResponse>('/api/user-sponsors');
+      if (data.hasSponsorMembership && user.currentSponsorId) {
         router.push('/earn/dashboard/listings?open=1');
       } else {
         const originUrl = params?.get('originUrl');


### PR DESCRIPTION
## What does this PR do?
- Added restricted select with required fields only to the following endpoints,
  - /api/user-sponsors
  - /api/agents/listings/details/[slug]
  - /api/submission/create
  - /api/submission/update
  - /api/sponsor-dashboard/grants/update-application-status
- Selects are added to avoid sensitive and extra information from these endpoints.
- All consumers of the said endpoints, use properly typed responses for better type checks.

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Quick Start documentation describing the public listing-details response.
  * Sponsor onboarding now recognizes existing sponsor membership and routes eligible users to the sponsor dashboard.

* **Improvements**
  * Submission actions return concise confirmation details.
  * Grant application status updates return the affected application IDs.

* **Bug Fixes**
  * Standardized unauthorized and server-error responses without exposing internal error details.
  * Public listing details now consistently return only supported public information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->