### PR TITLE
fix(listings): preserve explicit sort order

### DIFF
--- a/src/app/api/listings/route.ts
+++ b/src/app/api/listings/route.ts
@@ -13,7 +13,10 @@ import {
   listingSelect,
   QueryParamsSchema,
 } from '@/features/listings/constants/schema';
-import { buildListingQuery } from '@/features/listings/utils/query-builder';
+import {
+  buildListingQuery,
+  shouldPrioritizeFeatured,
+} from '@/features/listings/utils/query-builder';
 import { reorderFeaturedOngoing } from '@/features/listings/utils/reorderFeaturedOngoing';
 
 export async function GET(request: NextRequest) {
@@ -85,7 +88,9 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    const reorderedListings = reorderFeaturedOngoing(listings);
+    const orderedListings = shouldPrioritizeFeatured(queryData)
+      ? reorderFeaturedOngoing(listings)
+      : listings;
 
     const isBookmarksContext = queryData.context === 'bookmarks';
     const headersInit = isBookmarksContext
@@ -98,7 +103,7 @@ export async function GET(request: NextRequest) {
           Vary: 'Cookie',
         };
 
-    return NextResponse.json(reorderedListings, {
+    return NextResponse.json(orderedListings, {
       headers: headersInit,
     });
   } catch (error) {

--- a/src/features/listings/utils/query-builder.ts
+++ b/src/features/listings/utils/query-builder.ts
@@ -34,6 +34,16 @@ interface ListingQueryResult {
   readonly take?: number;
 }
 
+export function shouldPrioritizeFeatured(
+  args: Pick<BuildListingQueryArgs, 'sortBy' | 'order' | 'status'>,
+): boolean {
+  return (
+    args.sortBy === 'Date' &&
+    args.order === 'asc' &&
+    (args.status === 'open' || args.status === 'all')
+  );
+}
+
 function getSkillFilter(
   category: z.infer<typeof ListingCategorySchema>,
 ): BountiesWhereInput | null {
@@ -141,10 +151,7 @@ function getOrderBy(
   }
 
   // add isFeatured prioritization only for default sorting (date + asc) and open or all status
-  const isDefaultSort =
-    sortBy === 'Date' &&
-    order === 'asc' &&
-    (status === 'open' || status === 'all');
+  const isDefaultSort = shouldPrioritizeFeatured(args);
 
   return isDefaultSort ? [{ isFeatured: 'desc' }, primarySort] : primarySort;
 }


### PR DESCRIPTION
## What does this PR do?

Preserves the user's selected listing sort instead of unconditionally moving featured, ongoing listings to the front of every response.

The query builder intentionally prioritizes featured listings only for the default ordering (`Date`, ascending, with an `open` or `all` status). The API route previously called `reorderFeaturedOngoing` for every request after Prisma had applied the requested order. That second pass could silently override explicit `Prize`, `Submissions`, `Status`, and descending `Date` sorts.

This PR extracts the existing default-sort rule into `shouldPrioritizeFeatured` and uses the same predicate in both places:

- the Prisma `orderBy` construction
- the response-level pass that keeps expired or completed featured listings from being promoted

Custom sorts now retain the database order, while the existing default featured-listing behavior remains unchanged.

## Where should the reviewer start?

1. `src/features/listings/utils/query-builder.ts` — the shared `shouldPrioritizeFeatured` rule and its use in `getOrderBy`
2. `src/app/api/listings/route.ts` — conditional response reordering

## How should this be manually tested?

1. Open the listings page with status set to **Open**.
2. Select **Prize** ascending and confirm a higher-value featured listing no longer jumps ahead of lower-value listings.
3. Repeat with **Submissions**, **Status**, and **Date** descending; each result should follow the selected order.
4. Return to the default **Date** ascending sort and confirm ongoing featured listings are still prioritized.
5. With status set to **All**, confirm expired or completed featured listings are not promoted by the response-level reorder.

Validation performed locally:

- `pnpm check-types` — passed
- `pnpm lint` — completed with 0 errors
- `pnpm exec oxfmt --check src/app/api/listings/route.ts src/features/listings/utils/query-builder.ts` — passed
- `git diff --check` — passed

## Any background context you want to provide?

The mismatch existed because the database layer and response layer independently decided whether featured listings should be prioritized. Centralizing that decision prevents the two layers from drifting again.

## What are the relevant issues?

No linked issue. This was found while auditing the current listing query and response ordering paths. Existing open issues and pull requests were checked for overlap before implementation.

## Screenshots (if appropriate)

Not applicable; this is an API ordering correction with no visual layout changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Featured ongoing listings are now prioritized only when the default sorting and status filters are selected.
  - Results preserve the requested database order for other sorting and filtering combinations.
  - Listing order behavior is now more consistent across different search criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->