### PR TITLE
Tweet stats caching and minor updates

### DIFF
--- a/src/features/sponsor-dashboard/components/Submissions/Details.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/Details.tsx
@@ -64,9 +64,13 @@ export const Details = ({ bounty, isHackathonPage }: Props) => {
                   : '-'
               }
             />
-            {isTweetStatusUrl(selectedSubmission?.link) && (
-              <TweetStats submissionId={selectedSubmission!.id} type="link" />
-            )}
+            {selectedSubmission &&
+              isTweetStatusUrl(selectedSubmission.link) && (
+                <TweetStats
+                  source="link"
+                  submissionId={selectedSubmission.id}
+                />
+              )}
             <InfoBox
               label="Tweet Link"
               content={
@@ -75,9 +79,13 @@ export const Details = ({ bounty, isHackathonPage }: Props) => {
                   : '-'
               }
             />
-            {isTweetStatusUrl(selectedSubmission?.tweet) && (
-              <TweetStats submissionId={selectedSubmission!.id} type="tweet" />
-            )}
+            {selectedSubmission &&
+              isTweetStatusUrl(selectedSubmission.tweet) && (
+                <TweetStats
+                  source="tweet"
+                  submissionId={selectedSubmission.id}
+                />
+              )}
           </>
         )}
         {bounty?.compensationType !== 'fixed' && (

--- a/src/features/sponsor-dashboard/components/Submissions/TweetStats.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/TweetStats.tsx
@@ -1,3 +1,5 @@
+import { useQuery } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 import {
   Eye,
   Heart,
@@ -6,7 +8,8 @@ import {
   Loader2,
   AlertCircle,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+
+import { api } from '@/lib/api';
 
 interface TweetMetrics {
   views: number;
@@ -17,6 +20,20 @@ interface TweetMetrics {
   isAvailable?: boolean;
 }
 
+interface TweetStatsResponse {
+  data: TweetMetrics;
+}
+
+const TWEET_STATS_CACHE_TIME = 24 * 60 * 60 * 1000;
+
+const getTweetStatsErrorMessage = (error: unknown): string => {
+  if (isAxiosError<{ message?: string }>(error)) {
+    return error.response?.data?.message || 'Failed to fetch tweet statistics';
+  }
+
+  return error instanceof Error ? error.message : 'Error loading stats';
+};
+
 export const TweetStats = ({
   submissionId,
   type,
@@ -24,47 +41,31 @@ export const TweetStats = ({
   submissionId: string;
   type: 'link' | 'tweet';
 }) => {
-  const [metrics, setMetrics] = useState<TweetMetrics | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    data: metrics,
+    error,
+    isLoading,
+  } = useQuery({
+    queryKey: ['tweet-stats', submissionId, type],
+    queryFn: async ({ signal }): Promise<TweetMetrics> => {
+      const response = await api.get<TweetStatsResponse>(
+        '/api/twitter/tweet-stats',
+        {
+          params: { submissionId, type },
+          signal,
+        },
+      );
 
-  useEffect(() => {
-    let active = true;
-    const fetchStats = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch(
-          `/api/twitter/tweet-stats?submissionId=${submissionId}&type=${type}`,
-        );
-        if (!res.ok) {
-          const errData = await res.json().catch(() => ({}));
-          throw new Error(
-            errData.message || 'Failed to fetch tweet statistics',
-          );
-        }
-        const json = await res.json();
-        if (active) {
-          setMetrics(json.data);
-        }
-      } catch (err: any) {
-        if (active) {
-          setError(err.message || 'Error loading stats');
-        }
-      } finally {
-        if (active) {
-          setLoading(false);
-        }
-      }
-    };
+      return response.data.data;
+    },
+    staleTime: TWEET_STATS_CACHE_TIME,
+    gcTime: TWEET_STATS_CACHE_TIME,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: false,
+  });
 
-    fetchStats();
-    return () => {
-      active = false;
-    };
-  }, [submissionId, type]);
-
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="mb-4 flex max-w-md animate-pulse items-center space-x-2 rounded-xl border border-slate-100 bg-slate-50/50 px-3 py-2.5">
         <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
@@ -79,7 +80,9 @@ export const TweetStats = ({
     return (
       <div className="mb-4 flex max-w-md items-center space-x-2 rounded-xl border border-red-100/50 bg-red-50/30 px-3 py-2.5">
         <AlertCircle className="h-4 w-4 text-red-500" />
-        <span className="text-xs font-medium text-red-600">{error}</span>
+        <span className="text-xs font-medium text-red-600">
+          {getTweetStatsErrorMessage(error)}
+        </span>
       </div>
     );
   }

--- a/src/features/sponsor-dashboard/components/Submissions/TweetStats.tsx
+++ b/src/features/sponsor-dashboard/components/Submissions/TweetStats.tsx
@@ -9,6 +9,7 @@ import {
   AlertCircle,
 } from 'lucide-react';
 
+import { Button } from '@/components/ui/button';
 import { api } from '@/lib/api';
 
 interface TweetMetrics {
@@ -16,12 +17,13 @@ interface TweetMetrics {
   likes: number;
   retweets: number;
   comments: number;
-  isMocked: boolean;
   isAvailable?: boolean;
 }
 
+type TweetSource = 'link' | 'tweet';
+
 interface TweetStatsResponse {
-  data: TweetMetrics;
+  data: Record<TweetSource, TweetMetrics | null>;
 }
 
 const TWEET_STATS_CACHE_TIME = 24 * 60 * 60 * 1000;
@@ -36,22 +38,23 @@ const getTweetStatsErrorMessage = (error: unknown): string => {
 
 export const TweetStats = ({
   submissionId,
-  type,
+  source,
 }: {
   submissionId: string;
-  type: 'link' | 'tweet';
+  source: TweetSource;
 }) => {
   const {
-    data: metrics,
+    data: statsBySource,
     error,
     isLoading,
+    refetch,
   } = useQuery({
-    queryKey: ['tweet-stats', submissionId, type],
-    queryFn: async ({ signal }): Promise<TweetMetrics> => {
+    queryKey: ['tweet-stats', submissionId],
+    queryFn: async ({ signal }): Promise<TweetStatsResponse['data']> => {
       const response = await api.get<TweetStatsResponse>(
         '/api/twitter/tweet-stats',
         {
-          params: { submissionId, type },
+          params: { submissionId },
           signal,
         },
       );
@@ -67,9 +70,16 @@ export const TweetStats = ({
 
   if (isLoading) {
     return (
-      <div className="mb-4 flex max-w-md animate-pulse items-center space-x-2 rounded-xl border border-slate-100 bg-slate-50/50 px-3 py-2.5">
-        <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
-        <span className="text-xs font-medium text-slate-400">
+      <div
+        aria-live="polite"
+        className="mb-4 flex max-w-md items-center gap-2 rounded-xl border border-slate-100 bg-slate-50/50 px-3 py-2.5 motion-safe:animate-pulse dark:border-slate-800 dark:bg-slate-900/40"
+        role="status"
+      >
+        <Loader2
+          aria-hidden
+          className="h-4 w-4 text-slate-400 motion-safe:animate-spin"
+        />
+        <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
           Fetching X post metrics...
         </span>
       </div>
@@ -78,17 +88,57 @@ export const TweetStats = ({
 
   if (error) {
     return (
-      <div className="mb-4 flex max-w-md items-center space-x-2 rounded-xl border border-red-100/50 bg-red-50/30 px-3 py-2.5">
-        <AlertCircle className="h-4 w-4 text-red-500" />
-        <span className="text-xs font-medium text-red-600">
+      <div
+        className="mb-4 flex max-w-md items-center gap-3 rounded-xl border border-red-200 bg-red-50 p-3 dark:border-red-900/60 dark:bg-red-950/30"
+        role="alert"
+      >
+        <AlertCircle
+          aria-hidden
+          className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400"
+        />
+        <p className="flex-1 text-xs font-medium text-red-700 dark:text-red-300">
           {getTweetStatsErrorMessage(error)}
-        </span>
+        </p>
+        <Button
+          onClick={() => void refetch()}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          Try again
+        </Button>
       </div>
     );
   }
 
-  if (!metrics) return null;
+  if (!statsBySource) return null;
 
+  const metrics = statsBySource[source];
+
+  if (!metrics) {
+    return (
+      <div className="mb-4 flex max-w-md items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 p-3 dark:border-slate-800 dark:bg-slate-900/40">
+        <AlertCircle
+          aria-hidden
+          className="h-4 w-4 text-slate-500 dark:text-slate-400"
+        />
+        <p className="text-xs font-medium text-slate-600 dark:text-slate-300">
+          No X post stats are available for this submission.
+        </p>
+      </div>
+    );
+  }
+
+  return <TweetStatsCard metrics={metrics} source={source} />;
+};
+
+const TweetStatsCard = ({
+  metrics,
+  source,
+}: {
+  metrics: TweetMetrics;
+  source: TweetSource;
+}) => {
   const formatNumber = (num: number) => {
     if (num >= 1000000) {
       return (num / 1000000).toFixed(1) + 'M';
@@ -100,21 +150,20 @@ export const TweetStats = ({
   };
 
   return (
-    <div className="group relative mb-4 max-w-md overflow-hidden rounded-xl border border-slate-100 bg-white p-3 shadow-[0_1px_3px_rgba(0,0,0,0.02)] transition-all duration-200 hover:border-slate-200/80 hover:bg-slate-50/30 hover:shadow-md">
+    <div className="group relative mb-4 max-w-md overflow-hidden rounded-xl border border-slate-100 bg-white p-3 shadow-[0_1px_3px_rgba(0,0,0,0.02)] transition-all duration-200 hover:border-slate-200/80 hover:bg-slate-50/30 hover:shadow-md dark:border-slate-800 dark:bg-slate-950 dark:hover:border-slate-700 dark:hover:bg-slate-900/40">
       <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center space-x-1.5">
-          <svg className="h-3 w-3 fill-slate-700" viewBox="0 0 24 24">
+          <svg
+            aria-hidden
+            className="h-3 w-3 fill-slate-700 dark:fill-slate-300"
+            viewBox="0 0 24 24"
+          >
             <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
           </svg>
           <span className="text-[10px] font-bold tracking-wider text-slate-500 uppercase">
-            X Post Engagement
+            {source === 'link' ? 'Main Submission' : 'Tweet Link'} · X
           </span>
         </div>
-        {metrics.isMocked && (
-          <span className="rounded-full bg-amber-50 px-1.5 py-0.5 text-[9px] font-medium text-amber-600 dark:bg-amber-950/30 dark:text-amber-400">
-            Simulated
-          </span>
-        )}
         {metrics.isAvailable === false && (
           <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[9px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-400">
             Unavailable
@@ -124,32 +173,35 @@ export const TweetStats = ({
 
       <div className="grid grid-cols-4 gap-2 text-center">
         <div className="flex flex-col items-center justify-center rounded-lg p-1.5 transition-colors duration-150 hover:bg-slate-100/50">
-          <Eye className="mb-1 h-4 w-4 text-blue-500" />
-          <span className="text-xs font-semibold text-slate-700">
+          <Eye aria-hidden className="mb-1 h-4 w-4 text-blue-500" />
+          <span className="text-xs font-semibold text-slate-700 dark:text-slate-200">
             {formatNumber(metrics.views)}
           </span>
           <span className="text-[9px] font-medium text-slate-400">Views</span>
         </div>
 
         <div className="flex flex-col items-center justify-center rounded-lg p-1.5 transition-colors duration-150 hover:bg-slate-100/50">
-          <Heart className="mb-1 h-4 w-4 fill-rose-500/10 text-rose-500" />
-          <span className="text-xs font-semibold text-slate-700">
+          <Heart
+            aria-hidden
+            className="mb-1 h-4 w-4 fill-rose-500/10 text-rose-500"
+          />
+          <span className="text-xs font-semibold text-slate-700 dark:text-slate-200">
             {formatNumber(metrics.likes)}
           </span>
           <span className="text-[9px] font-medium text-slate-400">Likes</span>
         </div>
 
         <div className="flex flex-col items-center justify-center rounded-lg p-1.5 transition-colors duration-150 hover:bg-slate-100/50">
-          <Repeat className="mb-1 h-4 w-4 text-emerald-500" />
-          <span className="text-xs font-semibold text-slate-700">
+          <Repeat aria-hidden className="mb-1 h-4 w-4 text-emerald-500" />
+          <span className="text-xs font-semibold text-slate-700 dark:text-slate-200">
             {formatNumber(metrics.retweets)}
           </span>
           <span className="text-[9px] font-medium text-slate-400">Reposts</span>
         </div>
 
         <div className="flex flex-col items-center justify-center rounded-lg p-1.5 transition-colors duration-150 hover:bg-slate-100/50">
-          <MessageSquare className="mb-1 h-4 w-4 text-sky-500" />
-          <span className="text-xs font-semibold text-slate-700">
+          <MessageSquare aria-hidden className="mb-1 h-4 w-4 text-sky-500" />
+          <span className="text-xs font-semibold text-slate-700 dark:text-slate-200">
             {formatNumber(metrics.comments)}
           </span>
           <span className="text-[9px] font-medium text-slate-400">Replies</span>

--- a/src/pages/api/twitter/tweet-stats.ts
+++ b/src/pages/api/twitter/tweet-stats.ts
@@ -5,8 +5,8 @@ import logger from '@/lib/logger';
 import { prisma } from '@/prisma';
 import { safeStringify } from '@/utils/safeStringify';
 
-import { type NextApiRequestWithUser } from '@/features/auth/types';
-import { withAuth } from '@/features/auth/utils/withAuth';
+import { type NextApiRequestWithSponsor } from '@/features/auth/types';
+import { withSponsorAuth } from '@/features/auth/utils/withSponsorAuth';
 
 function extractTweetId(url: string): string | null {
   if (!url || typeof url !== 'string') return null;
@@ -46,7 +46,23 @@ const tweetStatsQuerySchema = z.object({
   }),
 });
 
-async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
+async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({
+      error: 'Method Not Allowed',
+      message: 'Only GET requests are supported',
+    });
+  }
+
+  if (!req.userSponsorId) {
+    logger.warn(`Tweet stats access denied for user ${req.userId}`);
+    return res.status(403).json({
+      error: 'Unauthorized',
+      message: 'User does not have an active sponsor',
+    });
+  }
+
   const validation = tweetStatsQuerySchema.safeParse(req.query);
 
   if (!validation.success) {
@@ -64,13 +80,17 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
 
   let tweetUrl: string | null = null;
   try {
-    const submission = await prisma.submission.findUnique({
-      where: { id: submissionId },
+    const submission = await prisma.submission.findFirst({
+      where: {
+        id: submissionId,
+      },
       select: { link: true, tweet: true },
     });
 
     if (!submission) {
-      logger.warn(`Submission not found: ${submissionId}`);
+      logger.warn(
+        `Submission ${submissionId} not found or inaccessible to user ${req.userId}`,
+      );
       return res.status(404).json({
         error: 'Submission not found',
         message: 'Submission not found',
@@ -228,4 +248,4 @@ async function handler(req: NextApiRequestWithUser, res: NextApiResponse) {
   }
 }
 
-export default withAuth(handler);
+export default withSponsorAuth(handler);

--- a/src/pages/api/twitter/tweet-stats.ts
+++ b/src/pages/api/twitter/tweet-stats.ts
@@ -41,9 +41,58 @@ const tweetStatsQuerySchema = z.object({
     })
     .trim()
     .min(1, 'Missing or invalid submissionId parameter'),
-  type: z.enum(['link', 'tweet'], {
-    required_error: 'Missing or invalid type parameter',
-  }),
+});
+
+type TweetSource = 'link' | 'tweet';
+
+interface TwitterPublicMetrics {
+  impression_count?: number;
+  like_count?: number;
+  quote_count?: number;
+  reply_count?: number;
+  retweet_count?: number;
+}
+
+interface TweetMetrics {
+  views: number;
+  likes: number;
+  retweets: number;
+  comments: number;
+  isAvailable: boolean;
+}
+
+const unavailableMetrics = (): TweetMetrics => ({
+  views: 0,
+  likes: 0,
+  retweets: 0,
+  comments: 0,
+  isAvailable: false,
+});
+
+const toTweetMetrics = (
+  metrics: TwitterPublicMetrics | undefined,
+): TweetMetrics => {
+  if (!metrics) return unavailableMetrics();
+
+  return {
+    views: metrics.impression_count || 0,
+    likes: metrics.like_count || 0,
+    retweets: (metrics.retweet_count || 0) + (metrics.quote_count || 0),
+    comments: metrics.reply_count || 0,
+    isAvailable: true,
+  };
+};
+
+const buildStatsBySource = (
+  tweetIds: Record<TweetSource, string | null>,
+  metricsByTweetId: Map<string, TwitterPublicMetrics> = new Map(),
+): Record<TweetSource, TweetMetrics | null> => ({
+  link: tweetIds.link
+    ? toTweetMetrics(metricsByTweetId.get(tweetIds.link))
+    : null,
+  tweet: tweetIds.tweet
+    ? toTweetMetrics(metricsByTweetId.get(tweetIds.tweet))
+    : null,
 });
 
 async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
@@ -76,18 +125,18 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     });
   }
 
-  const { submissionId, type } = validation.data;
+  const { submissionId } = validation.data;
 
-  let tweetUrl: string | null = null;
+  let submission: { link: string | null; tweet: string | null };
   try {
-    const submission = await prisma.submission.findFirst({
+    const foundSubmission = await prisma.submission.findFirst({
       where: {
         id: submissionId,
       },
       select: { link: true, tweet: true },
     });
 
-    if (!submission) {
+    if (!foundSubmission) {
       logger.warn(
         `Submission ${submissionId} not found or inaccessible to user ${req.userId}`,
       );
@@ -97,7 +146,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       });
     }
 
-    tweetUrl = type === 'link' ? submission.link : submission.tweet;
+    submission = foundSubmission;
   } catch (error: any) {
     logger.error(
       `Error querying submission ${submissionId}: ${safeStringify(error)}`,
@@ -108,35 +157,22 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
     });
   }
 
-  if (!tweetUrl) {
-    return res.status(200).json({
-      data: {
-        views: 0,
-        likes: 0,
-        retweets: 0,
-        comments: 0,
-        isMocked: false,
-        isAvailable: false,
-      },
-      message: 'No URL found in submission',
-    });
-  }
+  const tweetIds: Record<TweetSource, string | null> = {
+    link: submission.link ? extractTweetId(submission.link) : null,
+    tweet: submission.tweet ? extractTweetId(submission.tweet) : null,
+  };
+  const uniqueTweetIds = [
+    ...new Set(
+      Object.values(tweetIds).filter((tweetId): tweetId is string =>
+        Boolean(tweetId),
+      ),
+    ),
+  ];
 
-  const tweetId = extractTweetId(tweetUrl);
-  if (!tweetId) {
-    logger.warn(
-      `Invalid Twitter/X post URL in submission ${submissionId} ${type}: ${tweetUrl}`,
-    );
+  if (uniqueTweetIds.length === 0) {
     return res.status(200).json({
-      data: {
-        views: 0,
-        likes: 0,
-        retweets: 0,
-        comments: 0,
-        isMocked: false,
-        isAvailable: false,
-      },
-      message: 'Invalid Twitter/X post URL',
+      data: buildStatsBySource(tweetIds),
+      message: 'No valid Twitter/X post URLs found in submission',
     });
   }
 
@@ -148,14 +184,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       'Twitter/X API bearer token is not configured. Returning 0 metrics.',
     );
     return res.status(200).json({
-      data: {
-        views: 0,
-        likes: 0,
-        retweets: 0,
-        comments: 0,
-        isMocked: false,
-        isAvailable: false,
-      },
+      data: buildStatsBySource(tweetIds),
       message: 'Operation successful',
     });
   }
@@ -166,62 +195,46 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   }, 5000);
 
   try {
-    const response = await fetch(
-      `https://api.twitter.com/2/tweets/${tweetId}?tweet.fields=public_metrics`,
-      {
-        headers: {
-          Authorization: `Bearer ${bearerToken}`,
-        },
-        signal: controller.signal,
+    const twitterUrl = new URL('https://api.twitter.com/2/tweets');
+    twitterUrl.searchParams.set('ids', uniqueTweetIds.join(','));
+    twitterUrl.searchParams.set('tweet.fields', 'public_metrics');
+
+    const response = await fetch(twitterUrl, {
+      headers: {
+        Authorization: `Bearer ${bearerToken}`,
       },
-    );
+      signal: controller.signal,
+    });
 
     if (!response.ok) {
       logger.error(
         `Twitter API responded with status ${response.status}: ${await response.text()}`,
       );
       return res.status(200).json({
-        data: {
-          views: 0,
-          likes: 0,
-          retweets: 0,
-          comments: 0,
-          isMocked: false,
-          isAvailable: false,
-        },
+        data: buildStatsBySource(tweetIds),
         message: 'Operation successful',
       });
     }
 
-    const json = await response.json();
-    const metrics = json.data?.public_metrics;
+    const json = (await response.json()) as {
+      data?: Array<{ id?: string; public_metrics?: TwitterPublicMetrics }>;
+    };
+    const metricsByTweetId = new Map<string, TwitterPublicMetrics>();
 
-    if (!metrics) {
+    for (const tweet of json.data || []) {
+      if (tweet.id && tweet.public_metrics) {
+        metricsByTweetId.set(tweet.id, tweet.public_metrics);
+      }
+    }
+
+    if (metricsByTweetId.size === 0) {
       logger.warn(
-        `Metrics not found in Twitter API response for tweetId: ${tweetId}`,
+        `Metrics not found in Twitter API response for tweetIds: ${uniqueTweetIds.join(',')}`,
       );
-      return res.status(200).json({
-        data: {
-          views: 0,
-          likes: 0,
-          retweets: 0,
-          comments: 0,
-          isMocked: false,
-          isAvailable: false,
-        },
-        message: 'Operation successful',
-      });
     }
 
     return res.status(200).json({
-      data: {
-        views: metrics.impression_count || 0,
-        likes: metrics.like_count || 0,
-        retweets: (metrics.retweet_count || 0) + (metrics.quote_count || 0),
-        comments: metrics.reply_count || 0,
-        isMocked: false,
-        isAvailable: true,
-      },
+      data: buildStatsBySource(tweetIds, metricsByTweetId),
       message: 'Operation successful',
     });
   } catch (error: any) {
@@ -233,14 +246,7 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
       );
     }
     return res.status(200).json({
-      data: {
-        views: 0,
-        likes: 0,
-        retweets: 0,
-        comments: 0,
-        isMocked: false,
-        isAvailable: false,
-      },
+      data: buildStatsBySource(tweetIds),
       message: 'Operation successful',
     });
   } finally {


### PR DESCRIPTION
## What does this PR do?
- Switches useEffect fetch to react query with 24 hours in memory cache.
- changes auth to sponsor auth
- deduplication of tweet stats into one fetch and render differently using same react query key

## Where should the reviewer start?

## How should this be manually tested?

## Any background context you want to provide?

## What are the relevant issues?

## Screenshots (if appropriate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated tweet statistics to display separate metrics for linked posts and main submissions.
  * Added clearer loading and unavailable states, including retry support when statistics cannot be retrieved.
  * Improved accessibility and dark-mode presentation for statistics cards.

* **Bug Fixes**
  * Improved handling of missing, invalid, or unavailable post data.
  * Combined and deduplicated post metrics for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->