### PR TITLE
Switch to generic error messages

### DIFF
--- a/src/app/api/grant-application/create/route.ts
+++ b/src/app/api/grant-application/create/route.ts
@@ -313,8 +313,8 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(
       {
-        error: error.message,
-        message: `Unable to submit grant application: ${error.message}`,
+        error: 'Internal Server Error',
+        message: 'Unable to submit grant application.',
       },
       { status: statusCode },
     );

--- a/src/app/api/grant-application/request-tranche/route.ts
+++ b/src/app/api/grant-application/request-tranche/route.ts
@@ -119,18 +119,20 @@ export async function POST(request: Request) {
           { status: 403 },
         );
       }
+      logger.error(`Unable to create grant tranche: ${safeStringify(error)}`);
       return NextResponse.json(
         {
-          error: error.message,
+          error: 'Internal Server Error',
           message: 'Error occurred while creating tranche.',
         },
         { status: 500 },
       );
     }
   } catch (error: any) {
+    logger.error(`Unable to request grant tranche: ${safeStringify(error)}`);
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: 'Error occurred while creating tranche.',
       },
       { status: 500 },

--- a/src/app/api/grant-application/update/route.ts
+++ b/src/app/api/grant-application/update/route.ts
@@ -280,8 +280,8 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(
       {
-        error: error.message,
-        message: `Unable to update grant application: ${error.message}`,
+        error: 'Internal Server Error',
+        message: 'Unable to update grant application.',
       },
       { status: statusCode },
     );

--- a/src/app/api/homepage/recent-earners/route.ts
+++ b/src/app/api/homepage/recent-earners/route.ts
@@ -67,7 +67,10 @@ export async function GET(_request: NextRequest) {
       error: error.message,
     });
     return NextResponse.json(
-      { error: error.message, message: 'Error occurred while fetching totals' },
+      {
+        error: 'Internal Server Error',
+        message: 'Error occurred while fetching totals',
+      },
       { status: 400 },
     );
   }

--- a/src/app/api/image/delete/route.ts
+++ b/src/app/api/image/delete/route.ts
@@ -290,10 +290,8 @@ export async function DELETE(request: NextRequest) {
       );
     }
 
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error';
     return NextResponse.json(
-      { error: `Server error: ${errorMessage}` },
+      { error: 'Internal Server Error' },
       { status: 500 },
     );
   }

--- a/src/app/api/image/sign/route.ts
+++ b/src/app/api/image/sign/route.ts
@@ -126,10 +126,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error';
     return NextResponse.json(
-      { error: `Failed to generate signature: ${errorMessage}` },
+      { error: 'Internal Server Error' },
       { status: 500 },
     );
   }

--- a/src/app/api/listings/bookmark/status/route.ts
+++ b/src/app/api/listings/bookmark/status/route.ts
@@ -52,13 +52,12 @@ export async function GET(request: NextRequest) {
     logger.info(`Fetched bookmark status for listing ID: ${listingId}`);
     return NextResponse.json(response, { status: 200 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
     logger.error(
       `Error occurred while fetching bookmark status for listing ID=${request.nextUrl.searchParams.get('listingId')}: ${safeStringify(error)}`,
     );
     return NextResponse.json(
       {
-        error: message,
+        error: 'Internal Server Error',
         message: 'Error occurred while fetching bookmark status.',
       },
       { status: 500 },

--- a/src/app/api/listings/bookmark/toggle/route.ts
+++ b/src/app/api/listings/bookmark/toggle/route.ts
@@ -59,13 +59,12 @@ export async function POST(request: NextRequest) {
     );
     return NextResponse.json(result, { status: 200 });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error';
     logger.error(
       `Error occurred while toggling bookmark: ${safeStringify(error)}`,
     );
     return NextResponse.json(
       {
-        error: message,
+        error: 'Internal Server Error',
         message: 'Error occurred while toggling bookmark.',
       },
       { status: 400 },

--- a/src/app/api/og/update/route.ts
+++ b/src/app/api/og/update/route.ts
@@ -80,7 +80,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     logger.error(`Error updating ogImage: ${safeStringify(error)}`);
     return NextResponse.json(
-      { success: false, error: error.message },
+      { success: false, error: 'Internal Server Error' },
       { status: 500 },
     );
   }

--- a/src/app/api/sponsor-dashboard/ai-generate/description/route.ts
+++ b/src/app/api/sponsor-dashboard/ai-generate/description/route.ts
@@ -97,12 +97,10 @@ export async function POST(req: NextRequest) {
     }
 
     logger.error('Error generating description:', safeStringify(error));
-    const errorMessage =
-      error instanceof Error ? error.message : 'An unknown error occurred';
     return new Response(
       JSON.stringify({
         error: 'Failed to generate description',
-        details: errorMessage,
+        details: 'Internal Server Error',
       }),
       {
         status: 500,

--- a/src/app/api/sponsor-dashboard/grant-application/ai/commit-reviewed/route.ts
+++ b/src/app/api/sponsor-dashboard/grant-application/ai/commit-reviewed/route.ts
@@ -97,7 +97,7 @@ export async function POST(request: NextRequest) {
   } catch (error: any) {
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: `Error occurred while committing reviewed grant applications.`,
       },
       { status: 500 },

--- a/src/app/api/sponsor-dashboard/grant-application/ai/unreviewed/route.ts
+++ b/src/app/api/sponsor-dashboard/grant-application/ai/unreviewed/route.ts
@@ -73,7 +73,7 @@ export async function GET(request: NextRequest) {
     );
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: `Error occurred while retrieving unreviewed grant applications`,
       },
       { status: 500 },

--- a/src/app/api/sponsor-dashboard/grants/update-tranche-status/route.ts
+++ b/src/app/api/sponsor-dashboard/grants/update-tranche-status/route.ts
@@ -324,7 +324,7 @@ export async function POST(request: NextRequest) {
     );
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: 'Error occurred while updating the grant tranche.',
       },
       { status: 500 },

--- a/src/app/api/sponsor-dashboard/listing/[id]/announce/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/[id]/announce/route.ts
@@ -489,7 +489,7 @@ export async function POST(
     );
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: `Error occurred while announcing bounty with id=${params.id}.`,
       },
       { status: 400 },

--- a/src/app/api/sponsor-dashboard/listing/[id]/delete/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/[id]/delete/route.ts
@@ -54,7 +54,7 @@ export async function DELETE(
     logger.error(`Error deleting bounty ${id}: ${safeStringify(error)}`);
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: `Error occurred while deleting bounty with id=${id}.`,
       },
       { status: 400 },

--- a/src/app/api/sponsor-dashboard/listing/[id]/publish/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/[id]/publish/route.ts
@@ -160,7 +160,7 @@ export async function POST(
     );
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: 'Error occurred while publishing a Listing.',
       },
       { status: 500 },

--- a/src/app/api/sponsor-dashboard/listing/[id]/scout/invite/[userId]/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/[id]/scout/invite/[userId]/route.ts
@@ -96,7 +96,7 @@ export async function POST(
     );
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: `Error occurred while inviting scout user=${userId} for bounty with id=${id}.`,
       },
       { status: 400 },

--- a/src/app/api/sponsor-dashboard/listing/[id]/unpublish/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/[id]/unpublish/route.ts
@@ -154,7 +154,7 @@ export async function POST(
     logger.error(`Error unpublishing listing ${id}: ${safeStringify(error)}`);
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: 'Error occurred while unpublishing a listing.',
       },
       { status: 400 },

--- a/src/app/api/sponsor-dashboard/listing/[id]/update/route.ts
+++ b/src/app/api/sponsor-dashboard/listing/[id]/update/route.ts
@@ -106,7 +106,7 @@ export async function POST(
     );
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: `Error occurred while updating listing with id = ${id}.`,
       },
       { status: 500 },

--- a/src/app/api/sponsor-dashboard/submissions/ai/commit-reviewed/route.ts
+++ b/src/app/api/sponsor-dashboard/submissions/ai/commit-reviewed/route.ts
@@ -296,7 +296,7 @@ export async function POST(request: NextRequest) {
     console.log(error);
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: `Error occurred while committing reviewed submissions.`,
       },
       { status: 500 },

--- a/src/app/api/sponsor-dashboard/submissions/ai/unreviewed/route.ts
+++ b/src/app/api/sponsor-dashboard/submissions/ai/unreviewed/route.ts
@@ -112,7 +112,7 @@ export async function GET(request: NextRequest) {
     });
     return NextResponse.json(
       {
-        error: error.message,
+        error: 'Internal Server Error',
         message: `Error occurred while retrieving unreviewed submissions`,
       },
       { status: 500 },

--- a/src/app/api/sponsor-dashboard/templates/route.ts
+++ b/src/app/api/sponsor-dashboard/templates/route.ts
@@ -115,7 +115,7 @@ export async function GET(request: NextRequest) {
     );
     return NextResponse.json(
       {
-        error: err.message,
+        error: 'Internal Server Error',
         message: 'Error occurred while fetching bounties.',
       },
       { status: 400 },

--- a/src/app/api/user/complete-profile/route.ts
+++ b/src/app/api/user/complete-profile/route.ts
@@ -306,7 +306,7 @@ export async function POST(request: NextRequest) {
     );
     return NextResponse.json(
       {
-        message: `Error occurred while updating user ${userId}: ${error.message}`,
+        message: 'Error occurred while updating the user.',
       },
       { status: 500 },
     );

--- a/src/app/api/user/credit/balance/route.ts
+++ b/src/app/api/user/credit/balance/route.ts
@@ -27,7 +27,7 @@ export async function GET(_request: NextRequest) {
     return NextResponse.json({ balance });
   } catch (error: any) {
     return NextResponse.json(
-      { error: error.message || 'Internal Server Error' },
+      { error: 'Internal Server Error' },
       { status: 500 },
     );
   }

--- a/src/app/api/wallet/create-signed-transaction/route.ts
+++ b/src/app/api/wallet/create-signed-transaction/route.ts
@@ -444,6 +444,9 @@ export async function POST(request: NextRequest) {
     logger.error(
       `Failed to create transfer transaction: ${safeStringify(error)}`,
     );
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 },
+    );
   }
 }

--- a/src/pages/api/agents/listings/live.ts
+++ b/src/pages/api/agents/listings/live.ts
@@ -60,8 +60,8 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
   } catch (error) {
     logger.error(error);
 
-    res.status(400).json({
-      error,
+    res.status(500).json({
+      error: 'Internal Server Error',
       message: 'Error occurred while fetching listings',
     });
   }

--- a/src/pages/api/agents/submissions/create.ts
+++ b/src/pages/api/agents/submissions/create.ts
@@ -100,8 +100,8 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
     );
 
     return res.status(statusCode).json({
-      error: error.message,
-      message: `Agent ${agentId} unable to submit: ${error.message}`,
+      error: 'Internal Server Error',
+      message: 'Unable to create submission.',
     });
   }
 }

--- a/src/pages/api/agents/submissions/update.ts
+++ b/src/pages/api/agents/submissions/update.ts
@@ -107,8 +107,8 @@ async function handler(req: NextApiRequestWithAgent, res: NextApiResponse) {
     } catch {}
 
     return res.status(statusCode).json({
-      error: error.message,
-      message: `Agent ${agentId} unable to update submission: ${error.message}`,
+      error: 'Internal Server Error',
+      message: 'Unable to update submission.',
     });
   }
 }

--- a/src/pages/api/comment/[id]/delete.ts
+++ b/src/pages/api/comment/[id]/delete.ts
@@ -49,7 +49,7 @@ async function comment(req: NextApiRequestWithUser, res: NextApiResponse) {
     );
     return res.status(400).json({
       error: 'Error occurred while deleting a comment.',
-      message: error.message,
+      message: 'Internal Server Error',
     });
   }
 }

--- a/src/pages/api/comment/[id]/pin.ts
+++ b/src/pages/api/comment/[id]/pin.ts
@@ -81,7 +81,7 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
     );
     return res.status(400).json({
       error: 'Error occurred while pinning/unpinning comment.',
-      message: error.message,
+      message: 'Internal Server Error',
     });
   }
 }

--- a/src/pages/api/email/webhook/index.ts
+++ b/src/pages/api/email/webhook/index.ts
@@ -3,9 +3,11 @@ import { buffer } from 'micro';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { type WebhookRequiredHeaders } from 'svix';
 
+import logger from '@/lib/logger';
 import { webhook } from '@/lib/webhook';
 import { validateEmailWithZeroBounce } from '@/lib/zerobounce';
 import { prisma } from '@/prisma';
+import { safeStringify } from '@/utils/safeStringify';
 
 export const config = {
   api: {
@@ -145,7 +147,10 @@ const webhooks = async (req: NextApiRequest, res: NextApiResponse) => {
 
         return res.status(200).end();
       } catch (error) {
-        return res.status(400).send(error);
+        logger.error(
+          `Email webhook processing failed: ${safeStringify(error)}`,
+        );
+        return res.status(500).json({ error: 'Internal Server Error' });
       }
     }
     default:

--- a/src/pages/api/feed/[type]/[id]/get.ts
+++ b/src/pages/api/feed/[type]/[id]/get.ts
@@ -328,7 +328,7 @@ export default async function handler(
     logger.error(
       `Error occurred while fetching Post of type${type} with ID ${id}: ${safeStringify(error)}`,
     );
-    res.status(500).json({ error: `Unable to fetch data: ${error.message}` });
+    res.status(500).json({ error: 'Unable to fetch data.' });
   }
 }
 

--- a/src/pages/api/feed/get.ts
+++ b/src/pages/api/feed/get.ts
@@ -546,6 +546,6 @@ export default async function handler(
     logger.error(
       `Error occurred while fetching submissions and PoWs: ${safeStringify(error)}`,
     );
-    res.status(500).json({ error: `Unable to fetch data: ${error.message}` });
+    res.status(500).json({ error: 'Unable to fetch data.' });
   }
 }

--- a/src/pages/api/grant-application/get.ts
+++ b/src/pages/api/grant-application/get.ts
@@ -40,7 +40,7 @@ async function application(req: NextApiRequestWithUser, res: NextApiResponse) {
       `Error fetching Grant Application for user=${userId} and grantId=${id}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while getting the grant application.',
     });
   }

--- a/src/pages/api/grant-application/kyc/verify-completion.ts
+++ b/src/pages/api/grant-application/kyc/verify-completion.ts
@@ -96,18 +96,13 @@ const handler = async (req: NextApiRequestWithUser, res: NextApiResponse) => {
 
     return res.status(200).json(result);
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : 'Internal server error';
-
     logger.error(
       `Grant application KYC verification failed: ${safeStringify(error)}, grantApplicationId: ${grantApplicationId}`,
     );
 
-    if (typeof message === 'string' && message.includes('Sumsub')) {
-      return res.status(422).json({ message });
-    }
-
-    return res.status(400).json({ message });
+    return res
+      .status(500)
+      .json({ message: 'Unable to verify KYC completion.' });
   }
 };
 

--- a/src/pages/api/grant-application/like.ts
+++ b/src/pages/api/grant-application/like.ts
@@ -33,7 +33,7 @@ async function grantApplication(
       `Error updating submission like for user=${req.userId}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while updating submission like.',
     });
   }

--- a/src/pages/api/grants/[slug].ts
+++ b/src/pages/api/grants/[slug].ts
@@ -35,7 +35,7 @@ export default async function user(req: NextApiRequest, res: NextApiResponse) {
       `Error occurred while fetching grant with slug=${slug}: ${safeStringify(error)}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching grant with slug=${slug}.`,
     });
   }

--- a/src/pages/api/grants/delete/[id].ts
+++ b/src/pages/api/grants/delete/[id].ts
@@ -47,7 +47,7 @@ async function grantDelete(
       `Error occurred while deleting grant with ID: ${id}: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while deleting grant with id=${id}.`,
     });
   }

--- a/src/pages/api/grants/update/[id].ts
+++ b/src/pages/api/grants/update/[id].ts
@@ -52,7 +52,7 @@ async function grant(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error occurred while updating grant with ID: ${id}: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while updating grant with id=${id}.`,
     });
   }

--- a/src/pages/api/hackathon/list.ts
+++ b/src/pages/api/hackathon/list.ts
@@ -1,7 +1,9 @@
 import type { NextApiResponse } from 'next';
 
+import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
 import { parseBoundedIntegerParam } from '@/utils/apiPagination';
+import { safeStringify } from '@/utils/safeStringify';
 
 import { type NextApiRequestWithUser } from '@/features/auth/types';
 import { withAuth } from '@/features/auth/utils/withAuth';
@@ -96,9 +98,12 @@ async function hackathons(req: NextApiRequestWithUser, res: NextApiResponse) {
       });
     }
     res.status(200).json(finalHackathons);
-  } catch (error) {
-    res.status(400).json({
-      error,
+  } catch (error: unknown) {
+    logger.error(
+      `Error occurred while fetching hackathons: ${safeStringify(error)}`,
+    );
+    res.status(500).json({
+      error: 'Internal Server Error',
       message: 'Error occurred while fetching hackathons',
     });
   }

--- a/src/pages/api/hackathon/public-stats.ts
+++ b/src/pages/api/hackathon/public-stats.ts
@@ -48,6 +48,6 @@ export default async function handler(
       announceDate: hackathon.announceDate,
     });
   } catch (error) {
-    return res.status(500).json({ error: error });
+    return res.status(500).json({ error: 'Internal Server Error' });
   }
 }

--- a/src/pages/api/hackathon/stats.ts
+++ b/src/pages/api/hackathon/stats.ts
@@ -81,7 +81,7 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
     });
   } catch (error) {
     console.trace(error);
-    return res.status(500).json({ error: error });
+    return res.status(500).json({ error: 'Internal Server Error' });
   }
 }
 

--- a/src/pages/api/hackathon/subscribe/get.ts
+++ b/src/pages/api/hackathon/subscribe/get.ts
@@ -35,7 +35,7 @@ export default async function handler(
       `Error occurred while fetching subscription status for hackathon slug=${req.body.slug}: ${safeStringify(error)}`,
     );
     res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while fetching subscription status.',
     });
   }

--- a/src/pages/api/hackathon/subscribe/toggle.ts
+++ b/src/pages/api/hackathon/subscribe/toggle.ts
@@ -60,7 +60,7 @@ async function toggleSubscription(
       `Error occurred while toggling subscription for hackathon slug: ${slug} and user ID: ${userId}: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while toggling subscription.',
     });
   }

--- a/src/pages/api/listings/[listingId]/submission-count.ts
+++ b/src/pages/api/listings/[listingId]/submission-count.ts
@@ -39,7 +39,7 @@ export default async function submission(
       `Error occurred while fetching submission count for listing ID=${listingId}: ${safeStringify(error)}`,
     );
     res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching submission count of listing=${listingId}.`,
     });
   }

--- a/src/pages/api/listings/[listingId]/winners.ts
+++ b/src/pages/api/listings/[listingId]/winners.ts
@@ -69,7 +69,7 @@ export default async function submission(
       `Error occurred while fetching winning submissions for listing ID=${listingId}: ${safeStringify(error)}`,
     );
     res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching winning submissions for listing ID=${listingId}.`,
     });
   }

--- a/src/pages/api/listings/bookmarks.ts
+++ b/src/pages/api/listings/bookmarks.ts
@@ -56,7 +56,7 @@ async function getBookmarks(req: NextApiRequestWithUser, res: NextApiResponse) {
       `Error occurred while fetching bookmarks for user ID=${req.userId}: ${safeStringify(error)}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while fetching bookmarks.',
     });
   }

--- a/src/pages/api/listings/details/[slug].ts
+++ b/src/pages/api/listings/details/[slug].ts
@@ -76,7 +76,7 @@ export default async function handler(
       safeStringify(error),
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching bounty with slug=${slug}.`,
     });
   }

--- a/src/pages/api/listings/live.ts
+++ b/src/pages/api/listings/live.ts
@@ -97,8 +97,8 @@ export default async function listings(
   } catch (error) {
     logger.error(error);
 
-    res.status(400).json({
-      error,
+    res.status(500).json({
+      error: 'Internal Server Error',
       message: 'Error occurred while fetching listings',
     });
   }

--- a/src/pages/api/listings/submissions/[slug].ts
+++ b/src/pages/api/listings/submissions/[slug].ts
@@ -130,7 +130,7 @@ export default async function user(req: NextApiRequest, res: NextApiResponse) {
       `Error occurred while fetching bounty with slug=${slug}: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching bounty with slug=${slug}.`,
     });
   }

--- a/src/pages/api/member-invites/send.ts
+++ b/src/pages/api/member-invites/send.ts
@@ -114,7 +114,7 @@ async function sendInvites(
       `User ${userId} unable to send invite: ${safeStringify(error)}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while sending the invite.',
     });
   }

--- a/src/pages/api/pow/create.ts
+++ b/src/pages/api/pow/create.ts
@@ -80,7 +80,7 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
       safeStringify(error),
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
     });
   }
 }

--- a/src/pages/api/pow/edit.ts
+++ b/src/pages/api/pow/edit.ts
@@ -120,7 +120,7 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
       return res.status(500).json({
         error: {
           code: error.code,
-          message: error.message,
+          message: 'Internal Server Error',
           meta: error.meta,
         },
       });

--- a/src/pages/api/pow/get.ts
+++ b/src/pages/api/pow/get.ts
@@ -42,7 +42,7 @@ export default async function handler(
       safeStringify(error),
     );
     return res.status(500).json({
-      error: `An error occurred while fetching the data: ${error.message}`,
+      error: 'Internal Server Error',
     });
   }
 }

--- a/src/pages/api/pow/like.ts
+++ b/src/pages/api/pow/like.ts
@@ -33,7 +33,7 @@ async function poWLike(req: NextApiRequestWithUser, res: NextApiResponse) {
       safeStringify(error),
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while updating PoW like',
     });
   }

--- a/src/pages/api/search/[query].ts
+++ b/src/pages/api/search/[query].ts
@@ -430,8 +430,6 @@ s.name LIKE CONCAT('%', ?, '%')
     });
   } catch (err: any) {
     logger.error('Error fetching bounties or grants:', err);
-    res
-      .status(500)
-      .json({ error: 'Internal server error', details: err.message });
+    res.status(500).json({ error: 'Internal Server Error' });
   }
 }

--- a/src/pages/api/sponsor-dashboard/[slug]/listing.ts
+++ b/src/pages/api/sponsor-dashboard/[slug]/listing.ts
@@ -128,7 +128,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       safeStringify(error),
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching bounty with slug=${slug}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/[slug]/submissions.ts
+++ b/src/pages/api/sponsor-dashboard/[slug]/submissions.ts
@@ -153,7 +153,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error occurred while fetching submissions for slug=${slug}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching submissions with slug=${slug}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/active-hackathons.ts
+++ b/src/pages/api/sponsor-dashboard/active-hackathons.ts
@@ -45,7 +45,7 @@ async function handler(_: NextApiRequestWithSponsor, res: NextApiResponse) {
     logger.error('Error looking for active hackathon', error);
     return res.status(500).json({
       message: 'Error looking for active hackathon',
-      error,
+      error: 'Internal Server Error',
     });
   }
 }

--- a/src/pages/api/sponsor-dashboard/application/export-sheets.ts
+++ b/src/pages/api/sponsor-dashboard/application/export-sheets.ts
@@ -411,7 +411,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `User ${userId} unable to export to Google Sheets: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message || error.toString(),
+      error: 'Internal Server Error',
       message: `Error occurred while exporting applications to Google Sheets for grant=${grantId}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/application/export.ts
+++ b/src/pages/api/sponsor-dashboard/application/export.ts
@@ -112,7 +112,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `User ${userId} unable to download CSV: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message || error.toString(),
+      error: 'Internal Server Error',
       message: `Error occurred while exporting applications of grant=${grantId}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/grants/[slug]/applications.ts
+++ b/src/pages/api/sponsor-dashboard/grants/[slug]/applications.ts
@@ -3,14 +3,7 @@ import type { NextApiResponse } from 'next';
 import { type PrismaUserWithoutKYC } from '@/interface/user';
 import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
-import {
-  PrismaClientInitializationError,
-  PrismaClientKnownRequestError,
-  PrismaClientRustPanicError,
-  PrismaClientUnknownRequestError,
-  PrismaClientValidationError,
-  sql,
-} from '@/prisma/internal/prismaNamespace';
+import { sql } from '@/prisma/internal/prismaNamespace';
 import { safeStringify } from '@/utils/safeStringify';
 
 import { type NextApiRequestWithSponsor } from '@/features/auth/types';
@@ -221,37 +214,14 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
 
     return res.status(200).json(responseData);
   } catch (error: any) {
-    let errorMessage = `Error fetching submissions with slug=${slug}.`;
-    if (error.code) {
-      errorMessage += ` Code: ${error.code}`;
-    }
-    if (
-      error instanceof PrismaClientKnownRequestError ||
-      error instanceof PrismaClientUnknownRequestError ||
-      error instanceof PrismaClientRustPanicError ||
-      error instanceof PrismaClientInitializationError ||
-      error instanceof PrismaClientValidationError
-    ) {
-      logger.error(
-        `Prisma Error fetching submissions with slug=${slug}: ${safeStringify(error)}`,
-        error.stack,
-      );
-      if (error instanceof PrismaClientKnownRequestError && error.meta) {
-        errorMessage += ` Meta: ${safeStringify(error.meta)}`;
-      }
-    } else {
-      logger.error(
-        `Generic Error fetching submissions with slug=${slug}: ${safeStringify(error)}`,
-        error.stack,
-      );
-    }
+    logger.error(
+      `Error fetching submissions with slug=${slug}: ${safeStringify(error)}`,
+      error.stack,
+    );
 
     return res.status(500).json({
       error: 'Internal Server Error',
-      message: errorMessage,
-      ...(process.env.NODE_ENV !== 'production'
-        ? { details: safeStringify(error) }
-        : {}),
+      message: 'Error occurred while fetching grant applications.',
     });
   }
 }

--- a/src/pages/api/sponsor-dashboard/grants/[slug]/index.ts
+++ b/src/pages/api/sponsor-dashboard/grants/[slug]/index.ts
@@ -119,7 +119,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error fetching grant with slug=${slug} for user=${userId}: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching grant with slug=${slug}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/grants/[slug]/tranches.ts
+++ b/src/pages/api/sponsor-dashboard/grants/[slug]/tranches.ts
@@ -129,7 +129,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error fetching submissions with slug=${slug}: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while fetching submissions with slug=${slug}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/grants/add-tranche.ts
+++ b/src/pages/api/sponsor-dashboard/grants/add-tranche.ts
@@ -171,7 +171,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       safeStringify(error),
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while updating payment of a submission ${id}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/grants/approved-grantees.ts
+++ b/src/pages/api/sponsor-dashboard/grants/approved-grantees.ts
@@ -79,7 +79,7 @@ async function grantApplication(
       `Error occurred while fetching applications for grantId: ${grantId} by user ${userId}: ${safeStringify(error)}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while fetching grant applications.',
     });
   }

--- a/src/pages/api/sponsor-dashboard/grants/update-label.ts
+++ b/src/pages/api/sponsor-dashboard/grants/update-label.ts
@@ -115,7 +115,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error occurred while updating applications: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while updating the applications.',
     });
   }

--- a/src/pages/api/sponsor-dashboard/grants/update-notes.ts
+++ b/src/pages/api/sponsor-dashboard/grants/update-notes.ts
@@ -75,7 +75,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error occurred while updating application with ID ${id} with notes: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while updating the application with notes.',
     });
   }

--- a/src/pages/api/sponsor-dashboard/grants/update-ship-progress.ts
+++ b/src/pages/api/sponsor-dashboard/grants/update-ship-progress.ts
@@ -89,7 +89,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error updating grant application with ID ${id}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while updating the grant application.',
     });
   }

--- a/src/pages/api/sponsor-dashboard/listings/verify-external-payment.ts
+++ b/src/pages/api/sponsor-dashboard/listings/verify-external-payment.ts
@@ -229,7 +229,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
           submissionId: paymentLink.submissionId,
           txId: paymentLink.txId || '',
           status: 'FAIL',
-          message: error.message,
+          message: 'Payment verification failed',
         });
         await wait(5000);
         logger.warn(

--- a/src/pages/api/sponsor-dashboard/local-talent/export.ts
+++ b/src/pages/api/sponsor-dashboard/local-talent/export.ts
@@ -197,7 +197,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `User ${userId} unable to download CSV: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message || error.toString(),
+      error: 'Internal Server Error',
       message: `Error occurred while exporting users of local region.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/local-talent/index.ts
+++ b/src/pages/api/sponsor-dashboard/local-talent/index.ts
@@ -146,7 +146,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     );
     res.status(400).json({
       error: 'Error occurred while fetching users.',
-      details: error.message,
+      details: 'Internal Server Error',
     });
   }
 }

--- a/src/pages/api/sponsor-dashboard/submission/add-payment.ts
+++ b/src/pages/api/sponsor-dashboard/submission/add-payment.ts
@@ -231,7 +231,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       )}`,
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while updating payment of a submission ${id}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/submission/export-sheets.ts
+++ b/src/pages/api/sponsor-dashboard/submission/export-sheets.ts
@@ -410,7 +410,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `User ${userId} unable to export to Google Sheets: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message || error.toString(),
+      error: 'Internal Server Error',
       message: `Error occurred while exporting submissions to Google Sheets for listing=${listingId}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/submission/export.ts
+++ b/src/pages/api/sponsor-dashboard/submission/export.ts
@@ -123,7 +123,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `User ${userId} unable to download CSV: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      error: error.message || error.toString(),
+      error: 'Internal Server Error',
       message: `Error occurred while exporting submissions of listing=${listingId}.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/submission/reject.ts
+++ b/src/pages/api/sponsor-dashboard/submission/reject.ts
@@ -116,7 +116,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error occurred while rejecting listing submission ID: ${data.map((c) => c.id)}:  ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while rejecting listing submissions',
     });
   }

--- a/src/pages/api/sponsor-dashboard/submission/toggle-winner.ts
+++ b/src/pages/api/sponsor-dashboard/submission/toggle-winner.ts
@@ -338,7 +338,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       { error, submissionIds },
     );
     return res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while updating submissions.`,
     });
   }

--- a/src/pages/api/sponsor-dashboard/submission/update-label.ts
+++ b/src/pages/api/sponsor-dashboard/submission/update-label.ts
@@ -154,7 +154,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   } catch (error: any) {
     logger.error(`Error occurred while updating submissions: ${error.message}`);
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while updating the submissions.',
     });
   }

--- a/src/pages/api/sponsor-dashboard/submission/update-notes.ts
+++ b/src/pages/api/sponsor-dashboard/submission/update-notes.ts
@@ -60,7 +60,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error occurred while updating submission with ID ${id} with notes: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while updating the submission with notes.',
     });
   }

--- a/src/pages/api/sponsor/verification.ts
+++ b/src/pages/api/sponsor/verification.ts
@@ -126,8 +126,8 @@ async function verification(req: NextApiRequestWithUser, res: NextApiResponse) {
     );
 
     return res.status(500).json({
-      error: error.message,
-      message: `User ${userId} unable to update verification: ${error.message}`,
+      error: 'Internal Server Error',
+      message: 'Unable to update verification.',
     });
   }
 }

--- a/src/pages/api/sponsors/create.ts
+++ b/src/pages/api/sponsors/create.ts
@@ -116,7 +116,7 @@ async function user(req: NextApiRequestWithUser, res: NextApiResponse) {
       `Error occurred while adding a new sponsor for user ${userId}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message || 'Internal server error',
+      error: 'Internal Server Error',
       message: 'Error occurred while adding a new sponsor.',
     });
   }

--- a/src/pages/api/sponsors/edit.ts
+++ b/src/pages/api/sponsors/edit.ts
@@ -148,7 +148,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error occurred while updating sponsor for user ${userId}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message || 'Internal server error',
+      error: 'Internal Server Error',
       message: 'Error occurred while updating sponsor.',
     });
   }

--- a/src/pages/api/sponsors/index.ts
+++ b/src/pages/api/sponsors/index.ts
@@ -31,7 +31,7 @@ async function user(req: NextApiRequestWithUser, res: NextApiResponse) {
       `Error occurred while fetching user ${userId}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message || 'Internal server error',
+      error: 'Internal Server Error',
       message: 'Error occurred while fetching user.',
     });
   }

--- a/src/pages/api/sponsors/list.ts
+++ b/src/pages/api/sponsors/list.ts
@@ -124,7 +124,7 @@ async function sponsors(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error fetching sponsors for user ${userId}: ${error.message}`,
     );
     res.status(500).json({
-      error: error.message || 'Internal server error',
+      error: 'Internal Server Error',
       message: 'Error occurred while fetching sponsors',
     });
   }

--- a/src/pages/api/sponsors/update-entity-name.ts
+++ b/src/pages/api/sponsors/update-entity-name.ts
@@ -42,7 +42,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       `Error occurred while updating sponsor for user ${userId}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message || 'Internal server error',
+      error: 'Internal Server Error',
       message: 'Error occurred while updating sponsor.',
     });
   }

--- a/src/pages/api/sponsors/usersponsor-details.ts
+++ b/src/pages/api/sponsors/usersponsor-details.ts
@@ -102,7 +102,7 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
     );
     return res.status(500).json({
       error: 'Internal server error',
-      message: `Error occurred while updating user: ${error.message}`,
+      message: 'Error occurred while updating the user.',
     });
   }
 }

--- a/src/pages/api/submission/check.ts
+++ b/src/pages/api/submission/check.ts
@@ -89,7 +89,7 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
       `Error occurred while checking submission existence for listing ID=${listingId} and user ID=${userId}: ${safeStringify(error)}`,
     );
     res.status(400).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: `Error occurred while checking submission existence for listing=${listingId} and user=${userId}.`,
     });
   }

--- a/src/pages/api/submission/create.ts
+++ b/src/pages/api/submission/create.ts
@@ -192,8 +192,8 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
     logger.error(`User ${userId} unable to submit: ${safeStringify(error)}`);
 
     return res.status(statusCode).json({
-      error: error.message,
-      message: `User ${userId} unable to submit: ${error.message}`,
+      error: 'Internal Server Error',
+      message: 'Unable to create submission.',
     });
   }
 }

--- a/src/pages/api/submission/get.ts
+++ b/src/pages/api/submission/get.ts
@@ -42,7 +42,7 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
       `Error fetching submission for user=${userId} and listingId=${id}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while getting the submission.',
     });
   }

--- a/src/pages/api/submission/kyc/verify-completion.ts
+++ b/src/pages/api/submission/kyc/verify-completion.ts
@@ -91,18 +91,13 @@ const handler = async (req: NextApiRequestWithUser, res: NextApiResponse) => {
 
     return res.status(200).json(result);
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : 'Internal server error';
-
     logger.error(
       `Submission KYC verification failed: ${safeStringify(error)}, submissionId: ${submissionId}`,
     );
 
-    if (typeof message === 'string' && message.includes('Sumsub')) {
-      return res.status(422).json({ message });
-    }
-
-    return res.status(400).json({ message });
+    return res
+      .status(500)
+      .json({ message: 'Unable to verify KYC completion.' });
   }
 };
 

--- a/src/pages/api/submission/like.ts
+++ b/src/pages/api/submission/like.ts
@@ -30,7 +30,7 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
       `Error updating submission like for user=${req.userId}: ${error.message}`,
     );
     return res.status(500).json({
-      error: error.message,
+      error: 'Internal Server Error',
       message: 'Error occurred while updating submission like.',
     });
   }

--- a/src/pages/api/submission/update.ts
+++ b/src/pages/api/submission/update.ts
@@ -154,8 +154,8 @@ async function submission(req: NextApiRequestWithUser, res: NextApiResponse) {
     } catch {}
 
     return res.status(statusCode).json({
-      error: error.message,
-      message: `Unable to update submission: ${error.message}`,
+      error: 'Internal Server Error',
+      message: 'Unable to update submission.',
     });
   }
 }

--- a/src/pages/api/sumsub/access-token.ts
+++ b/src/pages/api/sumsub/access-token.ts
@@ -1,6 +1,9 @@
 import axios from 'axios';
 import type { NextApiResponse } from 'next';
 
+import logger from '@/lib/logger';
+import { safeStringify } from '@/utils/safeStringify';
+
 import { type NextApiRequestWithUser } from '@/features/auth/types';
 import { withAuth } from '@/features/auth/utils/withAuth';
 import { SUMSUB_BASE_URL } from '@/features/kyc/constants/SUMSUB_BASE_URL';
@@ -51,9 +54,10 @@ const handler = async (req: NextApiRequestWithUser, res: NextApiResponse) => {
 
     return res.status(200).json(result);
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : 'Internal server error';
-    return res.status(400).json({ message });
+    logger.error(
+      `Unable to create Sumsub access token: ${safeStringify(error)}`,
+    );
+    return res.status(500).json({ message: 'Internal Server Error' });
   }
 };
 

--- a/src/pages/api/user/pfps.ts
+++ b/src/pages/api/user/pfps.ts
@@ -38,6 +38,6 @@ export default async function getAllUsers(
     logger.error(
       `Error occurred while fetching user details: ${safeStringify(error)}`,
     );
-    return res.status(500).json({ error: error.message });
+    return res.status(500).json({ error: 'Internal Server Error' });
   }
 }

--- a/src/pages/api/user/resolve-privy-dids.ts
+++ b/src/pages/api/user/resolve-privy-dids.ts
@@ -2087,7 +2087,7 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
       `Error resolving userIds from privyDids: ${safeStringify(error)}`,
     );
     return res.status(500).json({
-      error: error?.message || 'Internal server error',
+      error: 'Internal Server Error',
       message: 'Error occurred while resolving user IDs from privyDids.',
     });
   }

--- a/src/pages/api/user/update.ts
+++ b/src/pages/api/user/update.ts
@@ -81,7 +81,7 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
       `Error occurred while updating user ${userId}: ${safeStringify(error)}`,
     );
     return res.status(400).json({
-      message: `Error occurred while updating user ${userId}: ${error.message}`,
+      message: 'Error occurred while updating the user.',
     });
   }
 }


### PR DESCRIPTION
## What does this PR do?
- Changes `error.message` to "Internal Server Error" to prevent internal errors from leaking to the client and logs the `error.message` whereever necessary

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - API error responses now use generic messages instead of exposing internal exception details or identifiers.
  - Unexpected failures consistently return appropriate server-error responses.
- **Bug Fixes**
  - Added safer server-side error logging for selected endpoints while preserving useful diagnostics.
  - Standardized failure messaging across grant, submission, listing, user, export, wallet, and other operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->