### PR TITLE
fix: add Redis locks to payment endpoints to prevent double-spend

### DIFF
--- a/src/pages/api/sponsor-dashboard/grants/add-tranche.ts
+++ b/src/pages/api/sponsor-dashboard/grants/add-tranche.ts
@@ -1,6 +1,7 @@
 import type { NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
+import { LockNotAcquiredError, withRedisLock } from '@/lib/with-redis-lock';
 import { prisma } from '@/prisma';
 import { getTokenBySymbol } from '@/server/tokenList';
 import { safeStringify } from '@/utils/safeStringify';
@@ -39,122 +40,134 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   }
 
   try {
-    logger.info(`Fetching grant application with ID: ${id}`);
-    const currentApplication = await prisma.grantApplication.findUnique({
-      where: { id },
-      include: { grant: true },
-    });
+    return await withRedisLock(
+      `locks:add-tranche:${id}`,
+      async () => {
+        logger.info(`Fetching grant application with ID: ${id}`);
+        const currentApplication = await prisma.grantApplication.findUnique({
+          where: { id },
+          include: { grant: true },
+        });
 
-    if (!currentApplication) {
-      logger.info(`Grant application not found with ID: ${id}`);
-      return res.status(404).json({ error: 'Grant application not found' });
-    }
+        if (!currentApplication) {
+          logger.info(`Grant application not found with ID: ${id}`);
+          return res.status(404).json({ error: 'Grant application not found' });
+        }
 
-    const { error } = await checkGrantSponsorAuth(
-      userSponsorId,
-      currentApplication.grantId,
+        const { error } = await checkGrantSponsorAuth(
+          userSponsorId,
+          currentApplication.grantId,
+        );
+
+        if (error) {
+          return res.status(error.status).json({ error: error.message });
+        }
+
+        const remainingAmount =
+          currentApplication.approvedAmount - currentApplication.totalPaid;
+        if (parsedTrancheAmount > remainingAmount) {
+          return res.status(400).json({
+            error: `Tranche amount exceeds remaining approved amount (${remainingAmount})`,
+          });
+        }
+
+        const normalizedTxId = normalizePaymentTxId(txId);
+        const alreadyUsedTxIds = await findUsedPaymentTxIds([normalizedTxId]);
+        if (alreadyUsedTxIds.length > 0) {
+          return res.status(400).json({
+            error: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
+          });
+        }
+
+        const dbToken = await getTokenBySymbol(currentApplication.grant.token);
+        if (!dbToken) {
+          return res.status(400).json({
+            error: "Token doesn't exist for this grant",
+          });
+        }
+
+        let tokenPriceUSD: number | undefined;
+        try {
+          tokenPriceUSD = await fetchTokenUSDValue(dbToken.mintAddress);
+        } catch (err) {
+          logger.warn(
+            `Failed to fetch token price for ${dbToken.tokenSymbol}, falling back to fixed tolerance`,
+          );
+        }
+
+        const validationResult = await validatePayment({
+          txId: normalizedTxId,
+          recipientPublicKey: currentApplication.walletAddress,
+          expectedAmount: parsedTrancheAmount,
+          tokenMint: dbToken,
+          tokenPriceUSD,
+        });
+
+        if (!validationResult.isValid) {
+          return res.status(400).json({
+            error: validationResult.error,
+            message: `Transaction validation failed: ${validationResult.error}`,
+          });
+        }
+
+        let updatedPaymentDetails = currentApplication.paymentDetails || [];
+        if (!Array.isArray(updatedPaymentDetails)) {
+          updatedPaymentDetails = [];
+        }
+
+        updatedPaymentDetails.push({
+          txId: txId || null,
+          tranche: currentApplication.totalTranches + 1,
+          amount: parsedTrancheAmount,
+        });
+
+        const newTotalPaid =
+          currentApplication.totalPaid + parsedTrancheAmount;
+        const isFullyPaid = newTotalPaid >= currentApplication.approvedAmount;
+
+        logger.info('Updating payment details and grant information');
+        const result = await prisma.$transaction(async (tx) => {
+          const updatedGrantApplication = await tx.grantApplication.update({
+            where: { id },
+            data: {
+              totalPaid: {
+                increment: parsedTrancheAmount,
+              },
+              totalTranches: {
+                increment: 1,
+              },
+              paymentDetails: updatedPaymentDetails as any,
+              ...(isFullyPaid && { applicationStatus: 'Completed' }),
+            },
+            include: {
+              user: true,
+              grant: true,
+            },
+          });
+
+          return updatedGrantApplication;
+        });
+
+        await queueEmail({
+          type: 'grantPaymentReceived',
+          id,
+          triggeredBy: userId,
+          userId: currentApplication.userId,
+        });
+
+        logger.info(
+          `Payment details updated successfully for grant application ID: ${id}`,
+        );
+        return res.status(200).json(result);
+      },
+      { ttlSeconds: 300 },
     );
-
-    if (error) {
-      return res.status(error.status).json({ error: error.message });
-    }
-
-    const remainingAmount =
-      currentApplication.approvedAmount - currentApplication.totalPaid;
-    if (parsedTrancheAmount > remainingAmount) {
-      return res.status(400).json({
-        error: `Tranche amount exceeds remaining approved amount (${remainingAmount})`,
-      });
-    }
-
-    const normalizedTxId = normalizePaymentTxId(txId);
-    const alreadyUsedTxIds = await findUsedPaymentTxIds([normalizedTxId]);
-    if (alreadyUsedTxIds.length > 0) {
-      return res.status(400).json({
-        error: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
-      });
-    }
-
-    const dbToken = await getTokenBySymbol(currentApplication.grant.token);
-    if (!dbToken) {
-      return res.status(400).json({
-        error: "Token doesn't exist for this grant",
-      });
-    }
-
-    let tokenPriceUSD: number | undefined;
-    try {
-      tokenPriceUSD = await fetchTokenUSDValue(dbToken.mintAddress);
-    } catch (err) {
-      logger.warn(
-        `Failed to fetch token price for ${dbToken.tokenSymbol}, falling back to fixed tolerance`,
-      );
-    }
-
-    const validationResult = await validatePayment({
-      txId: normalizedTxId,
-      recipientPublicKey: currentApplication.walletAddress,
-      expectedAmount: parsedTrancheAmount,
-      tokenMint: dbToken,
-      tokenPriceUSD,
-    });
-
-    if (!validationResult.isValid) {
-      return res.status(400).json({
-        error: validationResult.error,
-        message: `Transaction validation failed: ${validationResult.error}`,
-      });
-    }
-
-    let updatedPaymentDetails = currentApplication.paymentDetails || [];
-    if (!Array.isArray(updatedPaymentDetails)) {
-      updatedPaymentDetails = [];
-    }
-
-    updatedPaymentDetails.push({
-      txId: txId || null,
-      tranche: currentApplication.totalTranches + 1,
-      amount: parsedTrancheAmount,
-    });
-
-    const newTotalPaid = currentApplication.totalPaid + parsedTrancheAmount;
-    const isFullyPaid = newTotalPaid >= currentApplication.approvedAmount;
-
-    logger.info('Updating payment details and grant information');
-    const result = await prisma.$transaction(async (tx) => {
-      const updatedGrantApplication = await tx.grantApplication.update({
-        where: { id },
-        data: {
-          totalPaid: {
-            increment: parsedTrancheAmount,
-          },
-          totalTranches: {
-            increment: 1,
-          },
-          paymentDetails: updatedPaymentDetails as any,
-          ...(isFullyPaid && { applicationStatus: 'Completed' }),
-        },
-        include: {
-          user: true,
-          grant: true,
-        },
-      });
-
-      return updatedGrantApplication;
-    });
-
-    await queueEmail({
-      type: 'grantPaymentReceived',
-      id,
-      triggeredBy: userId,
-      userId: currentApplication.userId,
-    });
-
-    logger.info(
-      `Payment details updated successfully for grant application ID: ${id}`,
-    );
-    return res.status(200).json(result);
   } catch (error: any) {
+    if (error instanceof LockNotAcquiredError) {
+      return res.status(409).json({
+        error: 'Payment processing already in progress for this application',
+      });
+    }
     logger.error(
       `Error occurred while updating payment for grant application ID: ${id}`,
       safeStringify(error),

--- a/src/pages/api/sponsor-dashboard/listings/verify-external-payment.ts
+++ b/src/pages/api/sponsor-dashboard/listings/verify-external-payment.ts
@@ -1,6 +1,7 @@
 import { type NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
+import { LockNotAcquiredError, withRedisLock } from '@/lib/with-redis-lock';
 import { prisma } from '@/prisma';
 import { getTokenBySymbol } from '@/server/tokenList';
 import { safeStringify } from '@/utils/safeStringify';
@@ -35,273 +36,295 @@ export const config = {
 async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   const userSponsorId = req.userSponsorId;
 
+  logger.debug(`Request body: ${safeStringify(req.body)}`);
+  let { paymentLinks } = req.body as VerifyPaymentsFormData;
+  const { listingId } = req.body as VerifyPaymentsFormData & {
+    listingId: string;
+  };
+
+  paymentLinks = paymentLinks.filter((p) => !!p.link);
+
+  if (!listingId) {
+    return res.status(400).json({ error: 'Listing ID is missing' });
+  }
+
   try {
-    logger.debug(`Request body: ${safeStringify(req.body)}`);
-    let { paymentLinks } = req.body as VerifyPaymentsFormData;
-    const { listingId } = req.body as VerifyPaymentsFormData & {
-      listingId: string;
-    };
-
-    paymentLinks = paymentLinks.filter((p) => !!p.link);
-
-    if (!listingId) {
-      return res.status(400).json({ error: 'Listing ID is missing' });
-    }
-
-    const { error } = await checkListingSponsorAuth(userSponsorId, listingId);
-    if (error) {
-      return res.status(error.status).json({ error: error.message });
-    }
-
-    const listing = await prisma.bounties.findUnique({
-      where: {
-        id: listingId,
-      },
-    });
-    const submissions = await prisma.submission.findMany({
-      where: {
-        id: {
-          in: paymentLinks.map((d) => d.submissionId),
-        },
-        isPaid: false,
-      },
-      include: {
-        user: true,
-      },
-    });
-
-    if (!listing) return res.status(400).json({ error: 'Listing not found' });
-
-    if (!listing.isWinnersAnnounced)
-      return res.status(400).json({ error: 'Listing not announced' });
-
-    const dbToken = await getTokenBySymbol(listing.token);
-    if (!dbToken) {
-      return res
-        .status(400)
-        .json({ error: "Token doesn't exist for this listing" });
-    }
-
-    let tokenPriceUSD: number | undefined;
-    try {
-      tokenPriceUSD = await fetchTokenUSDValue(dbToken.mintAddress);
-    } catch (err) {
-      logger.warn(
-        `Failed to fetch token price for ${dbToken.tokenSymbol}, falling back to fixed tolerance`,
-      );
-    }
-
-    const validationResults: ValidatePaymentResult[] = [];
-
-    const txIds = paymentLinks
-      .map((link) => link.txId)
-      .filter(Boolean)
-      .map(normalizePaymentTxId);
-    const duplicateTxIds = txIds.filter(
-      (txId, index) => txIds.indexOf(txId) !== index,
-    );
-    if (duplicateTxIds.length > 0) {
-      return res.status(400).json({
-        error: `Duplicate transaction IDs found: ${duplicateTxIds.join(', ')}`,
-      });
-    }
-
-    // Check globally across ALL submissions (paid and unpaid) to prevent
-    // transaction replay attacks where a txId from a paid submission is reused
-    // for a different winner.
-    if (txIds.length === 0) {
-      return res
-        .status(400)
-        .json({ error: 'No valid transaction IDs provided' });
-    }
-
-    const alreadyUsedTxIds = await findUsedPaymentTxIds(txIds);
-
-    if (alreadyUsedTxIds.length > 0) {
-      return res.status(400).json({
-        error: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
-      });
-    }
-
-    for (const paymentLink of paymentLinks) {
-      try {
-        logger.debug(
-          `Beginning External Payment Verification for submission ID: ${paymentLink.submissionId} with TxId: ${paymentLink.txId}`,
+    return await withRedisLock(
+      `locks:verify-external-payment:${listingId}`,
+      async () => {
+        const { error } = await checkListingSponsorAuth(
+          userSponsorId,
+          listingId,
         );
-
-        if (paymentLink.isVerified) {
-          validationResults.push({
-            submissionId: paymentLink.submissionId,
-            txId: paymentLink.txId,
-            status: 'ALREADY_VERIFIED',
-            message: 'Already Verified',
-          });
-          continue;
+        if (error) {
+          return res.status(error.status).json({ error: error.message });
         }
 
-        if (!paymentLink.txId) {
-          throw new Error('Invalid URL');
-        }
-
-        const submission = submissions.find(
-          (s) => s.id === paymentLink.submissionId,
-        );
-        if (!submission) throw new Error('Submission not found');
-
-        const {
-          user: { walletAddress },
-          winnerPosition,
-        } = submission;
-
-        if (!winnerPosition) {
-          logger.error('Submission has no winner position');
-          throw new Error('Submission has no winner position');
-        }
-
-        const winnerReward = (listing.rewards as Record<string, any>)?.[
-          winnerPosition + ''
-        ] as number;
-        if (!winnerReward) {
-          logger.error('Winner Position has no reward');
-          throw new Error('Winner Position has no reward');
-        }
-
-        const isProject = listing.type === 'project';
-        const existingPayments = (submission.paymentDetails as any[]) || [];
-        const totalAlreadyPaid = existingPayments.reduce(
-          (sum, payment) => sum + payment.amount,
-          0,
-        );
-        const remainingAmount = winnerReward - totalAlreadyPaid;
-
-        if (remainingAmount <= 0) {
-          throw new Error('This submission is already fully paid');
-        }
-
-        let expectedAmount = winnerReward;
-        if (isProject) {
-          expectedAmount = 0;
-        }
-
-        const rpcValidationResult: ValidationResult = await validatePayment({
-          txId: paymentLink.txId,
-          recipientPublicKey: walletAddress!,
-          expectedAmount,
-          tokenMint: dbToken,
-          tokenPriceUSD,
+        const listing = await prisma.bounties.findUnique({
+          where: {
+            id: listingId,
+          },
+        });
+        const submissions = await prisma.submission.findMany({
+          where: {
+            id: {
+              in: paymentLinks.map((d) => d.submissionId),
+            },
+            isPaid: false,
+          },
+          include: {
+            user: true,
+          },
         });
 
-        if (!rpcValidationResult.isValid) {
-          throw new Error(`Failed (${rpcValidationResult.error})`);
+        if (!listing)
+          return res.status(400).json({ error: 'Listing not found' });
+
+        if (!listing.isWinnersAnnounced)
+          return res.status(400).json({ error: 'Listing not announced' });
+
+        const dbToken = await getTokenBySymbol(listing.token);
+        if (!dbToken) {
+          return res
+            .status(400)
+            .json({ error: "Token doesn't exist for this listing" });
         }
 
-        const actualPaidAmount = isProject
-          ? rpcValidationResult.actualAmount || 0
-          : winnerReward;
+        let tokenPriceUSD: number | undefined;
+        try {
+          tokenPriceUSD = await fetchTokenUSDValue(dbToken.mintAddress);
+        } catch (err) {
+          logger.warn(
+            `Failed to fetch token price for ${dbToken.tokenSymbol}, falling back to fixed tolerance`,
+          );
+        }
 
-        if (isProject) {
-          if (actualPaidAmount <= 0) {
-            throw new Error('Invalid payment amount');
-          }
+        const validationResults: ValidatePaymentResult[] = [];
 
-          const maxAllowedAmount =
-            remainingAmount * (1 + PROJECT_PAYMENT_OVERPAY_TOLERANCE_PERCENT);
-          if (actualPaidAmount > maxAllowedAmount) {
-            throw new Error(
-              `Payment amount (${actualPaidAmount}) exceeds remaining amount (${remainingAmount})`,
+        const txIds = paymentLinks
+          .map((link) => link.txId)
+          .filter(Boolean)
+          .map(normalizePaymentTxId);
+        const duplicateTxIds = txIds.filter(
+          (txId, index) => txIds.indexOf(txId) !== index,
+        );
+        if (duplicateTxIds.length > 0) {
+          return res.status(400).json({
+            error: `Duplicate transaction IDs found: ${duplicateTxIds.join(', ')}`,
+          });
+        }
+
+        // Check globally across ALL submissions (paid and unpaid) to prevent
+        // transaction replay attacks where a txId from a paid submission is reused
+        // for a different winner.
+        if (txIds.length === 0) {
+          return res
+            .status(400)
+            .json({ error: 'No valid transaction IDs provided' });
+        }
+
+        const alreadyUsedTxIds = await findUsedPaymentTxIds(txIds);
+
+        if (alreadyUsedTxIds.length > 0) {
+          return res.status(400).json({
+            error: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
+          });
+        }
+
+        for (const paymentLink of paymentLinks) {
+          try {
+            logger.debug(
+              `Beginning External Payment Verification for submission ID: ${paymentLink.submissionId} with TxId: ${paymentLink.txId}`,
+            );
+
+            if (paymentLink.isVerified) {
+              validationResults.push({
+                submissionId: paymentLink.submissionId,
+                txId: paymentLink.txId,
+                status: 'ALREADY_VERIFIED',
+                message: 'Already Verified',
+              });
+              continue;
+            }
+
+            if (!paymentLink.txId) {
+              throw new Error('Invalid URL');
+            }
+
+            const submission = submissions.find(
+              (s) => s.id === paymentLink.submissionId,
+            );
+            if (!submission) throw new Error('Submission not found');
+
+            const {
+              user: { walletAddress },
+              winnerPosition,
+            } = submission;
+
+            if (!winnerPosition) {
+              logger.error('Submission has no winner position');
+              throw new Error('Submission has no winner position');
+            }
+
+            const winnerReward = (listing.rewards as Record<string, any>)?.[
+              winnerPosition + ''
+            ] as number;
+            if (!winnerReward) {
+              logger.error('Winner Position has no reward');
+              throw new Error('Winner Position has no reward');
+            }
+
+            const isProject = listing.type === 'project';
+            const existingPayments =
+              (submission.paymentDetails as any[]) || [];
+            const totalAlreadyPaid = existingPayments.reduce(
+              (sum, payment) => sum + payment.amount,
+              0,
+            );
+            const remainingAmount = winnerReward - totalAlreadyPaid;
+
+            if (remainingAmount <= 0) {
+              throw new Error('This submission is already fully paid');
+            }
+
+            let expectedAmount = winnerReward;
+            if (isProject) {
+              expectedAmount = 0;
+            }
+
+            const rpcValidationResult: ValidationResult =
+              await validatePayment({
+                txId: paymentLink.txId,
+                recipientPublicKey: walletAddress!,
+                expectedAmount,
+                tokenMint: dbToken,
+                tokenPriceUSD,
+              });
+
+            if (!rpcValidationResult.isValid) {
+              throw new Error(`Failed (${rpcValidationResult.error})`);
+            }
+
+            const actualPaidAmount = isProject
+              ? rpcValidationResult.actualAmount || 0
+              : winnerReward;
+
+            if (isProject) {
+              if (actualPaidAmount <= 0) {
+                throw new Error('Invalid payment amount');
+              }
+
+              const maxAllowedAmount =
+                remainingAmount *
+                (1 + PROJECT_PAYMENT_OVERPAY_TOLERANCE_PERCENT);
+              if (actualPaidAmount > maxAllowedAmount) {
+                throw new Error(
+                  `Payment amount (${actualPaidAmount}) exceeds remaining amount (${remainingAmount})`,
+                );
+              }
+            }
+
+            validationResults.push({
+              submissionId: paymentLink.submissionId,
+              txId: paymentLink.txId,
+              status: 'SUCCESS',
+              actualAmount: actualPaidAmount,
+            });
+
+            logger.info(
+              `External Payment Validation Successful for Submission ID: ${paymentLink.submissionId} with TxId: ${paymentLink.txId}`,
+            );
+            await wait(5000);
+          } catch (error: any) {
+            validationResults.push({
+              submissionId: paymentLink.submissionId,
+              txId: paymentLink.txId || '',
+              status: 'FAIL',
+              message: error.message,
+            });
+            await wait(5000);
+            logger.warn(
+              `External Payment Verification Failed for Submission ID: ${paymentLink.submissionId} with TxId: ${paymentLink.txId} with message: ${error.message}`,
             );
           }
         }
 
-        validationResults.push({
-          submissionId: paymentLink.submissionId,
-          txId: paymentLink.txId,
-          status: 'SUCCESS',
-          actualAmount: actualPaidAmount,
-        });
+        const successfulResultsBySubmission = validationResults
+          .filter((result) => result.status === 'SUCCESS')
+          .reduce(
+            (acc, result) => {
+              if (!acc[result.submissionId]) {
+                acc[result.submissionId] = [];
+              }
+              acc[result.submissionId]!.push(result);
+              return acc;
+            },
+            {} as Record<string, ValidatePaymentResult[]>,
+          );
 
-        logger.info(
-          `External Payment Validation Successful for Submission ID: ${paymentLink.submissionId} with TxId: ${paymentLink.txId}`,
-        );
-        await wait(5000);
-      } catch (error: any) {
-        validationResults.push({
-          submissionId: paymentLink.submissionId,
-          txId: paymentLink.txId || '',
-          status: 'FAIL',
-          message: error.message,
-        });
-        await wait(5000);
-        logger.warn(
-          `External Payment Verification Failed for Submission ID: ${paymentLink.submissionId} with TxId: ${paymentLink.txId} with message: ${error.message}`,
-        );
-      }
-    }
+        for (const [submissionId, results] of Object.entries(
+          successfulResultsBySubmission,
+        )) {
+          logger.debug(
+            `Updating submission with ID: ${submissionId} with ${results.length} new external payment(s)`,
+          );
 
-    const successfulResultsBySubmission = validationResults
-      .filter((result) => result.status === 'SUCCESS')
-      .reduce(
-        (acc, result) => {
-          if (!acc[result.submissionId]) {
-            acc[result.submissionId] = [];
-          }
-          acc[result.submissionId]!.push(result);
-          return acc;
-        },
-        {} as Record<string, ValidatePaymentResult[]>,
-      );
+          const submission = submissions.find((s) => s.id === submissionId);
+          if (!submission) continue;
 
-    for (const [submissionId, results] of Object.entries(
-      successfulResultsBySubmission,
-    )) {
-      logger.debug(
-        `Updating submission with ID: ${submissionId} with ${results.length} new external payment(s)`,
-      );
+          const winnerReward = (listing.rewards as Record<string, any>)?.[
+            submission.winnerPosition + ''
+          ] as number;
 
-      const submission = submissions.find((s) => s.id === submissionId);
-      if (!submission) continue;
+          const isProject = listing.type === 'project';
+          const existingPayments =
+            (submission.paymentDetails as any[]) || [];
 
-      const winnerReward = (listing.rewards as Record<string, any>)?.[
-        submission.winnerPosition + ''
-      ] as number;
+          const newPayments = results
+            .filter(
+              (
+                result,
+              ): result is ValidatePaymentResult & {
+                actualAmount: number;
+              } =>
+                typeof result.actualAmount === 'number' &&
+                result.actualAmount > 0,
+            )
+            .map((result, i) => ({
+              txId: result.txId,
+              amount: result.actualAmount,
+              tranche: isProject ? existingPayments.length + 1 + i : 1,
+            }));
 
-      const isProject = listing.type === 'project';
-      const existingPayments = (submission.paymentDetails as any[]) || [];
+          const allPayments = [...existingPayments, ...newPayments];
 
-      const newPayments = results
-        .filter(
-          (
-            result,
-          ): result is ValidatePaymentResult & { actualAmount: number } =>
-            typeof result.actualAmount === 'number' && result.actualAmount > 0,
-        )
-        .map((result, i) => ({
-          txId: result.txId,
-          amount: result.actualAmount,
-          tranche: isProject ? existingPayments.length + 1 + i : 1,
-        }));
+          const totalPaidAmount = allPayments.reduce(
+            (sum, payment) => sum + payment.amount,
+            0,
+          );
+          const isFullyPaid = totalPaidAmount >= winnerReward;
 
-      const allPayments = [...existingPayments, ...newPayments];
+          await prisma.submission.update({
+            where: {
+              id: submissionId,
+            },
+            data: {
+              isPaid: isFullyPaid,
+              paymentDetails: allPayments,
+            },
+          });
+        }
 
-      const totalPaidAmount = allPayments.reduce(
-        (sum, payment) => sum + payment.amount,
-        0,
-      );
-      const isFullyPaid = totalPaidAmount >= winnerReward;
-
-      await prisma.submission.update({
-        where: {
-          id: submissionId,
-        },
-        data: {
-          isPaid: isFullyPaid,
-          paymentDetails: allPayments,
-        },
+        return res.status(200).json({ validationResults });
+      },
+      { ttlSeconds: 300 },
+    );
+  } catch (err: any) {
+    if (err instanceof LockNotAcquiredError) {
+      return res.status(409).json({
+        error: 'Payment verification already in progress for this listing',
       });
     }
-
-    return res.status(200).json({ validationResults });
-  } catch (err: any) {
     logger.error(
       `Error verifying external payments: ${userSponsorId}: ${err.message}`,
     );

--- a/src/pages/api/sponsor-dashboard/submission/add-payment.ts
+++ b/src/pages/api/sponsor-dashboard/submission/add-payment.ts
@@ -1,6 +1,7 @@
 import type { NextApiResponse } from 'next';
 
 import logger from '@/lib/logger';
+import { LockNotAcquiredError, withRedisLock } from '@/lib/with-redis-lock';
 import { prisma } from '@/prisma';
 import { getTokenBySymbol } from '@/server/tokenList';
 import { safeStringify } from '@/utils/safeStringify';
@@ -49,182 +50,197 @@ async function handler(req: NextApiRequestWithSponsor, res: NextApiResponse) {
   }
 
   try {
-    const currentSubmission = await prisma.submission.findUnique({
-      where: { id },
-      include: {
-        user: true,
-        listing: true,
-      },
-    });
-
-    if (!currentSubmission) {
-      logger.warn(`Submission with ID ${id} not found`);
-      return res.status(404).json({
-        message: `Submission with ID ${id} not found.`,
-      });
-    }
-
-    const userSponsorId = req.userSponsorId;
-
-    const { error } = await checkListingSponsorAuth(
-      userSponsorId,
-      currentSubmission.listingId,
-    );
-    if (error) {
-      return res.status(error.status).json({ error: error.message });
-    }
-
-    const { listing, user, winnerPosition } = currentSubmission;
-    const txIds = paymentDetails
-      .map((payment: { txId?: string }) => payment.txId)
-      .filter((txId: string | undefined): txId is string => !!txId)
-      .map(normalizePaymentTxId);
-    const duplicateTxIds = txIds.filter(
-      (txId, index) => txIds.indexOf(txId) !== index,
-    );
-    if (duplicateTxIds.length > 0) {
-      const uniqueDuplicateTxIds = [...new Set(duplicateTxIds)];
-      return res.status(400).json({
-        error: `Duplicate transaction IDs found: ${uniqueDuplicateTxIds.join(', ')}`,
-        message: `Duplicate transaction IDs found: ${uniqueDuplicateTxIds.join(', ')}`,
-      });
-    }
-
-    const alreadyUsedTxIds = await findUsedPaymentTxIds(txIds);
-    if (alreadyUsedTxIds.length > 0) {
-      return res.status(400).json({
-        error: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
-        message: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
-      });
-    }
-
-    const isProject = listing.type === 'project';
-    if (!isProject) {
-      if (paymentDetails.length > 1 || paymentDetail.tranche !== 1) {
-        logger.warn('Bounties only support single payment with tranche 1');
-        return res.status(400).json({
-          error: 'Bounties only support single payment with tranche 1',
-          message: 'Bounties only support single payment with tranche 1',
+    return await withRedisLock(
+      `locks:add-payment:${id}`,
+      async () => {
+        const currentSubmission = await prisma.submission.findUnique({
+          where: { id },
+          include: {
+            user: true,
+            listing: true,
+          },
         });
-      }
-    } else {
-      const existingPayments =
-        (currentSubmission.paymentDetails as any[]) || [];
-      const existingTranches = existingPayments.map((p) => p.tranche);
-      const newTranche = paymentDetail.tranche;
-      const expectedNextTranche = existingTranches.length + 1;
 
-      if (newTranche !== expectedNextTranche) {
-        logger.warn(
-          `Project tranche ${newTranche} is not the expected next tranche ${expectedNextTranche}`,
+        if (!currentSubmission) {
+          logger.warn(`Submission with ID ${id} not found`);
+          return res.status(404).json({
+            message: `Submission with ID ${id} not found.`,
+          });
+        }
+
+        const userSponsorId = req.userSponsorId;
+
+        const { error } = await checkListingSponsorAuth(
+          userSponsorId,
+          currentSubmission.listingId,
         );
-        return res.status(400).json({
-          error: `Expected tranche ${expectedNextTranche}, but received tranche ${newTranche}`,
-          message: `Expected tranche ${expectedNextTranche}, but received tranche ${newTranche}`,
+        if (error) {
+          return res.status(error.status).json({ error: error.message });
+        }
+
+        const { listing, user, winnerPosition } = currentSubmission;
+        const txIds = paymentDetails
+          .map((payment: { txId?: string }) => payment.txId)
+          .filter((txId: string | undefined): txId is string => !!txId)
+          .map(normalizePaymentTxId);
+        const duplicateTxIds = txIds.filter(
+          (txId, index) => txIds.indexOf(txId) !== index,
+        );
+        if (duplicateTxIds.length > 0) {
+          const uniqueDuplicateTxIds = [...new Set(duplicateTxIds)];
+          return res.status(400).json({
+            error: `Duplicate transaction IDs found: ${uniqueDuplicateTxIds.join(', ')}`,
+            message: `Duplicate transaction IDs found: ${uniqueDuplicateTxIds.join(', ')}`,
+          });
+        }
+
+        const alreadyUsedTxIds = await findUsedPaymentTxIds(txIds);
+        if (alreadyUsedTxIds.length > 0) {
+          return res.status(400).json({
+            error: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
+            message: `Transaction IDs already used: ${alreadyUsedTxIds.join(', ')}`,
+          });
+        }
+
+        const isProject = listing.type === 'project';
+        if (!isProject) {
+          if (paymentDetails.length > 1 || paymentDetail.tranche !== 1) {
+            logger.warn('Bounties only support single payment with tranche 1');
+            return res.status(400).json({
+              error: 'Bounties only support single payment with tranche 1',
+              message: 'Bounties only support single payment with tranche 1',
+            });
+          }
+        } else {
+          const existingPayments =
+            (currentSubmission.paymentDetails as any[]) || [];
+          const existingTranches = existingPayments.map((p) => p.tranche);
+          const newTranche = paymentDetail.tranche;
+          const expectedNextTranche = existingTranches.length + 1;
+
+          if (newTranche !== expectedNextTranche) {
+            logger.warn(
+              `Project tranche ${newTranche} is not the expected next tranche ${expectedNextTranche}`,
+            );
+            return res.status(400).json({
+              error: `Expected tranche ${expectedNextTranche}, but received tranche ${newTranche}`,
+              message: `Expected tranche ${expectedNextTranche}, but received tranche ${newTranche}`,
+            });
+          }
+        }
+
+        if (!winnerPosition) {
+          return res.status(400).json({
+            error: 'Submission has no winner position',
+            message: 'Submission has no winner position',
+          });
+        }
+
+        const winnerReward = (listing.rewards as Record<string, any>)?.[
+          winnerPosition + ''
+        ] as number;
+        if (!winnerReward) {
+          return res.status(400).json({
+            error: 'Winner position has no reward',
+            message: 'Winner position has no reward',
+          });
+        }
+
+        const dbToken = await getTokenBySymbol(listing.token);
+        if (!dbToken) {
+          return res.status(400).json({
+            error: "Token doesn't exist for this listing",
+            message: "Token doesn't exist for this listing",
+          });
+        }
+
+        let tokenPriceUSD: number | undefined;
+        try {
+          tokenPriceUSD = await fetchTokenUSDValue(dbToken.mintAddress);
+        } catch (err) {
+          logger.warn(
+            `Failed to fetch token price for ${dbToken.tokenSymbol}, falling back to fixed tolerance`,
+          );
+        }
+
+        logger.debug(`Validating transaction for submission ID: ${id}`);
+        const validationResult = await validatePayment({
+          txId: paymentDetail.txId,
+          recipientPublicKey: user.walletAddress!,
+          expectedAmount: paymentDetail.amount,
+          tokenMint: dbToken,
+          tokenPriceUSD,
         });
-      }
-    }
 
-    if (!winnerPosition) {
-      return res.status(400).json({
-        error: 'Submission has no winner position',
-        message: 'Submission has no winner position',
-      });
-    }
+        if (!validationResult.isValid) {
+          logger.warn(
+            `Transaction validation failed for submission ID: ${id}: ${validationResult.error}`,
+          );
+          return res.status(400).json({
+            error: validationResult.error,
+            message: `Transaction validation failed: ${validationResult.error}`,
+          });
+        }
 
-    const winnerReward = (listing.rewards as Record<string, any>)?.[
-      winnerPosition + ''
-    ] as number;
-    if (!winnerReward) {
-      return res.status(400).json({
-        error: 'Winner position has no reward',
-        message: 'Winner position has no reward',
-      });
-    }
+        const finalPaymentDetails = isProject
+          ? [
+              ...((currentSubmission.paymentDetails as any[]) || []),
+              ...paymentDetails,
+            ]
+          : paymentDetails;
 
-    const dbToken = await getTokenBySymbol(listing.token);
-    if (!dbToken) {
-      return res.status(400).json({
-        error: "Token doesn't exist for this listing",
-        message: "Token doesn't exist for this listing",
-      });
-    }
+        const totalAllPayments = finalPaymentDetails.reduce(
+          (sum, payment) => sum + payment.amount,
+          0,
+        );
+        const isFullyPaid = totalAllPayments >= winnerReward;
 
-    let tokenPriceUSD: number | undefined;
-    try {
-      tokenPriceUSD = await fetchTokenUSDValue(dbToken.mintAddress);
-    } catch (err) {
-      logger.warn(
-        `Failed to fetch token price for ${dbToken.tokenSymbol}, falling back to fixed tolerance`,
-      );
-    }
+        logger.debug(`Updating submission with ID: ${id}`);
+        const result = await prisma.submission.update({
+          where: {
+            id,
+          },
+          data: {
+            isPaid: isFullyPaid,
+            paymentDetails: finalPaymentDetails,
+          },
+        });
 
-    logger.debug(`Validating transaction for submission ID: ${id}`);
-    const validationResult = await validatePayment({
-      txId: paymentDetail.txId,
-      recipientPublicKey: user.walletAddress!,
-      expectedAmount: paymentDetail.amount,
-      tokenMint: dbToken,
-      tokenPriceUSD,
-    });
+        const bountyId = result.listingId;
+        const updatedBounty: any = {};
 
-    if (!validationResult.isValid) {
-      logger.warn(
-        `Transaction validation failed for submission ID: ${id}: ${validationResult.error}`,
-      );
-      return res.status(400).json({
-        error: validationResult.error,
-        message: `Transaction validation failed: ${validationResult.error}`,
-      });
-    }
+        logger.info(
+          `Sending payment notification email for submission ID: ${id}`,
+        );
+        await queueEmail({
+          type: 'addPayment',
+          id,
+          triggeredBy: userId,
+        });
 
-    const finalPaymentDetails = isProject
-      ? [
-          ...((currentSubmission.paymentDetails as any[]) || []),
-          ...paymentDetails,
-        ]
-      : paymentDetails;
+        logger.debug(`Updating bounty with ID: ${bountyId}`);
+        await prisma.bounties.update({
+          where: {
+            id: bountyId,
+          },
+          data: {
+            ...updatedBounty,
+          },
+        });
 
-    const totalAllPayments = finalPaymentDetails.reduce(
-      (sum, payment) => sum + payment.amount,
-      0,
+        logger.info(
+          `Successfully updated submission payment status for ID: ${id}`,
+        );
+        return res.status(200).json(result);
+      },
+      { ttlSeconds: 300 },
     );
-    const isFullyPaid = totalAllPayments >= winnerReward;
-
-    logger.debug(`Updating submission with ID: ${id}`);
-    const result = await prisma.submission.update({
-      where: {
-        id,
-      },
-      data: {
-        isPaid: isFullyPaid,
-        paymentDetails: finalPaymentDetails,
-      },
-    });
-
-    const bountyId = result.listingId;
-    const updatedBounty: any = {};
-
-    logger.info(`Sending payment notification email for submission ID: ${id}`);
-    await queueEmail({
-      type: 'addPayment',
-      id,
-      triggeredBy: userId,
-    });
-
-    logger.debug(`Updating bounty with ID: ${bountyId}`);
-    await prisma.bounties.update({
-      where: {
-        id: bountyId,
-      },
-      data: {
-        ...updatedBounty,
-      },
-    });
-
-    logger.info(`Successfully updated submission payment status for ID: ${id}`);
-    return res.status(200).json(result);
   } catch (error: any) {
+    if (error instanceof LockNotAcquiredError) {
+      return res.status(409).json({
+        error: 'Payment processing already in progress for this submission',
+      });
+    }
     logger.error(
       `Error updating payment status for submission ${id}: ${safeStringify(
         error,


### PR DESCRIPTION
## Summary
- Payment endpoints (add-payment, add-tranche, verify-external-payment) have no concurrency control. Two concurrent requests with the same txId can both pass the replay check before either writes, crediting a single on-chain transaction twice.
- Wrapped all three endpoints in withRedisLock, same pattern already used by announce-winners and update-tranche-status. Returns 409 on concurrent duplicate requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented concurrent payment requests from being processed simultaneously.
  * Added conflict responses when a payment for the same grant, listing, or submission is already in progress.
  * Preserved existing payment validation, transaction updates, and notifications while improving processing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->